### PR TITLE
HYDRA-564: Blacklight::Catalog.index should use @extra_controller_params 

### DIFF
--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -25,14 +25,14 @@ module Blacklight::Catalog
 
     # get search results from the solr index
     def index
-      
+      @extra_controller_params ||= {}
       delete_or_assign_search_session_params
       
       extra_head_content << view_context.auto_discovery_link_tag(:rss, url_for(params.merge(:format => 'rss')), :title => "RSS for results")
       extra_head_content << view_context.auto_discovery_link_tag(:atom, url_for(params.merge(:format => 'atom')), :title => "Atom for results")
       extra_head_content << view_context.auto_discovery_link_tag(:unapi, unapi_url, {:type => 'application/xml',  :rel => 'unapi-server', :title => 'unAPI' })
       
-      (@response, @document_list) = get_search_results
+      (@response, @document_list) = get_search_results(params, @extra_controller_params)
       @filters = params[:f] || []
       search_session[:total] = @response.total unless @response.nil?
       

--- a/test_support/spec/controllers/catalog_controller_spec.rb
+++ b/test_support/spec/controllers/catalog_controller_spec.rb
@@ -65,6 +65,16 @@ describe CatalogController do
       @controller.instance_variable_get("@response")
     end
     
+    it "should respect @extra_controller_params" do
+      # This can be removed once HYDRA-564 is closed
+      expected_params = {:q=>"sample query"}
+      controller.instance_variable_set(:@extra_controller_params, expected_params)
+      controller.stub(:params).and_return({:action=>:index})
+      controller.stub(:enforce_access_controls)
+      controller.should_receive(:get_search_results).with(controller.params, expected_params)
+      get :index
+    end
+    
     it "should have no search history if no search criteria" do
       session[:history] = []
       get :index


### PR DESCRIPTION
HYDRA-564: Blacklight::Catalog.index should use @extra_controller_params if it's been set.  See https://jira.duraspace.org/browse/HYDRA-564 for more info.
