### PR TITLE
Implement render_document_header using default templates

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -133,8 +133,13 @@ module BlacklightHelper
   def document_heading
     @document[Blacklight.config[:show][:heading]] || @document.id
   end
+
   def render_document_heading
-    content_tag(:h1, document_heading)
+    begin
+      render :partial=>"catalog/_header_partials/#{document_partial_name(@document)}"  
+    rescue ActionView::MissingTemplate
+      render :partial=>"catalog/_header_partials/default"
+    end
   end
   
   # Used in the show view for setting the main html document title

--- a/app/views/catalog/_header_partials/_default.html.erb
+++ b/app/views/catalog/_header_partials/_default.html.erb
@@ -1,0 +1,1 @@
+<h1><%= document_heading %></h1>

--- a/test_support/spec/helpers/blacklight_helper_spec.rb
+++ b/test_support/spec/helpers/blacklight_helper_spec.rb
@@ -183,10 +183,15 @@ describe BlacklightHelper do
 
    describe "render_document_heading" do
      it "should consist of #document_heading wrapped in a <h1>" do
-      @document = SolrDocument.new(Blacklight.config[:show][:heading] => "A Fake Document")
+       @document = SolrDocument.new(Blacklight.config[:show][:heading] => "A Fake Document", 'format'=>'fake')
 
-      render_document_heading.should have_selector("h1", :content => document_heading, :count => 1)
-      render_document_heading.html_safe?.should == true
+       render_document_heading.should have_selector("h1", :content => document_heading, :count => 1)
+       render_document_heading.html_safe?.should == true
+       
+       helper.stub!(:render).with({:partial=>'catalog/_header_partials/fake'}, {}).and_raise(ActionView::MissingTemplate.new([], nil, nil, nil))
+       helper.stub!(:render).with({:partial=>'catalog/_header_partials/default'}, {}).and_return('<h1>hi</h1')
+       render_document_heading
+       
      end
    end
 


### PR DESCRIPTION
Handle render_document_header as we do render_document_partial, allow user to override the header in a template
