### PR TITLE
Fixed possible bug in _constraints_element.html.erb

### DIFF
--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -21,7 +21,7 @@
                 if label.blank?
                   "Remove constraint #{options[:escape_value] ? h(value) : value}"
                 else
-                  "Remove constraint #{options[:escape_value] ? h(label) : label}: #{options[:escape_value] ? h(value) : value}"
+                  "Remove constraint #{options[:escape_label] ? h(label) : label}: #{options[:escape_value] ? h(value) : value}"
                 end              
         %>                
         <%= link_to(accessible_remove_label,


### PR DESCRIPTION
File: _constraints_element.html.erb

Please see the following page for an example: http://demo.projectblacklight.org/catalog?commit=search&f[language_facet][]=English&f[pub_date][]=2010&q=test&search_field=all_fields&utf8=%E2%9C%93

In each of the top facet "pills" for removing an existing facet, if you look at the anchor tag associated with each "x" in each pill, you'll see that the body of the tag contains something like: "Remove constraint 2010: 2010"

I changed things so that it will now say: "Remove constraint Publication Year: 2010"
