### PR TITLE
Fix self.down for the AddUserTypesToBookmarksSearches migration.

### DIFF
--- a/lib/generators/blacklight/templates/migrations/add_user_types_to_bookmarks_searches.rb
+++ b/lib/generators/blacklight/templates/migrations/add_user_types_to_bookmarks_searches.rb
@@ -10,7 +10,7 @@ class AddUserTypesToBookmarksSearches < ActiveRecord::Migration
   end
 
   def self.down
-    remove_column :searches, :user_type, :string
-    remove_column :bookmarks, :user_type, :string
+    remove_column :searches, :user_type
+    remove_column :bookmarks, :user_type
   end
 end


### PR DESCRIPTION
I'm using blacklight for a project and did a quick `rake db:migrate VERSION=0; rake db:migrate;` to refresh my database and got an exception when rolling back this migration.
