### PR TITLE
Extracted SolrHelper#get_solr_response

### DIFF
--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -315,13 +315,23 @@ module Blacklight::SolrHelper
     # better for us. 
     bench_start = Time.now
 
-    solr_response = find(blacklight_config.solr_request_handler, self.solr_search_params(user_params).merge(extra_controller_params))  
+    solr_response = get_solr_response(user_params, extra_controller_params)
     document_list = solr_response.docs.collect {|doc| SolrDocument.new(doc, solr_response)}  
     Rails.logger.debug("Solr fetch: #{self.class}#get_search_results (#{'%.1f' % ((Time.now.to_f - bench_start.to_f)*1000)}ms)")
     
     return [solr_response, document_list]
   end
-  
+
+  # a solr query method
+  # given a user query,
+  # Returns a solr response object
+  def get_solr_response(user_params = params || {}, extra_controller_params = {})
+    find(
+      blacklight_config.solr_request_handler,
+      self.solr_search_params(user_params).merge(extra_controller_params)
+    )
+  end
+
   # returns a params hash for finding a single solr document (CatalogController #show action)
   # If the id arg is nil, then the value is fetched from params[:id]
   # This method is primary called by the get_solr_response_for_doc_id method.

--- a/test_support/spec/lib/solr_helper_spec.rb
+++ b/test_support/spec/lib/solr_helper_spec.rb
@@ -497,6 +497,13 @@ describe 'Blacklight::SolrHelper' do
       end
     end
 
+    describe '#get_solr_response' do
+      it 'should have results' do
+        solr_response = get_solr_response(:q => @single_word_query)
+        solr_response.docs.size.should > 0
+      end
+    end
+
     describe 'for All Docs Query, No Facets' do
       it 'should have non-nil values for required doc fields set in initializer' do
         (solr_response, document_list) = get_search_results(:q => @all_docs_query)
@@ -510,6 +517,11 @@ describe 'Blacklight::SolrHelper' do
 
 
     describe "Single Word Query with no Facets" do
+      it 'should have results' do
+        solr_response = get_solr_response(:q => @single_word_query)
+        solr_response.docs.size.should > 0
+      end
+
       it 'should have results' do
         (solr_response, document_list) = get_search_results(:q => @single_word_query)
         solr_response.docs.size.should == document_list.size


### PR DESCRIPTION
In our existing blacklight-based project, we are regularly using the
SolrHelper#get_search_results method to get the solr_response, but
discarding the document_list. We therefore need a method that can
retrieve the solr_response without building the associated documents.
This pull request contains that logic.
