### PR TITLE
Removed duplicate bookmark.save call

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -23,7 +23,7 @@ class BookmarksController < ApplicationController
     success = bookmark.save
     
     unless request.xhr?
-      if bookmark.save
+      if success
         flash[:notice] = I18n.t('blacklight.bookmarks.add.success')
       else
         flash[:error] = I18n.t('blacklight.bookmarks.add.failure') 


### PR DESCRIPTION
We are capturing the result of the bookmark.save call; So instead
of calling bookmark.save again, make use of the local variable "success"
