### PR TITLE
Enables use of blacklight_highlight on index.show_link field

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "marc",      ">= 0.4.3", "< 1.1"  # Marc record parser.
   s.add_dependency "rsolr",     "~> 1.0.6"  # Library for interacting with rSolr.
   s.add_dependency "rsolr-ext", '~> 1.0.3'  # extension to the above for some rails-ish behaviors - currently embedded in our solr document ojbect.
-  s.add_dependency "kaminari", "< 0.14", ">= 0.12.4"  # the pagination (page 1,2,3, etc..) of our search results
+  s.add_dependency "kaminari", ">= 0.12.4"  # the pagination (page 1,2,3, etc..) of our search results
   s.add_dependency "sass-rails"
   s.add_development_dependency "jettywrapper", ">= 1.2.0"
   s.add_dependency "compass-rails", "~> 1.0.0"


### PR DESCRIPTION
Previously, the highlighted field would be html escaped, so search results would display the `<em>search term</em>` tags.

This commit allows highlighting in the show_link field, just as it is allowed for other fields in the index display.

I also limited the kaminari compatibility as kaminari 0.14 must use `total_pages` instead of `num_pages` as an option.
