### PR TITLE
Endnote and citation functions to render no layout

### DIFF
--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -95,12 +95,15 @@ module Blacklight::Catalog
     # citation action
     def citation
       @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
+      respond_to do |format|
+        format.js { render :layout => false }
+      end
     end
     # grabs a bunch of documents to export to endnote
     def endnote
       @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
       respond_to do |format|
-        format.endnote :layout => false
+        format.endnote { render :layout => false }
       end
     end
     


### PR DESCRIPTION
In regards to Issue #502:

After the :layout => true was added after format.endnote I was seeing wrong number of arguments. Is that an alternative syntax I'm unaware of? When I locally overrode it to be the following I got it working:

```
format.endnote { render :layout => false }
```

The demo seems to be getting a 500 on that function too.

Also, I added the following to the citation function to ensure that the partial would not render the layout when XHR:

```
respond_to do |format|
    format.js { render :layout => false }
 end
```
