### PR TITLE
Centered bottom results pagination below documents list

### DIFF
--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,6 +1,6 @@
 <% if paginate_params(@response).num_pages > 1 %>
  <div class="row record-padding">
-  <div class="span8 offset1"> 
+  <div class="span9"> 
     <div class="pagination">
       <%= paginate_rsolr_response @response, :outer_window => 2, :theme => 'blacklight' %>
     </div>


### PR DESCRIPTION
- Changed class of bottom results pagination from "span8 offset1" to "span9"
  in order to center the results pagination below the documents list.

The "span8 offset1" seems a very deliberate choice, but I don't see why the results pagination should not be centered below the documents list. Please bear with me if I'm missing the bigger picture here :-)
