### PR TITLE
Fix markup and css for distorted search history

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_history.css.scss
+++ b/app/assets/stylesheets/blacklight/_search_history.css.scss
@@ -32,7 +32,7 @@
     vertical-align: top; 
   }
 
-  .filterName, .label 
+  .filterName, .filterSeparator
   {
     color: gray; 
   }

--- a/app/helpers/blacklight/search_history_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/search_history_constraints_helper_behavior.rb
@@ -32,7 +32,7 @@ module Blacklight::SearchHistoryConstraintsHelperBehavior
       render_search_to_s_element(blacklight_config.facet_fields[facet_field].label,
         value_list.collect do |value|
           render_filter_value(value)
-        end.join(content_tag(:span, t('blacklight.and'), :class =>'label')).html_safe
+        end.join(content_tag(:span, " #{t('blacklight.and')} ", :class =>'filterSeparator')).html_safe
       )    
     end.join(" \n ").html_safe    
   end


### PR DESCRIPTION
After the bootstrap refactor the rendering of filters in the search history is slightly distorted since the filter separator is given the 'label' class which is used by bootstrap labels
- Use .filterSeparator instead of .label for the filterValue separator
- Add explicit whitespace around separator instead og padding/margin
