### PR TITLE
Removed the row wrapper from the catalog show view since it's already defined in the layout template

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,44 +1,41 @@
-<div class="row">
+<div id="content" class="span9 show-document">
 
-  <div id="content" class="span9 show-document">
+  <%= render 'previous_next_doc' %>
 
-    <%= render 'previous_next_doc' %>
+   
+<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name) %>
+<% extra_head_content << render_link_rel_alternates %>
+<% sidebar_items << render_document_sidebar_partial %>
 
-     
-  <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name) %>
-  <% extra_head_content << render_link_rel_alternates %>
-  <% sidebar_items << render_document_sidebar_partial %>
+<%# this should be in a partial -%>
+<div id="document" class="<%= render_document_class %>">
+  <div id="doc_<%= @document.id.to_s.parameterize %>">
+  
 
-  <%# this should be in a partial -%>
-  <div id="document" class="<%= render_document_class %>">
-    <div id="doc_<%= @document.id.to_s.parameterize %>">
-    
+    <% # bookmark/folder functions -%>
+    <%= render_document_heading(:h1).html_safe %>
 
-      <% # bookmark/folder functions -%>
-      <%= render_document_heading(:h1).html_safe %>
-
-      <div class="document">
-        <%= render_document_partial @document, :show %>
-      </div>
-
-     
+    <div class="document">
+      <%= render_document_partial @document, :show %>
     </div>
+
+   
   </div>
-
-
-
-    <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
-      <!-- 
-           // COinS, for Zotero among others. 
-           // This document_partial_name(@document) business is not quite right,
-           // but has been there for a while. 
-      -->
-      <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
-    <% end %>
-
-  </div>
-
-  <div id="sidebar" class="span3">
-     <%= render_document_sidebar_partial  %>
-  </div><!--/span -->
 </div>
+
+
+
+  <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+    <!-- 
+         // COinS, for Zotero among others. 
+         // This document_partial_name(@document) business is not quite right,
+         // but has been there for a while. 
+    -->
+    <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+  <% end %>
+
+</div>
+
+<div id="sidebar" class="span3">
+   <%= render_document_sidebar_partial  %>
+</div><!--/span -->


### PR DESCRIPTION
- Removed the <div class="row"> wrapper from the catalog show view
  since it is already defined in the layout template.

Also re-indented the template after having removed the row wrapper.
