### PR TITLE
Added z-index to CSS-dropdowns to avoid covered widgets shining through

### DIFF
--- a/app/assets/stylesheets/blacklight/_dropdown.css.scss
+++ b/app/assets/stylesheets/blacklight/_dropdown.css.scss
@@ -25,6 +25,7 @@
 	ul {
 		list-style: none;
 		position: absolute;
+    z-index: $zindexDropdown;
 		top: 100%;
 		left: 0;
 		right: 0;


### PR DESCRIPTION
- Added z-index to CSS-dropdowns so widgets that would be covered by
  the dropdown don't shine through. Value for z-index is using
  bootstrap's zindexDropdown variable.
