### PR TITLE
Bump rspec to ~> 2.12.0 in test_app

### DIFF
--- a/test_support/bin/setup-test-app.sh
+++ b/test_support/bin/setup-test-app.sh
@@ -97,8 +97,8 @@ end
 
 # For testing
 group :development, :test do 
-  gem 'rspec'
-  gem 'rspec-rails'
+  gem 'rspec', '~> 2.12.0'
+  gem 'rspec-rails', '~> 2.12.0'
   gem 'generator_spec'
   gem 'cucumber-rails'
   gem 'database_cleaner'

--- a/test_support/bin/test.sh
+++ b/test_support/bin/test.sh
@@ -97,8 +97,8 @@ end
 
 # For testing
 group :development, :test do
-  gem 'rspec'
-  gem 'rspec-rails'
+  gem 'rspec', '~> 2.12.0'
+  gem 'rspec-rails', '~> 2.12.0'
   gem 'generator_spec'
   gem 'cucumber-rails'
   gem 'database_cleaner'


### PR DESCRIPTION
Otherwise, on a fresh rvm install the test_app pulls in rspec 2.0.1
which fails with "undefined method `run_all' for []:Array" when
running tests in the test_app with ruby 1.9.3.
