### PR TITLE
store configuration procs on the configurable class

### DIFF
--- a/test_support/features/step_definitions/search_pagination_steps.rb
+++ b/test_support/features/step_definitions/search_pagination_steps.rb
@@ -1,11 +1,10 @@
 # -*- encoding : utf-8 -*-
 Given /^the application is configured to have per page with values "([^\"]*)"$/ do |values|
   values = values.split(", ")
-  CatalogController.blacklight_config[:per_page] = []
-  values.each do |value|
-    CatalogController.blacklight_config[:per_page] << value
+  CatalogController.configure_blacklight do |config|
+    config.default_solr_params[:rows] = values.first
+    config.per_page = values
   end
-  CatalogController.blacklight_config[:default_solr_params][:rows] = values[0]
 end
 
 

--- a/test_support/spec/lib/blacklight_configurable_spec.rb
+++ b/test_support/spec/lib/blacklight_configurable_spec.rb
@@ -10,7 +10,7 @@ describe "Blacklight::Configurable" do
         class Parent
           include Blacklight::Configurable
 
-          blacklight_config.configure do |config|
+          configure_blacklight do |config|
             config.list = [1,2,3]
           end
         end
@@ -82,24 +82,6 @@ describe "Blacklight::Configurable" do
       instance.blacklight_config.foo.should be_nil
     end
     
-    it "allows instance to set it's own config seperate from class" do
-      # this is built into class_attribute; we spec it both to document it,
-      # and to ensure we preserve this feature if we change implementation
-      # to not use class_attribute
-      klass = Class.new
-      klass.send(:include, Blacklight::Configurable)
-      klass.blacklight_config.foo = "bar"
-      klass.blacklight_config.bar = []
-      klass.blacklight_config.bar << "asd"
-      
-      instance = klass.new
-      instance.blacklight_config.bar << "123"
-      instance.blacklight_config.should_not == klass.blacklight_config
-      klass.blacklight_config.foo.should == "bar"
-      instance.blacklight_config.foo.should == "bar"
-      klass.blacklight_config.bar.should_not include("123")
-      instance.blacklight_config.bar.should include("asd", "123")
-    end
 
     it "configurable classes should not mutate the default configuration object" do
       klass = Class.new


### PR DESCRIPTION
Store the configure_blacklight procs on e.g. the CatalogController, and evaluate them only when blacklight_config is requested. This simplifies the deep-copy nonsense, and maybe makes it more difficult to accidentally mutate the config in unexpected ways.

It also, presumably, lets us bind the procs to a controller context, so we can use e.g. `params` or `current_user` in the configuration easily.

I'm not thrilled with it, but I had to do something similar in my ugly projectblacklight/blacklight/solr-service branch anyway, so maybe it's inevitable. 

Anyone have strong opinions about it? Or suggestions for making this cleaner?

(as a way to fix #526.)
