### PR TITLE
BM Controller returns 200 w/ empty body (jQuery 1.9 ) 

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -52,7 +52,7 @@ class BookmarksController < CatalogController
     end
 
     if request.xhr?
-      render :text => "", :status => (success ? "200" : "500" )
+      success ? head(:no_content) : render(:text => "", :status => "500")
     else
       if @bookmarks.length > 0 && success
         flash[:notice] = I18n.t('blacklight.bookmarks.add.success', :count => @bookmarks.length)
@@ -80,7 +80,7 @@ class BookmarksController < CatalogController
       redirect_to :back
     else
       # ajaxy request needs no redirect and should not have flash set
-      render :text => "", :status => (success ? "200" : "500")
+      success ? head(:no_content) : render(:text => "", :status => "500")
     end        
   end
   

--- a/test_support/spec/controllers/bookmarks_controller_spec.rb
+++ b/test_support/spec/controllers/bookmarks_controller_spec.rb
@@ -1,0 +1,42 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe BookmarksController do
+  include Devise::TestHelpers
+  
+  # jquery 1.9 ajax does error callback if 200 returns empty body. so use 204 instead. 
+  describe "update" do
+    it "has a 204 status code when creating a new one" do
+      xhr :put, :update, :id => '2007020969', :format => :js
+      response.should be_success
+      response.code.should == "204"
+    end
+    
+    it "has a 500 status code when fails is success" do
+      @controller.stub_chain(:current_or_guest_user, :existing_bookmark_for).and_return(false)
+      @controller.stub_chain(:current_or_guest_user, :persisted?).and_return(true)
+      @controller.stub_chain(:current_or_guest_user, :bookmarks, :create).and_return(false)  
+      xhr :put, :update, :id => 'iamabooboo', :format => :js
+      response.code.should == "500"
+    end
+  end
+  
+  describe "delete" do
+    it "has a 204 status code when delete is success" do
+      xhr :delete, :destroy, :id => '2007020969', :format => :js
+      response.should be_success
+      response.code.should == "204"
+    end
+
+   it "has a 500 status code when delete is not success" do
+      bm = mock(Bookmark)
+      @controller.stub_chain(:current_or_guest_user, :existing_bookmark_for).and_return(bm)
+      @controller.stub_chain(:current_or_guest_user, :bookmarks, :delete).and_return(false)
+     
+      xhr :delete, :destroy, :id => 'pleasekillme', :format => :js
+     #
+      response.code.should == "500"
+    end
+  end
+  
+end


### PR DESCRIPTION
 http://jquery.com/upgrade-guide/1.9/#jquery-ajax-returning-a-json-result-of-an-empty-string

jQuery 1.9 ajax doesn't like 200's with empty bodies. a bit annoying but technically this is correct since it's not valid json. returning a 204 ( i.e. head :no_content )  instead corrects this. 
