### PR TITLE
Multi-tab search feature

### DIFF
--- a/app/assets/javascripts/blacklight/search_context.js
+++ b/app/assets/javascripts/blacklight/search_context.js
@@ -2,25 +2,30 @@
 (function($) {
   Blacklight.do_search_context_behavior = function() {
       $('a[data-counter]').click(function(event) {
-      var f = document.createElement('form'); f.style.display = 'none'; 
-      this.parentNode.appendChild(f); 
-      f.method = 'POST'; 
+      var f = document.createElement('form'); f.style.display = 'none';
+      this.parentNode.appendChild(f);
+      f.method = 'POST';
       f.action = $(this).attr('href');
       if(event.metaKey || event.ctrlKey){f.target = '_blank';};
-      var d = document.createElement('input'); d.setAttribute('type', 'hidden'); 
+      var d = document.createElement('input'); d.setAttribute('type', 'hidden');
       d.setAttribute('name', 'counter'); d.setAttribute('value', $(this).data('counter')); f.appendChild(d);
-      var m = document.createElement('input'); m.setAttribute('type', 'hidden'); 
+      var m = document.createElement('input'); m.setAttribute('type', 'hidden');
       m.setAttribute('name', '_method'); m.setAttribute('value', 'put'); f.appendChild(m);
-      var m = document.createElement('input'); m.setAttribute('type', 'hidden'); 
+      var m = document.createElement('input'); m.setAttribute('type', 'hidden');
       m.setAttribute('name', $('meta[name="csrf-param"]').attr('content')); m.setAttribute('value', $('meta[name="csrf-token"]').attr('content')); f.appendChild(m);
 
+      var l = document.createElement('input'); l.setAttribute('type', 'hidden');
+      l.setAttribute('name', 'last_known_search_json_string'); l.setAttribute('value', Blacklight.last_known_search_json_string); f.appendChild(l);
+      var r = document.createElement('input'); r.setAttribute('type', 'hidden');
+      r.setAttribute('name', 'results_view'); r.setAttribute('value', $(this).data('results_view')); f.appendChild(r);
+
       f.submit();
-        
+
       return false;
       });
 
-    };  
+    };
 $(document).ready(function() {
-  Blacklight.do_search_context_behavior();  
+  Blacklight.do_search_context_behavior();
 });
 })(jQuery);

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
-class CatalogController < ApplicationController  
+class CatalogController < ApplicationController
 
   include Blacklight::Catalog
 
-end 
+end

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -468,7 +468,7 @@ module Blacklight::BlacklightHelperBehavior
   def link_to_document(doc, opts={:label=>nil, :counter => nil, :results_view => true})
     opts[:label] ||= blacklight_config.index.show_link.to_sym
     label = render_document_index_label doc, opts
-    link_to label, doc, { :'data-counter' => opts[:counter] }.merge(opts.reject { |k,v| [:label, :counter, :results_view].include? k  })
+    link_to label, doc, { :'data-counter' => opts[:counter], :'data-results_view' => opts[:results_view] }.merge(opts.reject { |k,v| [:label, :counter, :results_view].include? k  })
   end
 
   # link_back_to_catalog(:label=>'Back to Search')

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -1,12 +1,11 @@
-     
+			<% performing_a_search = params[:controller] == 'catalog' && params[:action] == 'index' %>
+
       <% # header bar for doc items in index view -%>
       <div class="documentHeader clearfix">
-        
-        <% # main title container for doc partial view -%>
-          <h5 class="index_title"><%= t('blacklight.search.documents.counter', :counter => (document_counter + 1 + @response.params[:start].to_i)) %><%= link_to_document document, :label=>document_show_link_field(document), :counter => (document_counter + 1 + @response.params[:start].to_i) %></h5>
 
-        
-        <% # bookmark functions for items/docs -%>
+        <% # main title container for doc partial view -%>
+        <h5 class="index_title"><%= t('blacklight.search.documents.counter', :counter => (document_counter + 1 + @response.params[:start].to_i)) %><%= link_to_document document, :label=>document_show_link_field(document), :counter => (document_counter + 1 + @response.params[:start].to_i), :results_view => performing_a_search %></h5>
+
+				<% # bookmark functions for items/docs -%>
         <%= render_index_doc_actions document, :wrapping_class => "documentFunctions span2" %>
       </div>
-      

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,6 +1,6 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="dl-horizontal dl-invert">
-  
+
   <% index_fields(document).each do |solr_fname, field| -%>
     <% if should_render_index_field? document, field %>
 	    <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label document, :field => solr_fname %></dt>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -18,8 +18,11 @@
     <%= favicon_link_tag asset_path('favicon.ico') %>
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application" %>
+
+    <%= render :partial=>'shared/head_tag_multi_tab_support' %>
+
     <%= csrf_meta_tags %>
-    <%= raw(render_head_content) %> 
+    <%= raw(render_head_content) %>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
@@ -45,12 +48,12 @@
                         <div id="main-flashes">
                           <%= render :partial=>'/flash_msg' %>
                         </div>
-                      </div>    
-                  </div>              
+                      </div>
+                  </div>
 
                   <div class="row">
                        <%= yield %>
-                       </div>   
+                       </div>
 </div>
 
 <%= render :partial => 'shared/footer' %>

--- a/app/views/shared/_head_tag_multi_tab_support.html.erb
+++ b/app/views/shared/_head_tag_multi_tab_support.html.erb
@@ -1,0 +1,21 @@
+<% content_for :multi_tab_support do %>
+	<script type="text/javascript">
+		<%
+		# Get correct response total
+		if ((params[:controller] == 'catalog' || params[:controller] == 'bookmarks') && params[:action] == 'index')
+			latest_total = @response.total
+		else
+			if(session[:search].nil? || session[:search][:total].nil?)
+			latest_total = 1
+			else
+			latest_total = session[:search][:total]
+			end
+		end
+		%>
+		<%
+			# Most recent search
+			%><%= 'Blacklight.last_known_search_json_string = "'.html_safe + escape_javascript((session[:search].merge(:total => latest_total).to_json).html_safe) + '";'.html_safe unless session[:search].nil? %><%
+		%>
+	</script>
+<% end %>
+<%=  yield :multi_tab_support %>

--- a/features/multi_tab_search.feature
+++ b/features/multi_tab_search.feature
@@ -1,0 +1,36 @@
+@multi_tab_search
+Feature: Multi Tab Search
+  As a user
+  In order to make sure that different simultaneously-open windows preserve their own session[:search] values
+  I want to perform two searches in two windows and make sure that as I page through results within each window, the independent results are preserved
+
+  @javascript
+  Scenario: Multi-tab search
+    Given I have done a search with term "tibetan"
+    Then the body tag should contain "1 - 6 of 6"
+    Then the body tag should contain "Pluvial nectar of blessings"
+    And the body tag should contain "Śes yon"
+    Given I have done a search with term "korea"
+    Then the body tag should contain "1 - 4 of 4"
+    Then the body tag should contain "Koryŏ inmul yŏlchŏn"
+    And the body tag should contain "Ajikto kŭrŏk chŏrŏk sasimnikka"
+
+    When I visit the page for the item with id "2008308175" using param last_known_search_json_string = '{"q":"tibetan","action":"index","controller":"catalog","total":6}'
+    Then the body tag should contain "| 1 of 6 |"
+    Then the body tag should contain "Pluvial nectar of blessings"
+    When I follow the Next » link
+    And the body tag should contain "| 2 of 6 |"
+    Then the body tag should contain "Śes yon"
+    When I follow the Next » link
+    And the body tag should contain "| 3 of 6 |"
+    Then the body tag should contain "Bod kyi naṅ chos ṅo sprod sñiṅ bsdus"
+
+    When I visit the page for the item with id "77826928" using param last_known_search_json_string = '{"q":"korea","action":"index","controller":"catalog","total":4}'
+    And the body tag should contain "| 1 of 4 |"
+    And the body tag should contain "Koryŏ inmul yŏlchŏn"
+    When I follow the Next » link
+    And the body tag should contain "| 2 of 4 |"
+    Then the body tag should contain "Ajikto kŭrŏk chŏrŏk sasimnikka"
+    When I follow the Next » link
+    And the body tag should contain "| 3 of 4 |"
+    Then the body tag should contain "Pukhan pŏmnyŏngjip"

--- a/features/search_history.feature
+++ b/features/search_history.feature
@@ -3,18 +3,18 @@ Feature: Search History Page
   As a user
   In order see searches I've used and reuse them
   I want a page that shows my (unique) search history from this session
-  
+
   Scenario: Menu Link
     When I am on the home page
     Then I should see "History"
     When I go to the search history page
     And I should see a stylesheet
-  
+
   Scenario: Have No Searches
     Given no previous searches
     When I go to the search history page
     Then I should see "You have no search history"
-    
+
   Scenario: Have Searches
     Given I have done a search with term "book"
     When I go to the search history page
@@ -34,9 +34,9 @@ Feature: Search History Page
     When I follow "Clear Search History"
     Then I should see "Cleared your search history."
     And I should see "You have no search history"
-    Then I should not see "book"
-    And I should not see "dang"
-    
+    And the body tag should not contain "book"
+    And the body tag should not contain "dang"
+
   Scenario: Saving a Search when logged in
     Given I am logged in as "user1"
     And I have done a search with term "book"
@@ -82,4 +82,3 @@ Feature: Search History Page
     And I should not see "user1"
     When I go to the search history page
     Then I should not see "book"
-      

--- a/features/step_definitions/multi_tab_search_steps.rb
+++ b/features/step_definitions/multi_tab_search_steps.rb
@@ -1,0 +1,9 @@
+# -*- encoding : utf-8 -*-
+
+When /^I visit the page for the item with id "([^\"]*)" using param last_known_search_json_string = '([^\']*)'$/ do |item_id, last_known_search_json_string|
+  visit catalog_path(:action => 'update', :id => item_id, :method => 'put', :counter => 1, :results_view => true, :last_known_search_json_string => last_known_search_json_string)
+end
+
+When /^(?:|I )follow the Next » link$/ do
+  click_link('Next »')
+end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -16,7 +16,7 @@
 #
 # * http://benmabey.com/2008/05/19/imperative-vs-declarative-scenarios-in-user-stories.html
 # * http://dannorth.net/2011/01/31/whose-domain-is-it-anyway/
-# * http://elabs.se/blog/15-you-re-cuking-it-wrong 
+# * http://elabs.se/blog/15-you-re-cuking-it-wrong
 #
 
 
@@ -139,6 +139,38 @@ Then /^(?:|I )should not see \/([^\/]*)\/$/ do |regexp|
   end
 end
 
+Then /^the body tag should contain "([^"]*)"$/ do |text|
+  if page.respond_to? :should
+    find('body').should have_content(text)
+  else
+    assert find('body').has_content?(text)
+  end
+end
+
+Then /^the body tag should not contain "([^"]*)"$/ do |text|
+  if page.respond_to? :should
+    find('body').should have_no_content(text)
+  else
+    assert find('body').has_no_content?(text)
+  end
+end
+
+Then /^the head tag should contain "([^"]*)"$/ do |text|
+  if page.respond_to? :should
+    find('head').should have_content(text)
+  else
+    assert find('head').has_content?(text)
+  end
+end
+
+Then /^the head tag should not contain "([^"]*)"$/ do |text|
+  if page.respond_to? :should
+    find('head').should have_no_content(text)
+  else
+    assert find('head').has_no_content?(text)
+  end
+end
+
 Then /^the "([^"]*)" field(?: within (.*))? should contain "([^"]*)"$/ do |field, parent, value|
   with_scope(parent) do
     field = find_field(field)
@@ -184,7 +216,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should not be checked$/ do |label
     end
   end
 end
- 
+
 Then /^(?:|I )should be on (.+)$/ do |page_name|
   current_path = URI.parse(current_url).path
   if current_path.respond_to? :should
@@ -198,8 +230,8 @@ Then /^(?:|I )should have the following query string:$/ do |expected_pairs|
   query = URI.parse(current_url).query
   actual_params = query ? CGI.parse(query) : {}
   expected_params = {}
-  expected_pairs.rows_hash.each_pair{|k,v| expected_params[k] = v.split(',')} 
-  
+  expected_pairs.rows_hash.each_pair{|k,v| expected_params[k] = v.split(',')}
+
   if actual_params.respond_to? :should
     actual_params.should == expected_params
   else
@@ -214,4 +246,3 @@ end
 Then  /^I should get a status code (\d+)/ do |http_status|
   page.driver.status_code.should == http_status.to_i
 end
-

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -1,15 +1,16 @@
 # -*- encoding : utf-8 -*-
-module Blacklight::Catalog   
+module Blacklight::Catalog
+
   extend ActiveSupport::Concern
-  
+
   include Blacklight::Configurable
   include Blacklight::SolrHelper
-  
+
   SearchHistoryWindow = 12 # how many searches to save in session history
 
   # The following code is executed when someone includes blacklight::catalog in their
   # own controller.
-  included do  
+  included do
     helper_method :search_action_url
     before_filter :search_session, :history_session
     before_filter :delete_or_assign_search_session_params, :only => :index
@@ -24,30 +25,32 @@ module Blacklight::Catalog
     # Example, when the standard query parser is used, and a user submits a "bad" query.
     rescue_from RSolr::Error::Http, :with => :rsolr_request_error
   end
-  
+
   def search_action_url
     url_for(:action => 'index', :only_path => true)
   end
 
     # get search results from the solr index
     def index
-      
       extra_head_content << view_context.auto_discovery_link_tag(:rss, url_for(params.merge(:format => 'rss')), :title => t('blacklight.search.rss_feed') )
       extra_head_content << view_context.auto_discovery_link_tag(:atom, url_for(params.merge(:format => 'atom')), :title => t('blacklight.search.atom_feed') )
-      
+
       (@response, @document_list) = get_search_results
       @filters = params[:f] || []
-      
+
       respond_to do |format|
         format.html { save_current_search_params }
         format.rss  { render :layout => false }
         format.atom { render :layout => false }
       end
     end
-    
+
     # get single document from the solr index
     def show
-      @response, @document = get_solr_response_for_doc_id    
+
+      @response, @document = get_solr_response_for_doc_id
+
+      update_last_known_search_json_string
 
       respond_to do |format|
         format.html {setup_next_and_previous_documents}
@@ -56,30 +59,35 @@ module Blacklight::Catalog
         # export formats.
         @document.export_formats.each_key do | format_name |
           # It's important that the argument to send be a symbol;
-          # if it's a string, it makes Rails unhappy for unclear reasons. 
+          # if it's a string, it makes Rails unhappy for unclear reasons.
           format.send(format_name.to_sym) { render :text => @document.export_as(format_name), :layout => false }
         end
-        
+
       end
     end
 
     # updates the search counter (allows the show view to paginate)
     def update
+
       adjust_for_results_view
       session[:search][:counter] = params[:counter]
+
+      update_last_known_search_json_string
+
       redirect_to :action => "show"
+
     end
-    
+
     # displays values and pagination links for a single facet field
     def facet
       @pagination = get_facet_pagination(params[:id], params)
 
       respond_to do |format|
-        format.html 
+        format.html
         format.js { render :layout => false }
       end
     end
-    
+
     # method to serve up XML OpenSearch description and JSON autocomplete response
     def opensearch
       respond_to do |format|
@@ -91,7 +99,7 @@ module Blacklight::Catalog
         end
       end
     end
-    
+
     # citation action
     def citation
       @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
@@ -107,14 +115,14 @@ module Blacklight::Catalog
         format.endnote { render :layout => false }
       end
     end
-    
+
     # Email Action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
     def email
       @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
       if request.post?
         if params[:to]
           url_gen_params = {:host => request.host_with_port, :protocol => request.protocol}
-          
+
           if params[:to].match(/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/)
             email = RecordMailer.email_record(@documents, {:to => params[:to], :message => params[:message]}, url_gen_params)
           else
@@ -125,7 +133,7 @@ module Blacklight::Catalog
         end
 
         unless flash[:error]
-          email.deliver 
+          email.deliver
           flash[:success] = "Email sent"
           redirect_to catalog_path(params['id']) unless request.xhr?
         end
@@ -138,13 +146,13 @@ module Blacklight::Catalog
         end
       end
     end
-    
+
     # SMS action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
-    def sms 
+    def sms
       @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
       if request.post?
         url_gen_params = {:host => request.host_with_port, :protocol => request.protocol}
-        
+
         if params[:to]
           phone_num = params[:to].gsub(/[^\d]/, '')
           unless params[:carrier].blank?
@@ -162,12 +170,12 @@ module Blacklight::Catalog
         end
 
         unless flash[:error]
-          email.deliver 
+          email.deliver
           flash[:success] = "SMS sent"
           redirect_to catalog_path(params['id']) unless request.xhr?
         end
       end
-        
+
       unless !request.xhr? && flash[:success]
         respond_to do |format|
           format.js { render :layout => false }
@@ -175,7 +183,7 @@ module Blacklight::Catalog
         end
       end
     end
-    
+
     def librarian_view
       @response, @document = get_solr_response_for_doc_id
 
@@ -184,9 +192,9 @@ module Blacklight::Catalog
         format.js { render :layout => false }
       end
     end
-    
-    
-    protected    
+
+
+    protected
     #
     # non-routable methods ->
     #
@@ -197,37 +205,37 @@ module Blacklight::Catalog
       setup_previous_document
       setup_next_document
     end
-    
-    # gets a document based on its position within a resultset  
+
+    # gets a document based on its position within a resultset
     def setup_document_by_counter(counter)
       return if counter < 1 || session[:search].blank?
       search = session[:search] || {}
       get_single_doc_via_search(counter, search)
     end
-    
+
     def setup_previous_document
       @previous_document = session[:search][:counter] ? setup_document_by_counter(session[:search][:counter].to_i - 1) : nil
     end
-    
+
     def setup_next_document
       @next_document = session[:search][:counter] ? setup_document_by_counter(session[:search][:counter].to_i + 1) : nil
     end
-    
+
     # sets up the session[:search] hash if it doesn't already exist
     def search_session
       session[:search] ||= {}
     end
-    
+
     # sets up the session[:history] hash if it doesn't already exist.
     # assigns all Search objects (that match the searches in session[:history]) to a variable @searches.
     def history_session
       session[:history] ||= []
       @searches = searches_from_history # <- in BlacklightController
     end
-    
+
     # This method copies request params to session[:search], omitting certain
     # known blacklisted params not part of search, omitting keys with blank
-    # values. All keys in session[:search] are as symbols rather than strings. 
+    # values. All keys in session[:search] are as symbols rather than strings.
     def delete_or_assign_search_session_params
       session[:search] = {}
       params.each_pair do |key, value|
@@ -235,34 +243,34 @@ module Blacklight::Catalog
           value.blank?
       end
     end
-    
+
     # Saves the current search (if it does not already exist) as a models/search object
     # then adds the id of the serach object to session[:history]
-    def save_current_search_params    
+    def save_current_search_params
       # If it's got anything other than controller, action, total, we
       # consider it an actual search to be saved. Can't predict exactly
       # what the keys for a search will be, due to possible extra plugins.
-      return if (search_session.keys - [:controller, :action, :total, :counter, :commit ]) == [] 
+      return if (search_session.keys - [:controller, :action, :total, :counter, :commit ]) == []
       params_copy = search_session.clone # don't think we need a deep copy for this
       params_copy.delete(:page)
-      
+
       unless @searches.collect { |search| search.query_params }.include?(params_copy)
-        
+
         new_search = Search.create(:query_params => params_copy)
         session[:history].unshift(new_search.id)
-        # Only keep most recent X searches in history, for performance. 
+        # Only keep most recent X searches in history, for performance.
         # both database (fetching em all), and cookies (session is in cookie)
         session[:history] = session[:history].slice(0, Blacklight::Catalog::SearchHistoryWindow )
       end
     end
-          
+
     # sets some additional search metadata so that the show view can display it.
     def set_additional_search_session_values
       unless @response.nil?
         search_session[:total] = @response.total
       end
     end
-    
+
     # we need to know if we are viewing the item as part of search results so we know whether to
     # include certain partials or not
     def adjust_for_results_view
@@ -272,11 +280,11 @@ module Blacklight::Catalog
         session[:search][:results_view] = true
       end
     end
-    
-       
+
+
     # when solr (RSolr) throws an error (RSolr::RequestError), this method is executed.
     def rsolr_request_error(exception)
-      
+
       if Rails.env.development?
         raise exception # Rails own code will catch and give usual Rails error page with stack trace
       else
@@ -292,11 +300,11 @@ module Blacklight::Catalog
 
         logger.error exception
 
-        flash[:notice] = flash_notice 
+        flash[:notice] = flash_notice
         redirect_to root_path
       end
     end
-    
+
     # when a request for /catalog/BAD_SOLR_ID is made, this method is executed...
     def invalid_solr_id_error
       if Rails.env == "development"
@@ -316,4 +324,19 @@ module Blacklight::Catalog
     def blacklight_solr_config
       Blacklight.solr_config
     end
+
+    def update_last_known_search_json_string
+
+      if(params[:last_known_search_json_string].nil?)
+        session[:search][:results_view] = false
+      else
+        last_known_search_hash = ActiveSupport::JSON.decode(params[:last_known_search_json_string])
+        last_known_search_hash['counter'] = params[:counter]
+        last_known_search_hash['results_view'] = true
+        last_known_search_hash.symbolize_keys!
+        session[:search] = last_known_search_hash
+        session[:search][:results_view] = true
+      end
+    end
+
 end


### PR DESCRIPTION
This addition to Blacklight will allow users to perform simultaneous searches in multiple browser tabs/windows, making it possible to click the "Previous" and "Next" links on an item-level page for one tab's result set without losing the other result sets in different tabs.

This multi-tab feature requires JavaScript and the new cucumber test that I added does as well.
