### PR TITLE
Removed redundant call to #render_document_sidebar_partial

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,7 +5,6 @@
    
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name) %>
 <% extra_head_content << render_link_rel_alternates %>
-<% sidebar_items << render_document_sidebar_partial %>
 
 <%# this should be in a partial -%>
 <div id="document" class="<%= render_document_class %>">


### PR DESCRIPTION
The removed line appeared redundant.  If it's there for some reason, please add a test for it, and close this PR w/o merging.  All tests pass without the line.
