### PR TITLE
Update lightbox_dialog.js - Adding an event for DOM change when modal already exists.

### DIFF
--- a/app/assets/javascripts/blacklight/lightbox_dialog.js
+++ b/app/assets/javascripts/blacklight/lightbox_dialog.js
@@ -1,5 +1,11 @@
 //= require blacklight/core
 Blacklight.setup_modal = function(link_selector, form_selector, launch_modal) {
+
+	// Event indicating blacklight is setting up a modal link
+	var e = $.Event('lightbox.setup_modal');
+	$(link_selector).trigger(e);
+	if (e.isDefaultPrevented()) return;
+
     $(link_selector).click(function(e) {
       link = $(this)
       


### PR DESCRIPTION
There is an event for when the modal is new and the DOM is ready for use (by using the "show" event in bootstrap-modal.js).
There is no event for when the DOM has changed and the modal already exists.

Such event was added in this commit.
