### PR TITLE
574 adding keyboard accessibility  to the facet expanders

### DIFF
--- a/app/assets/javascripts/blacklight/facet_expand_contract.js
+++ b/app/assets/javascripts/blacklight/facet_expand_contract.js
@@ -26,6 +26,11 @@ Blacklight.do_facet_expand_contract_behavior = function() {
            }
 
            // attach the toggle behavior to the h3 tag
+           $('h5', f_content.parent()).click(function(){
+               // toggle the content
+               $(this).toggleClass('twiddle-open');
+               $(f_content).slideToggle();
+           });
            $('a', f_content.parent()).click(function(){
                // toggle the content
                $(this).toggleClass('twiddle-open');

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,4 +1,4 @@
 <div class="facet_limit blacklight-<%= facet_field.field.parameterize %>">
-  <h3><a href="#"><%= facet_field.label -%></a></h3>
+  <h5><a href="#"><%= facet_field.label -%></a></h5>
   <%= yield %>
 </div>


### PR DESCRIPTION
Bug #574 :

Adding a tab index and a button role to the h3 that constitutes the expandable facet header to enable keyboard navigation. Using the role button rather than link because the W3C recommends that if it doesn't change focus or page -- http://www.w3.org/TR/wai-aria/roles#link

Adding a keypress handler for pressing "enter" on that header, as well as a click handler.
