### PR TITLE
use HTML5 autofocus attribute and the helper should_autofocus_on_search_...

### DIFF
--- a/app/assets/javascripts/blacklight/autofocus.js
+++ b/app/assets/javascripts/blacklight/autofocus.js
@@ -1,0 +1,16 @@
+//= require blacklight/core
+(function($) {
+  Blacklight.do_search_autofocus_fallback = function() {
+    if (typeof Modernizer != "undefined") {
+      if (Modernizr.autofocus) {
+        return;
+      }
+    }
+
+    $('input[autofocus]').focus();
+  }
+
+  Blacklight.onLoad(function() {
+    Blacklight.do_search_autofocus_fallback();
+  });
+})(jQuery);

--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -5,6 +5,7 @@
 //
 // These javascript files are compiled in via the Rails asset pipeline:
 //= require blacklight/core
+//= require blacklight/autofocus
 //= require blacklight/bookmark_toggle
 //= require blacklight/facet_expand_contract
 //= require blacklight/lightbox_dialog

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -82,4 +82,10 @@ module Blacklight::CatalogHelperBehavior
     response.total > 1
   end
 
+  def should_autofocus_on_search_box?
+    controller.is_a? Blacklight::Catalog and
+      action_name == "index" and
+      params[:q].to_s.empty? and
+      params[:f].to_s.empty?
+  end
 end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -10,7 +10,7 @@
       <% end %>
        <div class="input-append pull-left">
         <label for="q" class="hide-text"><%= t('blacklight.search.form.q') %></label>
-         <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q", :id => "q"%>
+         <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q", :id => "q", :autofocus => should_autofocus_on_search_box? %>
         <button type="submit" class="btn btn-primary search-btn" id="search">
           <span class="submit-search-text"><%=t('blacklight.search.form.submit')%></span>
           <i class="icon-search icon-white"></i>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -27,8 +27,7 @@
     <![endif]-->
 
   </head>
-  <% onload_text = "$('input#q').focus();" if params[:q].to_s.empty? and params[:f].to_s.empty? and params[:id].nil? %>
-  <body onload="<%= onload_text %>" class="<%= render_body_class %>">
+  <body class="<%= render_body_class %>">
   <%= render :partial => 'shared/header_navbar' %>
 
   <div id="ajax-modal" class="modal hide fade" tabindex="-1"></div>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -89,4 +89,31 @@ describe CatalogHelper do
     end
 
   end
+
+  describe "should_autofocus_on_search_box?" do
+    it "should be focused if we're on a catalog-like index page without query or facet parameters" do
+      helper.stub(:controller => CatalogController.new, :action_name => "index", :params => { })
+      expect(helper.should_autofocus_on_search_box?).to be_true
+    end
+
+    it "should not be focused if we're not on a catalog controller" do
+      helper.stub(:controller => ApplicationController.new)
+      expect(helper.should_autofocus_on_search_box?).to be_false
+    end
+
+    it "should not be focused if we're not on a catalog controller index" do
+      helper.stub(:controller => CatalogController.new, :action_name => "show")
+      expect(helper.should_autofocus_on_search_box?).to be_false
+    end
+
+    it "should not be focused if a search string is provided" do
+      helper.stub(:controller => CatalogController.new, :action_name => "index", :params => { :q => "hello"})
+      expect(helper.should_autofocus_on_search_box?).to be_false
+    end
+
+    it "should not be focused if a facet is selected" do
+      helper.stub(:controller => CatalogController.new, :action_name => "index", :params => { :f => { "field" => ["value"]}})
+      expect(helper.should_autofocus_on_search_box?).to be_false
+    end
+  end
 end


### PR DESCRIPTION
use HTML5 autofocus attribute and the helper should_autofocus_on_search_box? to determine if a search box should be autofocused or not.

fixes #584.

I've included support for modernizr, if it is is provided, but do not force it on downstream consumers.
