### PR TITLE
Provide Blacklight configuration support for linking field values to facets

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -12,8 +12,8 @@ class BookmarksController < CatalogController
  
   # Blacklight uses #search_action_url to figure out the right URL for
   # the global search box
-  def search_action_url
-    catalog_index_url
+  def search_action_url *args
+    catalog_index_url *args
   end
   helper_method :search_action_url
 

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -25,8 +25,8 @@ module Blacklight::Catalog
     rescue_from RSolr::Error::Http, :with => :rsolr_request_error
   end
   
-  def search_action_url
-    url_for(:action => 'index', :only_path => true)
+  def search_action_url options = {}
+    url_for(options.merge(:action => 'index', :only_path => true))
   end
 
     # get search results from the solr index

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -479,6 +479,8 @@ describe BlacklightHelper do
       @config = Blacklight::Configuration.new.configure do |config|
         config.add_index_field 'qwer'
         config.add_index_field 'asdf', :helper_method => :render_asdf_index_field
+        config.add_index_field 'link_to_search_true', :link_to_search => true
+        config.add_index_field 'link_to_search_named', :link_to_search => :some_field
         config.add_index_field 'highlight', :highlight => true
       end
       helper.stub(:blacklight_config).and_return(@config)
@@ -497,6 +499,20 @@ describe BlacklightHelper do
       helper.stub(:render_asdf_index_field).and_return('custom asdf value')
       value = helper.render_index_field_value :document => doc, :field => 'asdf'
       value.should == 'custom asdf value'
+    end
+
+    it "should check for a link_to_search" do
+      doc = double()
+      doc.should_receive(:get).with('link_to_search_true', :sep => nil).and_return('x')
+      value = helper.render_index_field_value :document => doc, :field => 'link_to_search_true'
+      value.should == helper.link_to("x", helper.search_action_url(:f => { :link_to_search_true => ['x'] }))
+    end
+
+    it "should check for a link_to_search with a field name" do
+      doc = double()
+      doc.should_receive(:get).with('link_to_search_named', :sep => nil).and_return('x')
+      value = helper.render_index_field_value :document => doc, :field => 'link_to_search_named'
+      value.should == helper.link_to("x", helper.search_action_url(:f => { :some_field => ['x'] }))
     end
 
     it "should gracefully handle when no highlight field is available" do
@@ -537,6 +553,8 @@ describe BlacklightHelper do
       @config = Blacklight::Configuration.new.configure do |config|
         config.add_show_field 'qwer'
         config.add_show_field 'asdf', :helper_method => :render_asdf_document_show_field
+        config.add_show_field 'link_to_search_true', :link_to_search => true
+        config.add_show_field 'link_to_search_named', :link_to_search => :some_field
         config.add_show_field 'highlight', :highlight => true
       end
       helper.stub(:blacklight_config).and_return(@config)
@@ -556,6 +574,20 @@ describe BlacklightHelper do
       helper.stub(:render_asdf_document_show_field).and_return('custom asdf value')
       value = helper.render_document_show_field_value :document => doc, :field => 'asdf'
       value.should == 'custom asdf value'
+    end
+
+    it "should check for a link_to_search" do
+      doc = double()
+      doc.should_receive(:get).with('link_to_search_true', :sep => nil).and_return('x')
+      value = helper.render_document_show_field_value :document => doc, :field => 'link_to_search_true'
+      value.should == helper.link_to("x", helper.search_action_url(:f => { :link_to_search_true => ['x'] }))
+    end
+
+    it "should check for a link_to_search with a field name" do
+      doc = double()
+      doc.should_receive(:get).with('link_to_search_named', :sep => nil).and_return('x')
+      value = helper.render_document_show_field_value :document => doc, :field => 'link_to_search_named'
+      value.should == helper.link_to("x", helper.search_action_url(:f => { :some_field => ['x'] }))
     end
 
     it "should gracefully handle when no highlight field is available" do


### PR DESCRIPTION
Fixes #575
    config.add_index_field 'format', :label => 'Format:', :link_to_search =>  true
    config.add_index_field 'author_display', :label => 'Author:', :link_to_search =>  :author_facet

I think the logic to render the link e.g.

```
link_to render_field_value(v), search_action_url(add_facet_params(field, value, {}))
```

probably needs to be pulled into a helper that can be overridden. But maybe that's a phase 2 concern?
