### PR TITLE
move kaminari pagination helpers into Blacklight::SolrResponse, so kaminari can work with our response objects natively.

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -5,28 +5,7 @@ module Blacklight::CatalogHelperBehavior
   # it translates to a Kaminari-paginatable
   # object, with the keys Kaminari views expect.
   def paginate_params(response)
-
-    per_page = response.rows
-    per_page = 1 if per_page < 1
-
-    current_page = (response.start / per_page).ceil + 1
-    num_pages = (response.total / per_page.to_f).ceil
-
-    total_count = response.total
-
-    start_num = response.start + 1
-    end_num = start_num + response.docs.length - 1
-
-    OpenStruct.new(:start => start_num,
-                   :end => end_num,
-                   :per_page => per_page,
-                   :current_page => current_page,
-                   :num_pages => num_pages,
-                   :limit_value => per_page, # backwards compatibility
-                   :total_count => total_count,
-                   :first_page? => current_page > 1,
-                   :last_page? => current_page < num_pages
-      )
+    response
   end
 
   # Equivalent to kaminari "paginate", but takes an RSolr::Response as first argument.
@@ -35,8 +14,7 @@ module Blacklight::CatalogHelperBehavior
   # kaminari paginate, passed on through.
   # will output HTML pagination controls.
   def paginate_rsolr_response(response, options = {}, &block)
-    pagination_info = paginate_params(response)
-    paginate Kaminari.paginate_array(response.docs, :total_count => pagination_info.total_count).page(pagination_info.current_page).per(pagination_info.per_page), options, &block
+    paginate response, options, &block
   end
 
   #
@@ -47,18 +25,15 @@ module Blacklight::CatalogHelperBehavior
   #
   # Pass in an RSolr::Response. Displays the "showing X through Y of N" message.
   def render_pagination_info(response, options = {})
-      pagination_info = paginate_params(response)
-
    # TODO: i18n the entry_name
       entry_name = options[:entry_name]
       entry_name ||= response.docs.first.class.name.underscore.sub('_', ' ') unless response.docs.empty?
       entry_name ||= t('blacklight.entry_name.default')
 
-
-      case pagination_info.total_count
+      case response.total_count
         when 0; t('blacklight.search.pagination_info.no_items_found', :entry_name => entry_name.pluralize ).html_safe
         when 1; t('blacklight.search.pagination_info.single_item_found', :entry_name => entry_name).html_safe
-        else; t('blacklight.search.pagination_info.pages', :entry_name => entry_name.pluralize, :current_page => pagination_info.current_page, :num_pages => pagination_info.num_pages, :start_num => format_num(pagination_info.start), :end_num => format_num(pagination_info.end), :total_num => pagination_info.total_count, :count => pagination_info.num_pages).html_safe
+        else; t('blacklight.search.pagination_info.pages', :entry_name => entry_name.pluralize, :current_page => response.current_page, :num_pages => response.total_pages, :start_num => format_num(response.start + 1) , :end_num => format_num(response.start + response.docs.length), :total_num => response.total_count, :count => response.total_pages).html_safe
       end
   end
 

--- a/app/views/catalog/_opensearch_response_metadata.html.erb
+++ b/app/views/catalog/_opensearch_response_metadata.html.erb
@@ -1,4 +1,3 @@
-<% page_info = paginate_params(@response) %>
 <%= tag :meta, :name => "totalResults", :content => @response.total %>
-<%= tag :meta, :name => "startIndex", :content => (page_info.current_page == 1 ? 1 : @response.start ) %>
-<%= tag :meta, :name => "itemsPerPage", :content => page_info.limit_value %>
+<%= tag :meta, :name => "startIndex", :content => @response.start %>
+<%= tag :meta, :name => "itemsPerPage", :content => @response.limit_value %>

--- a/app/views/catalog/_paginate_compact.html.erb
+++ b/app/views/catalog/_paginate_compact.html.erb
@@ -1,4 +1,4 @@
-<% if paginate_params(@response).num_pages > 1 %>
+<% if @response.total_pages > 1 %>
 <%= paginate_rsolr_response @response, :theme => :blacklight_compact %>
 <% else %>
 <%= render_pagination_info(@response) %>

--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,8 +1,8 @@
-<% if paginate_params(@response).num_pages > 1 %>
+<% if @response.total_pages > 1 %>
  <div class="row record-padding">
   <div class="span9"> 
     <div class="pagination">
-      <%= paginate_rsolr_response @response, :outer_window => 2, :theme => 'blacklight' %>
+      <%= paginate @response, :outer_window => 2, :theme => 'blacklight' %>
     </div>
   </div>
  </div>

--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -1,5 +1,4 @@
 require 'base64'
-page_info = paginate_params(@response)
 
 xml.instruct!(:xml, :encoding => "UTF-8")
 
@@ -17,18 +16,18 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
   # Navigational and context links
   
   xml.link( "rel" => "next", 
-            "href" => url_for(params.merge(:only_path => false, :page => (page_info.current_page + 1).to_s))
-           ) if  page_info.num_pages > page_info.current_page
+            "href" => url_for(params.merge(:only_path => false, :page => @response.next_page.to_s))
+           ) if @response.next_page
   
   xml.link( "rel" => "previous", 
-            "href" => url_for(params.merge(:only_path => false, :page => (page_info.current_page - 1).to_s))
-           ) if page_info.current_page > 1
+            "href" => url_for(params.merge(:only_path => false, :page => @response.prev_page.to_s))
+           ) if @response.prev_page
            
   xml.link( "rel" => "first", 
             "href" => url_for(params.merge(:only_path => false, :page => "1")))
   
   xml.link( "rel" => "last",
-            "href" => url_for(params.merge(:only_path => false, :page => page_info.num_pages.to_s)))
+            "href" => url_for(params.merge(:only_path => false, :page => @response.total_pages.to_s)))
   
   # "search" doesn't seem to actually be legal, but is very common, and
   # used as an example in opensearch docs
@@ -39,8 +38,8 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
   # opensearch response elements
   xml.opensearch :totalResults, @response.total.to_s
   xml.opensearch :startIndex, @response.start.to_s
-  xml.opensearch :itemsPerPage, page_info.limit_value
-  xml.opensearch :Query, :role => "request", :searchTerms => params[:q], :startPage => page_info.current_page
+  xml.opensearch :itemsPerPage, @response.limit_value
+  xml.opensearch :Query, :role => "request", :searchTerms => params[:q], :startPage => @response.current_page
   
   
   # updated is required, for now we'll just set it to now, sorry

--- a/lib/blacklight/solr_response.rb
+++ b/lib/blacklight/solr_response.rb
@@ -1,8 +1,41 @@
+require 'kaminari'
+
 class Blacklight::SolrResponse < HashWithIndifferentAccess
 
   autoload :Spelling, 'blacklight/solr_response/spelling'
   autoload :Facets, 'blacklight/solr_response/facets'
   autoload :MoreLikeThis, 'blacklight/solr_response/more_like_this'
+
+  include Kaminari::PageScopeMethods
+  
+
+  module PaginationMethods
+
+    def limit_value #:nodoc:
+      rows
+    end
+
+    def offset_value #:nodoc:
+      start
+    end
+
+    def total_count #:nodoc:
+      total
+    end
+
+    ## Methods in kaminari master that we'd like to use today.
+    # Next page number in the collection
+    def next_page
+      current_page + 1 unless last_page?
+    end
+
+    # Previous page number in the collection
+    def prev_page
+      current_page - 1 unless first_page?
+    end
+  end
+
+  include PaginationMethods
 
   attr_reader :request_params
   def initialize(data, request_params)
@@ -18,7 +51,6 @@ class Blacklight::SolrResponse < HashWithIndifferentAccess
     self['responseHeader']
   end
   
-
   def update(other_hash) 
     other_hash.each_pair { |key, value| self[key] = value } 
     self 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -11,7 +11,9 @@ describe CatalogHelper do
     start = (current_page - 1) * per_page
 
     mock_response = double("Blacklight::SolrResponse")
-    mock_response.stub(:total).and_return(total)
+    mock_response.stub(:total_count).and_return(total)
+    mock_response.stub(:current_page).and_return(current_page)
+    mock_response.stub(:total_pages).and_return((total / per_page).to_i + 1)
     mock_response.stub(:rows).and_return(per_page)
     mock_response.stub(:start).and_return(start)
     mock_response.stub(:docs).and_return((1..total).to_a.slice(start, per_page))

--- a/spec/lib/blacklight_solr_response_spec.rb
+++ b/spec/lib/blacklight_solr_response_spec.rb
@@ -8,21 +8,19 @@ describe Blacklight::SolrResponse do
     Blacklight::SolrResponse.new(raw_response, raw_response['params'])
   end
 
+  let(:r) { create_response }
+
   it 'should create a valid response' do
-    r = create_response
     r.should respond_to(:header)
   end
 
   it 'should have accurate pagination numbers' do
-    r = create_response
     r.rows.should == 11
     r.total.should == 26
     r.start.should == 0
   end
 
   it 'should create a valid response class' do
-    r = create_response
-
     r.should respond_to(:response)
     r.docs.size.should == 11
     r.params[:echoParams].should == 'EXPLICIT'
@@ -31,7 +29,6 @@ describe Blacklight::SolrResponse do
   end
 
   it 'should provide facet helpers' do
-    r = create_response
     r.facets.size.should == 2
 
     field_names = r.facets.collect{|facet|facet.name}
@@ -58,6 +55,15 @@ describe Blacklight::SolrResponse do
       end
     end
 
+  end
+
+  it "should provide kaminari pagination helpers" do
+    expect(r.limit_value).to eq(r.rows)
+    expect(r.offset_value).to eq(r.start)
+    expect(r.total_count).to eq(r.total)
+    expect(r.next_page).to eq(r.current_page + 1)
+    expect(r.prev_page).to eq(nil)
+    expect(r).to be_a_kind_of Kaminari::PageScopeMethods
   end
 
   describe "FacetItem" do


### PR DESCRIPTION
I'm happy to call this sufficiently backwards-compatible. Some of the values from paginate_params will be missing, but only those that weren't kaminari values in the first place. 
