### PR TITLE
add support for thumbnails in search results

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -248,3 +248,8 @@ span.page a,span.page.current
 #email_form {
   @extend .span6;
 }
+
+.document-thumbnail {
+  float: right;
+  padding-left: 20px;
+}

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -88,4 +88,26 @@ module Blacklight::CatalogHelperBehavior
       params[:q].to_s.empty? and
       params[:f].to_s.empty?
   end
+
+  def has_thumbnail? document
+    blacklight_config.index.thumbnail_method or
+      blacklight_config.index.thumbnail_field && document.has_field?(blacklight_config.index.thumbnail_field)
+  end
+
+  def render_thumbnail_tag document, image_options = {}, url_options = {}
+    value = if blacklight_config.index.thumbnail_method
+      send(blacklight_config.index.thumbnail_method, document, image_options)
+    elsif blacklight_config.index.thumbnail_field
+      image_tag thumbnail_url(document), image_options
+    end
+
+    if value
+      link_to_document document, url_options.merge(:label => value)
+    end
+  end
+
+  def thumbnail_url document
+    document.get(blacklight_config.index.thumbnail_field, :sep => nil).first if document.has_field?(blacklight_config.index.thumbnail_field)
+  end
+
 end

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,7 +1,8 @@
     <% # container for a single doc -%>
     <div class="document <%= render_document_class document %>">
-      
       <%= render :partial => 'document_header', :locals => { :document => document, :document_counter => document_counter } %>
+
+      <%= render_document_partial document, :thumbnail, :document_counter => document_counter %>
 
       <% # main container for doc partial view -%>
       <%= render_document_partial document, :index %>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,5 +1,5 @@
 <%# default partial to display solr document fields in catalog index view -%>
-<dl class="dl-horizontal dl-invert">
+<dl class="document-metadata dl-horizontal dl-invert">
   
   <% index_fields(document).each do |solr_fname, field| -%>
     <% if should_render_index_field? document, field %>

--- a/app/views/catalog/_thumbnail_default.html.erb
+++ b/app/views/catalog/_thumbnail_default.html.erb
@@ -1,0 +1,5 @@
+<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, nil, :counter => document_counter + 1 + @response.params[:start].to_i) %>
+<div class="document-thumbnail">
+  <%= tn %>
+</div>  
+<%- end %>

--- a/lib/generators/blacklight/templates/alternate_controller.rb
+++ b/lib/generators/blacklight/templates/alternate_controller.rb
@@ -1,4 +1,13 @@
 # -*- encoding : utf-8 -*-
 class AlternateController < CatalogController  
+  configure_blacklight do |config|
+    config.index.thumbnail_method = :xyz
+  end
+
+  def xyz *args
+    view_context.image_tag "asdfg"
+  end
+  
+  helper_method :xyz
 
 end 

--- a/spec/features/alternate_controller_spec.rb
+++ b/spec/features/alternate_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe "Alternate Controller Behaviors" do
+  it "should have the correct per-page form" do
+    visit alternate_index_path
+    page.should have_selector("form[action='#{alternate_index_path}']")
+    fill_in "q", :with=>"history"
+    click_button 'search'
+    expect(current_path).to match /#{alternate_index_path}/
+    click_on '10 per page'
+    expect(current_path).to match /#{alternate_index_path}/
+  end
+
+  it "should have the correct search field form" do
+    visit alternate_index_path
+    page.should have_selector("form[action='#{alternate_index_path}']")
+    fill_in "q", :with=>"history"
+    click_button 'search'
+    expect(current_path).to match /#{alternate_index_path}/
+    click_on 'relevance'
+    expect(current_path).to match /#{alternate_index_path}/
+  end
+
+  it "should display document thumbnails" do
+    visit alternate_index_path
+    page.should have_selector("form[action='#{alternate_index_path}']")
+    fill_in "q", :with=>"history"
+    click_button 'search'
+    expect(page).to have_selector ".document-thumbnail"
+    expect(page).to have_selector ".document-thumbnail a[data-counter]"
+    expect(page).to have_selector ".document-thumbnail a img"
+
+  end
+end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -116,4 +116,83 @@ describe CatalogHelper do
       expect(helper.should_autofocus_on_search_box?).to be_false
     end
   end
+
+  describe "has_thumbnail?" do
+    it "should have a thumbnail if a thumbnail_method is configured" do
+      helper.stub(:blacklight_config => OpenStruct.new(:index => OpenStruct.new(:thumbnail_method => :xyz) ))
+      document = double()
+      expect(helper.has_thumbnail? document).to be_true
+    end
+
+    it "should have a thumbnail if a thumbnail_field is configured and it exists in the document" do
+      helper.stub(:blacklight_config => OpenStruct.new(:index => OpenStruct.new(:thumbnail_field => :xyz) ))
+      document = double(:has_field? => true)
+      expect(helper.has_thumbnail? document).to be_true
+    end
+    
+    it "should not have a thumbnail if the thumbnail_field is missing from the document" do
+      helper.stub(:blacklight_config => OpenStruct.new(:index => OpenStruct.new(:thumbnail_field => :xyz) ))
+      document = double(:has_field? => false)
+      expect(helper.has_thumbnail? document).to be_false
+    end
+
+    it "should not have a thumbnail if none of the fields are configured" do
+      helper.stub(:blacklight_config => OpenStruct.new(:index => OpenStruct.new()))
+      expect(helper.has_thumbnail? double()).to be_false
+    end
+  end
+
+  describe "render_thumbnail_tag" do
+    it "should call the provided thumbnail method" do
+      helper.stub(:blacklight_config => double(:index => double(:thumbnail_method => :xyz)))
+      document = double()
+      helper.stub(:xyz => "some-thumbnail")
+
+      helper.should_receive(:link_to_document).with(document, :label => "some-thumbnail")
+      helper.render_thumbnail_tag document
+    end
+
+    it "should create an image tag from the given field" do
+      helper.stub(:blacklight_config => double(:index => OpenStruct.new(:thumbnail_field => :xyz)))
+      document = double()
+
+      document.stub(:has_field?).with(:xyz).and_return(true)
+      document.stub(:get).with(:xyz, :sep => nil).and_return(["http://example.com/some.jpg"])
+
+      helper.should_receive(:link_to_document).with(document, :label => image_tag("http://example.com/some.jpg"))
+      helper.render_thumbnail_tag document
+    end
+
+    it "should return nil if no thumbnail is available" do
+      helper.stub(:blacklight_config => double(:index => OpenStruct.new()))
+
+      document = double()
+      expect(helper.render_thumbnail_tag document).to be_nil
+    end
+
+    it "should return nil if no thumbnail is returned from the thumbnail method" do
+      helper.stub(:blacklight_config => double(:index => OpenStruct.new(:thumbnail_method => :xyz)))
+      helper.stub(:xyz => nil)
+      document = double()
+
+      expect(helper.render_thumbnail_tag document).to be_nil
+    end
+  end
+
+  describe "thumbnail_url" do
+    it "should pull the configured thumbnail field out of the document" do
+      helper.stub(:blacklight_config => double(:index => double(:thumbnail_field => "xyz")))
+      document = double()
+      document.stub(:has_field?).with("xyz").and_return(true)
+      document.stub(:get).with("xyz", :sep => nil).and_return(["asdf"])
+      expect(helper.thumbnail_url document).to eq("asdf")
+    end
+
+    it "should return nil if the thumbnail field doesn't exist" do
+      helper.stub(:blacklight_config => double(:index => double(:thumbnail_field => "xyz")))
+      document = double()
+      document.stub(:has_field?).with("xyz").and_return(false)
+      expect(helper.thumbnail_url document).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Fixes #580

Add support for:

```
  configure_blacklight do |config|
    config.index.thumbnail_method = :xyz
  end
```

and

```
  configure_blacklight do |config|
    config.index.thumbnail_field = :some_field_in_the_document
  end
```

Given that, Blacklight will render a thumbnail (by default, right aligned, under the bookmark button) as a link to the document page. If no thumbnail is available (missing data in solr, the thumbnail method returned nil), the thumbnail block is not displayed at all.
