### PR TITLE
solr_helper.solr_param_quote now allows digits in un-escaped arg

### DIFF
--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -96,7 +96,7 @@ module Blacklight::SolrHelper
   # if needed. 
   def solr_param_quote(val, options = {})
     options[:quote] ||= '"'
-    unless val =~ /^[a-zA-Z$_\-\^]+$/
+    unless val =~ /^[a-zA-Z0-9$_\-\^]+$/
       val = options[:quote] +
         # Yes, we need crazy escaping here, to deal with regexp esc too!
         val.gsub("'", "\\\\\'").gsub('"', "\\\\\"") + 

--- a/spec/lib/solr_helper_spec.rb
+++ b/spec/lib/solr_helper_spec.rb
@@ -379,7 +379,8 @@ describe 'Blacklight::SolrHelper' do
           :key => "custom_author_key",
           :solr_local_parameters => {
             :qf => "$author_qf",
-            :pf => "you'll have \" to escape this"
+            :pf => "you'll have \" to escape this",
+            :pf2 => "$pf2_do_not_escape_or_quote"
           },
           :solr_parameters => {
             :qf => "someField^1000",
@@ -406,6 +407,7 @@ describe 'Blacklight::SolrHelper' do
       it "should include include local params with escaping" do
         @result[:q].should include('qf=$author_qf')
         @result[:q].should include('pf=\'you\\\'ll have \\" to escape this\'')
+        @result[:q].should include('pf2=$pf2_do_not_escape_or_quote')
       end
     end
     


### PR DESCRIPTION
This is for  https://github.com/projectblacklight/blacklight/issues/603;  fix so local param of $pf2_do_not_quote is passed to solr as   :q=>"{!pf2=$pf2_do_not_quote}foo"  rather than having quotes added like so: :q=>"{!pf2='$pf2_do_not_quote'}foo"  which doesn't work.
