### PR TITLE
Refactor catalog#email and catalog#sms

### DIFF
--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -14,24 +14,9 @@ class RecordMailer < ActionMailer::Base
   end
   
   def sms_record(documents, details, url_gen_params)
-    if sms_mapping[details[:carrier]]
-      to = "#{details[:to]}@#{sms_mapping[details[:carrier]]}"
-    end
     @documents      = documents
     @url_gen_params = url_gen_params
-    mail(:to => to, :subject => "")
+    mail(:to => details[:to], :subject => "")
   end
 
-  protected
-  
-  def sms_mapping
-    {'virgin' => 'vmobl.com',
-    'att' => 'txt.att.net',
-    'verizon' => 'vtext.com',
-    'nextel' => 'messaging.nextel.com',
-    'sprint' => 'messaging.sprintpcs.com',
-    'tmobile' => 'tmomail.net',
-    'alltel' => 'message.alltel.com',
-    'cricket' => 'mms.mycricket.com'}
-  end
 end

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -1,4 +1,3 @@
-<%- unless flash[:success] %>
 <%= form_tag url_for(:controller => "catalog", :action => "email"), :id => 'email_form', :class => "form-horizontal ajax_form", :method => :post do %>
 
   <div class="modal-body">
@@ -35,9 +34,3 @@
   <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
   </div>
 <% end %>
-<%- else %>
-<div class="modal-body">
-  <%= render :partial=>'/flash_msg' %>
-    <span class="ajax-close-modal"/>
-    </div>
-<%- end %>

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -1,17 +1,3 @@
-<% carriers = 
-{
-'AT&T' => 'att',
-'Verizon' => 'verizon',
-'T Mobile' => 'tmobile',
-'Sprint' => 'sprint',
-'Nextel' => 'nextel',
-'Virgin Mobile' => 'virgin',
-'Alltel' => 'alltel',
-'Cricket' => 'cricket'
-}
-%>
-<%- unless flash[:success] %>
-  
   <%= form_tag url_for(:controller => "catalog", :action => "sms"), :id => 'sms_form', :class => "form-horizontal ajax_form", :method => :post do %>
 <div class="modal-body">
   <%= render :partial=>'/flash_msg' %>
@@ -28,7 +14,7 @@
         <%= t('blacklight.sms.form.carrier') %> 
       </label>
       <div class="controls">
-          <%= select_tag(:carrier, options_for_select(carriers.to_a.sort.unshift([t('blacklight.sms.form.carrier_prompt'),'']), params[:carrier])) %><br/>
+          <%= select_tag(:carrier, options_for_select(sms_mappings.to_a.sort.unshift([t('blacklight.sms.form.carrier_prompt'),'']), params[:carrier])) %><br/>
       </div>
 
     </div>
@@ -40,9 +26,3 @@
 <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
 </div>
   <% end %>
-<%- else %>
-<div class="modal-body">
-  <%= render :partial=>'/flash_msg' %>
-    <span class="ajax-close-modal"/>
-    </div>
-<%- end %>

--- a/app/views/catalog/email_sent.html.erb
+++ b/app/views/catalog/email_sent.html.erb
@@ -1,0 +1,9 @@
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+  <h1><%= t('blacklight.email.form.title') %></h1>
+</div>
+
+<div class="modal-body">
+  <%= render :partial=>'/flash_msg' %>
+  <span class="ajax-close-modal"></span>
+</div>

--- a/app/views/catalog/sms_sent.html.erb
+++ b/app/views/catalog/sms_sent.html.erb
@@ -1,0 +1,9 @@
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+  <h1><%= t('blacklight.sms.form.title') %></h1>
+</div>
+
+<div class="modal-body">
+  <%= render :partial=>'/flash_msg' %>
+  <span class="ajax-close-modal"></span>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -131,6 +131,8 @@ en:
         url: 'URL: %{url}'
         message: 'Message: %{message}'
 
+      success: "Email Sent"
+
       errors:
         to:
           invalid: 'You must enter a valid email address'
@@ -146,12 +148,14 @@ en:
         title: '%{value}'
         author: ' by %{value}'
         url: 'Link: %{url}'
+      success: "SMS Sent"
       errors:
         to:
           invalid: 'You must enter a valid 10 digit phone number'
           blank: "You must enter a recipient's phone number in order to send this message"
         carrier:
           blank: 'You must select a carrier'
+          invalid: "You must enter a valid carrier"
 
     back_to_search: 'Back to Search'
     back_to_bookmarks: 'Back to Bookmarks'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -141,10 +141,13 @@ fr:
         url: 'URL : %{url}'
         message: 'Message : %{message}'
 
+      success: "Message envoyé"
+
       errors:
         to:
           invalid: 'Vous devez saisir une adresse correcte.'
           blank: 'Vous devez saisir l''adresse de votre destinataire.'
+
     sms:
       form:
         title: 'Envoyer par SMS'
@@ -156,12 +159,16 @@ fr:
         title: '%{value}'
         author: ' by %{value}'
         url: 'Lien : %{url}'
+
+      success: "SMS envoyé"
+
       errors:
         to:
           invalid: 'Vous devez saisir un numéro de téléphone à 10 chiffres.'
           blank: "Vous devez saisir le numéro de téléphone de votre destinataire."
         carrier:
           blank: 'Vous devez choisir un opérateur.'
+          invalid: "Vous devez saisir le opérateur."
 
     back_to_search: 'Retour aux résultats'
     back_to_bookmarks: 'Retour aux favoris'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -368,6 +368,12 @@ describe CatalogController do
         request.flash[:error].should be_nil
         request.should redirect_to(catalog_path(doc_id))
       end
+
+      it "should render email_sent for XHR requests" do
+        xhr :post, :email, :id => doc_id, :to => 'test_email@projectblacklight.org'
+        expect(request).to render_template 'email_sent'
+        expect(request.flash[:success]).to eq "Email Sent"
+      end
     end
     describe "sms" do
       it "should give error if no phone number is given" do
@@ -379,18 +385,28 @@ describe CatalogController do
         request.flash[:error].should == "You must select a carrier"
       end
       it "should give an error when the phone number is not 10 digits" do
-        post :sms, :id => doc_id, :to => '555555555', :carrier => 'att'
+        post :sms, :id => doc_id, :to => '555555555', :carrier => 'txt.att.net'
         request.flash[:error].should == "You must enter a valid 10 digit phone number"
       end
+      it "should give an error when the carrier is not in our list of carriers" do
+        post :sms, :id => doc_id, :to => '5555555555', :carrier => 'no-such-carrier'
+        request.flash[:error].should == "You must enter a valid carrier"
+      end
       it "should allow punctuation in phone number" do
-        post :sms, :id => doc_id, :to => '(555) 555-5555', :carrier => 'att'
+        post :sms, :id => doc_id, :to => '(555) 555-5555', :carrier => 'txt.att.net'
         request.flash[:error].should be_nil
         request.should redirect_to(catalog_path(doc_id))
       end
       it "should redirect back to the record upon success" do
-        post :sms, :id => doc_id, :to => '5555555555', :carrier => 'att'
+        post :sms, :id => doc_id, :to => '5555555555', :carrier => 'txt.att.net'
         request.flash[:error].should be_nil
         request.should redirect_to(catalog_path(doc_id))
+      end
+
+      it "should render sms_sent template for XHR requests" do
+        xhr :post, :sms, :id => doc_id, :to => '5555555555', :carrier => 'txt.att.net'
+        expect(request).to render_template 'sms_sent'
+        expect(request.flash[:success]).to eq "SMS Sent"
       end
     end
   end

--- a/spec/models/record_mailer_spec.rb
+++ b/spec/models/record_mailer_spec.rb
@@ -41,7 +41,7 @@ describe RecordMailer do
   
   describe "SMS" do
     before(:each) do
-      details = {:to => '5555555555', :carrier => 'att'}
+      details = {:to => '5555555555@txt.att.net'}
       @sms = RecordMailer.sms_record(@documents,details,{:host =>'projectblacklight.org:3000'})
     end
     it "should create the correct TO address for the SMS email" do
@@ -56,10 +56,10 @@ describe RecordMailer do
     it "should print out the correct body" do
       @sms.body.should =~ /The horn/
       @sms.body.should =~ /by Janetzky, Kurt/
-      @sms.body.should =~ /projectblacklight.org:300/      
+      @sms.body.should =~ /projectblacklight.org:3000/      
     end
     it "should use https URL when protocol is set" do
-      details = {:to => '5555555555', :carrier => 'att'}
+      details = {:to => '5555555555@txt.att.net'}
       @https_sms = RecordMailer.sms_record(@documents,details,{:host =>'projectblacklight.org', :protocol => 'https'})
       @https_sms.body.should =~ %r|https://projectblacklight.org/|
     end


### PR DESCRIPTION
Extract email validation into a stand-alone, overridable method.

Extract sms validation similarly, and move the SMS provider to email gateway mapping into the `Blacklight::Catalog`, where it can be easily overridden. 
