### PR TITLE
Refactor the catalog/index.html.erb template to render e.g. facets in a separate partial

### DIFF
--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -16,4 +16,4 @@
   <%= render_facet_partials %>
 </div>
 </div>
-<% end %>&nbsp;
+<% end %>

--- a/app/views/catalog/_search_sidebar.html.erb
+++ b/app/views/catalog/_search_sidebar.html.erb
@@ -1,0 +1,1 @@
+<%= render 'facets' %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,6 +1,6 @@
 <div id="sidebar" class="span3">
- <%= render :partial=>'facets' %>
-</div><!--/well -->
+ <%= render 'search_sidebar' %>
+</div>
 
 <div id="content" class="span9">
 

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "catalog/index.html.erb" do
+  it "should render the sidebar and content panes" do
+    view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
+    render
+    expect(rendered).to match /id="sidebar"/
+    expect(rendered).to match /id="content"/
+  end
+
+  it "should render the search_sidebar partial " do
+    stub_template "catalog/_search_sidebar.html.erb" => "sidebar_content"
+
+    view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
+    render
+    expect(rendered).to match /sidebar_content/
+  end
+end


### PR DESCRIPTION
Currently, the `catalog/index.html.erb` template renders facets and the like directly in the template. This should be extracted into a separate partial (containing all the sidebar content, I suppose), which will give applications a hook to modify the sidebar without overriding the whole index template.

There are several use cases (in searchworks, and likely other applications) where we'd like to prepend or append content to the sidebar depending on the search context. This commit allows us to override just the sidebar partial, instead of the whole index template.

Here are some examples:

http://searchworks.stanford.edu/?f%5Bformat%5D%5B%5D=Database

http://searchworks.stanford.edu/?f%5Bcourse%5D%5B%5D=AA-100-01&f%5Binstructor%5D%5B%5D=Pavone%2C+Marco

![screen shot 2013-09-23 at 11 43 44](https://f.cloud.github.com/assets/111218/1194122/1c27079a-2480-11e3-9484-94b454d106a0.png)
![screen shot 2013-09-23 at 11 43 51](https://f.cloud.github.com/assets/111218/1194123/1c2ea8a6-2480-11e3-9f65-a392156d4bba.png)

Or, in some other sides, render some other partials:

![screen shot 2013-09-23 at 11 44 19](https://f.cloud.github.com/assets/111218/1194131/350fc404-2480-11e3-9a43-1de92706eeb4.png)
