### PR TITLE
Add :document_counter to index.atom.builder

### DIFF
--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -45,7 +45,7 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
   # updated is required, for now we'll just set it to now, sorry
   xml.updated Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
   
-  @document_list.each do |doc|
+  @document_list.each_with_index do |doc, document_counter|
     xml.entry do
       xml.title   doc.to_semantic_values[:title][0] || doc.id
 
@@ -68,7 +68,7 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
         xml.summary "type" => "html" do
           xml.text! render_document_partial(doc,
                                             :index,
-                                            :document_counter => @document_list.index(doc))
+                                            :document_counter => document_counter)
         end
       end
       


### PR DESCRIPTION
In my application, I've done some pretty extensive customization of the catalog#index view, and as a result, I need to access the 'document_counter' variable in some of the templates where it wasn't originally included.

As a result, the Atom links are now causing errors in my app, because in line 69 of app/views/catalog/index.atom.builder:

``` ruby
xml.text! render_document_partial(doc, :index)
```

'render_document_partial' is called without the :document_counter parameter, and the templates in my app that are rendered by 'render_document_partial' expect that the :document_counter parameter will be available. And when it isn't, the app throws an error.

I believe that this problem may plague other Blackight apps that have customized the catalog#index view, though I can't be 100% sure since they're running in production. Some examples:
- Columbia University Human Rights Web Archive: http://hrwa.cul.columbia.edu/search.atom?q=human&amp;search_type=find_site&amp;search_type_mobile_button=find_site&amp;utf8=%E2%9C%93
- Tufts: http://dl.tufts.edu/catalog.atom?q=murrow&search_field=all_fields&utf8=%E2%9C%93

(Obviously there could be other issues causing errors with these sites/links.)

This pull request fixes the problem and doesn't affect the pre-existing functionality.
