### PR TITLE
add :document_counter to render_document_partial call in atom builder

### DIFF
--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -45,7 +45,7 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
   # updated is required, for now we'll just set it to now, sorry
   xml.updated Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
   
-  @document_list.each do |doc|
+  @document_list.each_with_index do |doc, document_counter|
     xml.entry do
       xml.title   doc.to_semantic_values[:title][0] || doc.id
 
@@ -66,7 +66,9 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
       
       with_format("html") do
         xml.summary "type" => "html" do
-	            xml.text! render_document_partial(doc, :index)           
+          xml.text! render_document_partial(doc,
+                                            :index,
+                                            :document_counter => document_counter)
         end
       end
       


### PR DESCRIPTION
so that index templates which use the 'document_counter' variable
don't cause errors in catalog#index atom-format view

From @ebenenglish
https://github.com/ebenenglish/blacklight/tree/add-doc-counter-to-atom-builder
