### PR TITLE
Create locales.js.erb - Now the locales are accessible to JS

### DIFF
--- a/app/assets/javascripts/blacklight/locales.js.erb
+++ b/app/assets/javascripts/blacklight/locales.js.erb
@@ -3,6 +3,6 @@ Blacklight.load_locales = function() {
 	Blacklight.locales = <%=I18n.t('blacklight').to_json%>;
 }
 
-$(document).ready( function() {
+Blacklight.onLoad(function() {
   Blacklight.load_locales();
 });


### PR DESCRIPTION
Some JS files (like bookmark_toggle.js) have locales strings inside them, this causes 2 problems:
1) Changing to another language won't work (for the locales strings that are in bookmark_toggle.js).
2) The locales are scatterd around the project instead of one place.

Now the locales which are used from ruby are also used from Javascript.
