### PR TITLE
remove unicode gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :test do
   gem "bootstrap-sass"
   gem 'turbolinks'
   gem 'poltergeist'
-  gem "unicode", :platforms => [:mri_18, :mri_19]
 end
 
 if File.exists?('spec/test_app_templates/Gemfile.extra')

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -17,7 +17,6 @@ group :test do
   gem 'turbolinks'
   gem 'uglifier'
   gem 'poltergeist'
-  gem "unicode", :platforms => [:mri_18, :mri_19]
 end
 
 f = File.expand_path(File.dirname(__FILE__) + '/../spec/test_app_templates/Gemfile.extra')

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -16,7 +16,6 @@ group :test do
   gem "bootstrap-sass"
   gem 'turbolinks'
   gem 'poltergeist'
-  gem "unicode", :platforms => [:mri_18, :mri_19]
 end
 
 f = File.expand_path(File.dirname(__FILE__) + '/../spec/test_app_templates/Gemfile.extra')

--- a/lib/generators/blacklight/blacklight_generator.rb
+++ b/lib/generators/blacklight/blacklight_generator.rb
@@ -20,10 +20,6 @@ This generator makes the following changes to your application:
 Thank you for Installing Blacklight.
        """ 
 
-  def add_unicode_gem
-    gem "unicode", :platforms => [:mri_18, :mri_19] unless defined?(:RUBY_VERSION) and RUBY_VERSION == '2.0.0'
-  end
-
   def add_bootstrap_gem
     # Don't need a version here, because we specify the version in blacklight.gemspec
     gem 'bootstrap-sass'

--- a/spec/lib/marc_export_spec.rb
+++ b/spec/lib/marc_export_spec.rb
@@ -676,14 +676,7 @@ describe Blacklight::Solr::Document::MarcExport do
       @music_record.export_as_refworks_marc_txt.should == "LEADER 01828cjm a2200409 a 4500001    a4768316\n003    SIRSI\n007    sd fungnnmmned\n008    020117p20011990xxuzz    h              d\n245 00 Music for horn |h[sound recording] / |cBrahms, Beethoven, von Krufft.\n260    [United States] : |bHarmonia Mundi USA, |cp2001.\n700 1  Greer, Lowell.\n700 1  Lubin, Steven.\n700 1  Chase, Stephanie, |d1957-\n700 12 Brahms, Johannes, |d1833-1897. |tTrios, |mpiano, violin, horn, |nop. 40, |rE? major.\n700 12 Beethoven, Ludwig van, |d1770-1827. |tSonatas, |mhorn, piano, |nop. 17, |rF major.\n700 12 Krufft, Nikolaus von, |d1779-1818. |tSonata, |mhorn, piano, |rF major.\n"
     end
     describe "for UTF-8 record" do
-      it "should export in Unicode normalized C form" do
-
-        begin
-          require 'unicode'
-        rescue LoadError
-          Blacklight.logger.should_receive(:warn) unless defined? :JRUBY_VERSION
-        end
-
+      it "should export in Unicode normalized C form" do        
         @utf8_exported = @record_utf8_decomposed.export_as_refworks_marc_txt
 
         if defined? Unicode


### PR DESCRIPTION
Turns out the unicode normalization functionality from it we were using
has been in ActiveSupport since 3.0. So un-needed, and we can simplify
things substantially without the unicode gem -- which only worked on
MRI anyway, maybe had problems in ruby 2.0, and required alternates on
jruby etc. Much simpler now, just use ActiveSupport!
