### PR TITLE
render search results header content (did you mean, constraints, sort an...

### DIFF
--- a/app/views/catalog/_search_header.html.erb
+++ b/app/views/catalog/_search_header.html.erb
@@ -1,0 +1,5 @@
+<%= render 'did_you_mean' %>
+
+<%= render 'constraints' %>
+
+<%= render 'sort_and_per_page' %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -16,11 +16,7 @@
 
       <% extra_head_content << render_opensearch_response_metadata.html_safe %>
 
-	    <%= render 'did_you_mean' %>
-
-      <%= render 'constraints' %>
-
-      <%= render 'sort_and_per_page' %>
+      <%= render 'search_header' %>
 
       <h2 class="hide-text"><%= t('blacklight.search.search_results') %></h2>
 

--- a/spec/views/catalog/_search_header.erb_spec.rb
+++ b/spec/views/catalog/_search_header.erb_spec.rb
@@ -1,0 +1,17 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+# spec for sidebar partial in catalog show view
+
+describe "/catalog/_search_header.html.erb" do
+
+  it "should render the default search header partials" do
+    stub_template "_did_you_mean.html.erb" => "did_you_mean"
+    stub_template "_constraints.html.erb" => "constraints"
+    stub_template "_sort_and_per_page.html.erb" => "sort_and_per_page"
+    render
+    expect(rendered).to match /did_you_mean/
+    expect(rendered).to match /constraints/
+    expect(rendered).to match /sort_and_per_page/
+  end
+end

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -15,4 +15,17 @@ describe "catalog/index.html.erb" do
     render
     expect(rendered).to match /sidebar_content/
   end
+
+  it "should render the search_header partial " do
+    stub_template "catalog/_results_pagination.html.erb" => ""
+    stub_template "catalog/_search_header.html.erb" => "header_content"
+
+    view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
+    view.stub(:has_search_parameters?).and_return(true)
+    view.stub(:extra_head_content).and_return([])
+    view.stub(:render_opensearch_response_metadata).and_return("")
+    view.stub(:response_has_no_search_results?).and_return(true)
+    render
+    expect(rendered).to match /header_content/
+  end
 end


### PR DESCRIPTION
...d per page tools, etc) in a separate, overridable partial
