### PR TITLE
adjust space sharing between title and bookmarks checkbox on results

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -220,11 +220,6 @@ span.page a,span.page.current
 
 }
 
-.index_title {
-  float: left;
-  max-width: 414px; //col-md-7; figure out how to calculate this correctly?
-}
-
 .document-thumbnail {
   float: right;
   padding-left: 20px;

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -3,13 +3,13 @@
       <div class="documentHeader row">
         
         <%- # main title container for doc partial view -%>
-         <h5 class="index_title col-md-10 col-xs-12">
+         <h5 class="index_title col-sm-10">
          <% counter = document_counter_with_offset(document_counter) %>
          <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
          <%= link_to_document document, :label=>document_show_link_field(document), :counter => counter %>
         </h5>
 
         <% # bookmark functions for items/docs -%>
-        <%= render_index_doc_actions document, :wrapping_class => "documentFunctions col-md-2" %>
+        <%= render_index_doc_actions document, :wrapping_class => "documentFunctions col-sm-2" %>
       </div>
       


### PR DESCRIPTION
long titles on the results page were wrapping at 414px, which I couldn't think of a reason for, they should use the space they have before running into the bookmarks checkbox, no?

This change, they share space with the bookmarks checkbox purely via bootstrap fluid columns, all the way down to bootstrap -xs size (768px). They collapse to full width at 768 -- above that, they seem to do fine sharing space. 
