### PR TITLE
Add a route_set parameter to some of the link helpers.

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -447,11 +447,14 @@ module Blacklight::BlacklightHelperBehavior
     { :'data-counter' => counter, :'data-search_id' => current_search_session.try(:id) }
   end
 
-  # link_back_to_catalog(:label=>'Back to Search')
   # Create a link back to the index screen, keeping the user's facet, query and paging choices intact by using session.
+  # @example
+  #   link_back_to_catalog(label: 'Back to Search')
+  #   link_back_to_catalog(label: 'Back to Search', route_set: my_engine)
   def link_back_to_catalog(opts={:label=>nil})
+    scope = opts.delete(:route_set) || self
     query_params = current_search_session.try(:query_params) || {}
-    link_url = url_for(query_params)
+    link_url = scope.url_for(query_params)
     label = opts.delete(:label)
 
     if link_url =~ /bookmarks/

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -77,9 +77,12 @@ module Blacklight::FacetsHelperBehavior
   # first arg item is a facet value item from rsolr-ext.
   # options consist of:
   # :suppress_link => true # do not make it a link
+  # :route_set => my_engine # call link_to on engine routes.
   def render_facet_value(facet_solr_field, item, options ={})    
+    scope = options.delete(:route_set) || self
+    path = scope.url_for(add_facet_params_and_redirect(facet_solr_field, item).merge(only_path: true))
     content_tag(:span, :class => "facet-label") do
-      link_to_unless(options[:suppress_link], facet_display_value(facet_solr_field, item), add_facet_params_and_redirect(facet_solr_field, item), :class=>"facet_select")
+      link_to_unless(options[:suppress_link], facet_display_value(facet_solr_field, item), path, :class=>"facet_select")
     end + render_facet_count(item.hits)
   end
 

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -103,13 +103,11 @@ describe BlacklightHelper do
   end
 
   describe "link_back_to_catalog" do
-    before(:all) do
-      @query_params = {:q => "query", :f => "facets", :per_page => "10", :page => "2", :controller=>'catalog'}
-      @bookmarks_query_params = { :page => "2", :controller=>'bookmarks'}
-    end
+    let(:query_params)  {{:q => "query", :f => "facets", :per_page => "10", :page => "2", :controller=>'catalog'}}
+    let(:bookmarks_query_params) {{ :page => "2", :controller=>'bookmarks'}}
 
     it "should build a link tag to catalog using session[:search] for query params" do
-      helper.stub(:current_search_session).and_return double(:query_params => @query_params)
+      helper.stub(:current_search_session).and_return double(:query_params => query_params)
       tag = helper.link_back_to_catalog
       tag.should =~ /q=query/
       tag.should =~ /f=facets/
@@ -118,11 +116,26 @@ describe BlacklightHelper do
     end
 
     it "should build a link tag to bookmarks using session[:search] for query params" do
-      helper.stub(:current_search_session).and_return double(:query_params => @bookmarks_query_params)
+      helper.stub(:current_search_session).and_return double(:query_params => bookmarks_query_params)
       tag = helper.link_back_to_catalog
       tag.should =~ /Back to Bookmarks/
       tag.should =~ /\/bookmarks/
       tag.should =~ /page=2/
+    end
+
+    describe "when an alternate scope is passed in" do
+      let(:my_engine) { double("Engine") }
+
+      it "should call url_for on the engine scope" do
+        helper.stub(:current_search_session).and_return double(:query_params => query_params)
+        expect(my_engine).to receive(:url_for).and_return(url_for(query_params))
+        tag = helper.link_back_to_catalog(route_set: my_engine)
+        tag.should =~ /Back to Search/
+        tag.should =~ /q=query/
+        tag.should =~ /f=facets/
+        tag.should =~ /per_page=10/
+        tag.should =~ /page=2/
+      end
     end
   end
 

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -1,6 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
-require 'nokogiri'
 require 'equivalent-xml'
 
 describe FacetsHelper do
@@ -377,24 +376,37 @@ describe FacetsHelper do
   end
 
   describe "render_facet_value" do
-    it "should use facet_display_value" do
+    let (:item) { double(:value => 'A', :hits => 10) }
+    before do
       helper.stub(:facet_configuration_for_field).with('simple_field').and_return(double(:query => nil, :date => nil, :helper_method => nil, :single => false))
- 
       helper.should_receive(:facet_display_value).and_return('Z')
-      helper.should_receive(:add_facet_params_and_redirect).and_return('link')
-
-      expected  = Nokogiri::HTML "<span class=\"facet-label\"><a class=\"facet_select\" href=\"link\">Z</a></span><span class=\"facet-count\">10</span>"
-      rendered  = Nokogiri::HTML helper.render_facet_value('simple_field', double(:value => 'A', :hits => 10))
-
-      rendered.should be_equivalent_to(expected).respecting_element_order
+      helper.should_receive(:add_facet_params_and_redirect).and_return({controller:'catalog'})
+    end
+    describe "simple case" do
+      let(:expected_html) { "<span class=\"facet-label\"><a class=\"facet_select\" href=\"/\">Z</a></span><span class=\"facet-count\">10</span>" }
+      it "should use facet_display_value" do
+        result = helper.render_facet_value('simple_field', item)
+        expect(result).to be_equivalent_to(expected_html).respecting_element_order
+      end
     end
 
-    it "should suppress the link" do
-      helper.stub(:facet_configuration_for_field).with('simple_field').and_return(double(:query => nil, :date => nil, :helper_method => nil, :single => false))
- 
-      helper.should_receive(:facet_display_value).and_return('Z')
-      helper.should_receive(:add_facet_params_and_redirect).and_return('link')
-      helper.render_facet_value('simple_field', double(:value => 'A', :hits => 10), :suppress_link => true).should == "<span class=\"facet-label\">Z</span><span class=\"facet-count\">10</span>"
+    describe "when :suppress_link is set" do
+      let(:expected_html) { "<span class=\"facet-label\">Z</span><span class=\"facet-count\">10</span>" }
+      it "should suppress the link" do
+        result = helper.render_facet_value('simple_field', item, :suppress_link => true)
+        expect(result).to be_equivalent_to(expected_html).respecting_element_order
+      end
+    end
+
+    describe "when a route_set is passed" do
+      let(:my_engine) { double("Engine") }
+      let(:expected_html) { "<span class=\"facet-label\"><a class=\"facet_select\" href=\"/\">Z</a></span><span class=\"facet-count\">10</span>" }
+
+      it "should use the engine scope" do
+        expect(my_engine).to receive(:url_for).and_return({controller: 'catalog'})
+        result = helper.render_facet_value('simple_field', item, route_set: my_engine)
+        expect(result).to be_equivalent_to(expected_html).respecting_element_order
+      end
     end
   end
  


### PR DESCRIPTION
Thie enable blacklight to be used by another Rails engine, without
having to reimplement a number of the helpers. See
https://github.com/projecthydra/sufia/commit/9b495ae76e55aef505cb070fff0b325a31ace356
