### PR TITLE
Added 303 redirect to catalog update

### DIFF
--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -61,7 +61,7 @@ module Blacklight::Catalog
     # updates the search counter (allows the show view to paginate)
     def update
       search_session[:counter] = params[:counter]
-      redirect_to :action => "show"
+      redirect_to :action => "show", :status => 303
     end
     
     # displays values and pagination links for a single facet field

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -172,6 +172,11 @@ describe CatalogController do
       put :update, :id => doc_id, :counter => 3
       assert_redirected_to(catalog_path(doc_id))
     end
+
+    it "HTTP status code for redirect should be 303" do
+      put :update, :id => doc_id, :counter => 3
+      response.status.should == 303
+    end
   end
 
   # SHOW ACTION


### PR DESCRIPTION
OK, sorry about the formatting errors, this one looks good to go.

Added 303 redirect to catalog#update to override default link_to status (302).. hopefully to improve SEO even a little bit -- per the spec here: http://tools.ietf.org/html/rfc2616#section-10.3.4. Test passing.

Last one, hopefully :)
