### PR TITLE
When removing 'no-js', also add a 'js' class.

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -50,4 +50,4 @@
         };
 */
 
-$('.no-js').removeClass('no-js')
+$('.no-js').removeClass('no-js').addClass('js');


### PR DESCRIPTION
Adding the 'js' class is demo'd in the originator of the no-js
thing at http://www.paulirish.com/2009/avoiding-the-fouc-v3/
and commonly used in other places that do the no-js dance. It
can come in handy.
