### PR TITLE
rescue ActiveRecord::RecordNotFound, not everything

### DIFF
--- a/lib/blacklight/catalog/search_context.rb
+++ b/lib/blacklight/catalog/search_context.rb
@@ -31,10 +31,18 @@ module Blacklight::Catalog::SearchContext
     elsif params[:search_context].present?
       find_or_initialize_search_session_from_params JSON.load(params[:search_context])
     elsif params[:search_id].present?
-      # TODO : check the search id signature.
-      searches_from_history.find(params[:search_id]) rescue nil
+      begin
+        # TODO : check the search id signature.      
+        searches_from_history.find(params[:search_id])
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
     elsif search_session[:id]
-      searches_from_history.find(search_session[:id]) rescue nil
+      begin
+        searches_from_history.find(search_session[:id])
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
     end
 
     search_session[:id] = @current_search_session.id if @current_search_session


### PR DESCRIPTION
The one-line rescue found here ends up rescueing all exceptions. I think that was making troubleshooting of #646 a lot harder. It seems probably seldom appropriate to rescue all exceptions (which means the one-line rescue is probably seldom appropriate, sadly).

I think this was meant to mainly rescue `ActiveRecord::RecordNotFound`  -- if there's a search id in params or session that can't be found in the database, don't complain, just say no search context found. 

So I changed it to do so in this pull request. 

One reason I PR'd this for code review instead of just commiting it is -- I have not changed or added any tests. There did not seem to be any existing tests that touched this func at all (removing the rescue altogether didn't seem to make any tests fail, neither does this PR).   It seems like tests might be a good idea -- but I'm having trouble figuring out how to do appropriate tests. 

So I guess I'm asking for help,  either someone else saying "Yeah, tests would be nice but it's okay to commit this without them," or someone else helping with the tests, by writing some or giving me some guidance. Thanks!
