### PR TITLE
Improve the single result message (English only).

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -25,10 +25,7 @@ module Blacklight::CatalogHelperBehavior
   #
   # Pass in an RSolr::Response. Displays the "showing X through Y of N" message.
   def render_pagination_info(response, options = {})
-   # TODO: i18n the entry_name
-      entry_name = options[:entry_name]
-      entry_name ||= response.docs.first.class.name.underscore.sub('_', ' ') unless response.docs.empty?
-      entry_name ||= t('blacklight.entry_name.default')
+      entry_name = options[:entry_name] || t('blacklight.entry_name.default')
 
 
       end_num = if render_grouped_response?

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -183,7 +183,7 @@ en:
         title: 'Results navigation'
       pagination_info:
         no_items_found: 'No %{entry_name} found'
-        single_item_found: '<strong>1</strong> to <strong>1</strong> of <strong>1</strong>'
+        single_item_found: '<strong>1</strong> %{entry_name} found'
         pages:
           one: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong> of <strong>%{total_num}</strong>'
           other: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong> of <strong>%{total_num}</strong>'

--- a/spec/features/did_you_mean_spec.rb
+++ b/spec/features/did_you_mean_spec.rb
@@ -26,7 +26,7 @@ describe "Did You Mean" do
       expect(page).to have_content("Did you mean")
       click_link 'yehudiyim'
       within ("#sortAndPerPage") do
-        expect(page).to have_content "1 to 1 of 1"
+        expect(page).to have_content "1 entry found"
       end
       within ("select#search_field") do
         expect(page).to have_selector("option[selected]", text: "Title")
@@ -44,7 +44,7 @@ describe "Did You Mean" do
       expect(page).to have_content("Did you mean")
       click_link 'sharma'
       within ("#sortAndPerPage") do
-        expect(page).to have_content "1 to 1 of 1"
+        expect(page).to have_content "1 entry found"
       end
       within ("select#search_field") do
         expect(page).to have_selector("option[selected]", text: "Author")
@@ -91,7 +91,7 @@ describe "Did You Mean" do
       
       click_link 'bon'
       within ("#sortAndPerPage") do
-        expect(page).to have_content "1 to 1 of 1"
+        expect(page).to have_content "1 entry found"
       end
     end
     

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -58,7 +58,7 @@ describe "Facets" do
     click_link "2004"
 
     within ("#sortAndPerPage") do
-      expect(page).to have_content "1 to 1 of 1"
+      expect(page).to have_content "1 entry found"
     end
     within "#facet-language" do
       expect(page).to have_selector("span.selected", :text => "Tibetan")

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -80,7 +80,7 @@ describe "Search Page" do
       expect(page).to have_content "1."
     end
     within ("#sortAndPerPage") do
-      expect(page).to have_content "1 to 1 of 1"
+      expect(page).to have_content "1 entry found"
     end
   end
 


### PR DESCRIPTION
The previous message "1 to 1 of 1" was needlessly confusing.  It is now:
 "1 entry found"

Additionally, fixed the render_pagination_info helper so that it didn't
use the humanized class as the default 'entry_name'.  That approach
resulted in "1 active support/hash_with_indifferent_access found"
