### PR TITLE
padding on show_tools bookmarks

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -92,6 +92,14 @@ span.constraints-label {
   }
 } 
 
+// Tools link on documetn show page
+.show-tools {
+  .bookmark_toggle {
+    padding: $nav-link-padding;
+  }
+}
+
+
 #sidebar form {
   margin: 0;
 }

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -7,7 +7,7 @@
   # functions by default only on detail.
 
 -%>
-<div class="panel panel-default">
+<div class="panel panel-default show-tools">
   <div class="panel-heading">
     <%= t('blacklight.tools.title') %>
   </div>


### PR DESCRIPTION
Make it line up with other items in panel horizontally,
as well as have consistent vertical padding
