### PR TITLE
line-height for constraints

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -1,8 +1,3 @@
-.catalog_startOverLink {
-  @extend .pull-right;
-  padding: $padding-base-vertical $padding-base-horizontal ;
-}
-
 .ajax_form
 {
   margin-bottom: 0;
@@ -43,8 +38,14 @@
   }
 }
 
+.catalog_startOverLink {
+  @extend .pull-right;
+}
+
 .constraints-container {
   @extend .well;
+  line-height: 2.5;
+  padding: 16px 19px;
 }
 
 span.constraints-label {


### PR DESCRIPTION
When contraints wrap to two lines, they needed more space. 

![constraints-vertical-collision](https://f.cloud.github.com/assets/149304/1860849/9cc4eb92-77b9-11e3-8127-84144a7531e1.png)

Fixed by increasing line-height of the .constraints-container, then had to adjust padding on other elements to leave spacing the same. 

![vertical-collision-fixed](https://f.cloud.github.com/assets/149304/1860854/a34be5e2-77b9-11e3-9ab9-bdf9c33b594f.png)

(I'm also trying to figure out a solution to when the screen is so narrow and one individual constraint so lengthy that it goes off screen, but that's proving very tricky, so will do it as a separate PR, if at all)
