### PR TITLE
add clearfix to #previousNextDoc, for small screens

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -158,6 +158,7 @@ label.toggle_bookmark
 }
 
 #previousNextDocument {
+  @extend .clearfix;
   padding-top: 1px;
   padding-bottom: $padding-base-vertical;
 }


### PR DESCRIPTION
On very small screens, on the Catalog#show, the floated "back to search"/"start over" escape their bounding box, and wind up below the bottom border, and too close to the next line:

![prev-next-doc-overflow](https://f.cloud.github.com/assets/149304/1879688/c339f37c-794d-11e3-9b44-05f811eb0ff0.png)

Fixed simply by adding the .clearfix to the #previousNextDocument div:

![prev-next-doc-clearfixed](https://f.cloud.github.com/assets/149304/1879692/cf53f5ae-794d-11e3-829c-5e5ec20d0333.png)

Arguably, additional tweaks should be done, to keep these from being floated right on small screens, or even to hide them entirey on small screens (?), I'm not really sure, and the clearfix seems a good idea regardless, I think?
