### PR TITLE
simple schema.org support

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -189,7 +189,7 @@ module Blacklight::BlacklightHelperBehavior
 
     tag ||= :h4
 
-    content_tag(tag, render_field_value(document_heading(document)))
+    content_tag(tag, render_field_value(document_heading(document)), :itemprop => "name")
   end
 
   # Used in the show view for setting the main html document title
@@ -316,6 +316,11 @@ module Blacklight::BlacklightHelperBehavior
 
   def render_field_value value=nil, field_config=nil
     safe_values = Array(value).collect { |x| x.respond_to?(:force_encoding) ? x.force_encoding("UTF-8") : x }
+
+    if field_config and field_config.itemprop
+      safe_values = safe_values.map { |x| content_tag :span, x, :itemprop => field_config.itemprop }
+    end
+
     safe_join(safe_values, (field_config.separator if field_config) || field_value_separator)
   end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,4 @@
-    <% # container for a single doc -%>
-    <div class="document <%= render_document_class document %>">
-      <%= render_document_partials document, blacklight_config.index.partials, :document_counter => document_counter %>
-    </div>
+<% # container for a single doc -%>
+<div class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
+  <%= render_document_partials document, blacklight_config.index.partials, :document_counter => document_counter %>
+</div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,9 +5,9 @@
    
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name) -%>
 <% content_for(:head) { render_link_rel_alternates } -%>
-
 <%# this should be in a partial -%>
-<div id="document" class="document <%= render_document_class %>">
+
+<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
   <div id="doc_<%= @document.id.to_s.parameterize %>">
   
     <% # bookmark/folder functions -%>

--- a/lib/blacklight/solr/document.rb
+++ b/lib/blacklight/solr/document.rb
@@ -16,6 +16,7 @@ require 'rsolr'
 #
 
 module Blacklight::Solr::Document
+  autoload :SchemaOrg, 'blacklight/solr/document/schema_org'
   autoload :DublinCore, 'blacklight/solr/document/dublin_core'
   autoload :Email, 'blacklight/solr/document/email'
   autoload :Sms, 'blacklight/solr/document/sms'
@@ -24,6 +25,7 @@ module Blacklight::Solr::Document
   autoload :MoreLikeThis, 'blacklight/solr/document/more_like_this'
 
   extend ActiveSupport::Concern
+  include Blacklight::Solr::Document::SchemaOrg
   include Blacklight::Solr::Document::Export
   include Blacklight::Solr::Document::MoreLikeThis
 

--- a/lib/blacklight/solr/document/schema_org.rb
+++ b/lib/blacklight/solr/document/schema_org.rb
@@ -1,0 +1,7 @@
+module Blacklight::Solr::Document::SchemaOrg
+
+  def itemtype
+    "http://schema.org/Thing"
+  end
+
+end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -292,13 +292,20 @@ describe BlacklightHelper do
       @document = SolrDocument.new('title_display' => "A Fake Document")
 
       render_document_heading.should have_selector("h4", :text => "A Fake Document", :count => 1)
-      render_document_heading.html_safe?.should == true
+      expect(render_document_heading).to be_html_safe
      end
+
+     it "should have a schema.org itemprop for name" do
+      @document = SolrDocument.new('title_display' => "A Fake Document")
+
+      render_document_heading.should have_selector("h4[@itemprop='name']", :text => "A Fake Document")
+     end
+
      it "should join the values if it is an array" do
       @document = SolrDocument.new('title_display' => ["A Fake Document", 'Something Else'])
 
       render_document_heading.should have_selector("h4", :text => "A Fake Document, Something Else", :count => 1)
-      render_document_heading.html_safe?.should == true
+      expect(render_document_heading).to be_html_safe
      end
    end
 
@@ -718,7 +725,11 @@ describe BlacklightHelper do
     end
 
     it "should use the separator from the Blacklight field configuration by default" do
-      expect(helper.render_field_value(['c', 'd'], double(:separator => '; '))).to eq "c; d"
+      expect(helper.render_field_value(['c', 'd'], double(:separator => '; ', :itemprop => nil))).to eq "c; d"
+    end
+
+    it "should include schema.org itemprop attributes" do
+      expect(helper.render_field_value('a', double(:separator => nil, :itemprop => 'some-prop'))).to have_selector("span[@itemprop='some-prop']", :text => "a") 
     end
   end
 end

--- a/spec/views/catalog/_document.html.erb_spec.rb
+++ b/spec/views/catalog/_document.html.erb_spec.rb
@@ -19,6 +19,8 @@ describe "catalog/_document" do
     expect(rendered).to match /document_header/
     expect(rendered).to match /thumbnail_default/
     expect(rendered).to match /index_default/
+    expect(rendered).to have_selector('div.document[@itemscope]')
+    expect(rendered).to have_selector('div.document[@itemtype="http://schema.org/Thing"]')
   end
 
 

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "catalog/show.html.erb" do
+
+  let :document do
+    SolrDocument.new :id => 'xyz', :format => 'a'
+  end
+
+  let :blacklight_config do
+    Blacklight::Configuration.new
+  end
+
+  before :each do
+    view.stub(:has_user_authentication_provider? => false)
+    view.stub(:render_document_sidebar_partial => "Sidebar")
+  end
+
+  it "should include schema.org itemscope/type properties" do
+    view.stub(:document_show_html_title).and_return("Heading")
+    document.stub(:itemtype => 'some-item-type-uri')
+    assign :document, document
+    view.stub(:blacklight_config).and_return(blacklight_config)
+    render
+
+    expect(rendered).to have_selector('div#document[@itemscope]')
+    expect(rendered).to have_selector('div#document[@itemtype="some-item-type-uri"]')
+  end
+end


### PR DESCRIPTION
e.g.

```
    config.add_index_field 'author_display', :label => 'Author:', :itemprop => 'author' 
```

```
class SolrDocument
  ...
  def itemtype
     first("my_schema_org_type_field") || "http://schema.org/CreativeWork"
  end
end
```

@awead? @jkeck? @jronallo? 

This doesn't support any of the advanced schema.org features (see http://schema.org/docs/gs.html#advanced). I think we could tackle 3a. Not sure about the others. I'd propose we merge this without support for those features, but happy to hear otherwise.
