### PR TITLE
page_entries_info uses number format helper for total too

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -57,7 +57,7 @@ module Blacklight::CatalogHelperBehavior
     case collection.total_count
       when 0; t('blacklight.search.pagination_info.no_items_found', :entry_name => entry_name ).html_safe
       when 1; t('blacklight.search.pagination_info.single_item_found', :entry_name => entry_name).html_safe
-      else; t('blacklight.search.pagination_info.pages', :entry_name => entry_name, :current_page => collection.current_page, :num_pages => collection.total_pages, :start_num => format_num(collection.offset_value + 1) , :end_num => end_num, :total_num => collection.total_count, :count => collection.total_pages).html_safe
+      else; t('blacklight.search.pagination_info.pages', :entry_name => entry_name, :current_page => collection.current_page, :num_pages => collection.total_pages, :start_num => format_num(collection.offset_value + 1) , :end_num => end_num, :total_num => format_num(collection.total_count), :count => collection.total_pages).html_safe
     end
   end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -109,6 +109,13 @@ describe CatalogHelper do
       html.html_safe?.should == true
     end
 
+    it "uses delimiters with large numbers" do
+      @response = mock_response :total => 5000, :rows => 10, :current_page => 101
+      html = page_entries_info(@response, { :entry_name => 'entry_name' })
+
+      html.should == "<strong>1,001</strong> - <strong>1,010</strong> of <strong>5,000</strong>"
+    end
+
   end
 
   describe "should_autofocus_on_search_box?" do


### PR DESCRIPTION
before, eg;
- 1-10 of 2257
- 1,991 - 2,000 of 2257

after, eg:
- 1-10 of 2,227
- 1,991 - 2,000 of 2,257

it already was using rails helper to put commas in start/end, just not in total, I made consistent by doing same with total (total is actually the one most likely to need it, as you seldom page past 1000 items!)

There were no tests for adding delimiters to any of em, even though it did to some of them, now added for all of them. 
