### PR TITLE
index bookmark checkbox, purely bootstrap grids

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -82,21 +82,21 @@ span.constraints-label {
     padding-top: $padding-base-vertical;
     border-bottom:1px dotted $table-border-color;
   }
-
-  .documentFunctions {
-    @extend .pull-right;
-
-    .bookmark_toggle
-    {
-      display:inline;
-    }
-  }
 } 
 
 // Tools link on documetn show page
 .show-tools {
   .bookmark_toggle {
     padding: $nav-link-padding;
+  }
+}
+
+// bookmarks checkbox on index, give it some
+// lower margin when it collapses
+.index-document-functions {
+  margin-bottom: ($line-height-computed / 2);
+  @media (min-width: $screen-sm-min) {
+    margin-bottom: 0;
   }
 }
 
@@ -180,10 +180,6 @@ label.toggle_bookmark
     float: none;
   }
 
-}
-
-.index_title {
-  float: left;
 }
 
 .document-thumbnail {

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -72,7 +72,7 @@ module Blacklight::BlacklightHelperBehavior
   # Save function area for search results 'index' view, normally
   # renders next to title.
   def render_index_doc_actions(document, options={})
-    wrapping_class = options.delete(:wrapping_class) || "documentFunctions"
+    wrapping_class = options.delete(:wrapping_class) || "index-document-functions"
 
     content = []
     content << render(:partial => 'catalog/bookmark_control', :locals => {:document=> document}.merge(options)) if render_bookmarks_control?

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -2,14 +2,17 @@
       <% # header bar for doc items in index view -%>
       <div class="documentHeader row">
         
-        <%- # main title container for doc partial view -%>
-         <h5 class="index_title col-sm-10">
+        <%# main title container for doc partial view 
+            How many bootstrap columns need to be reserved
+            for bookmarks control depends on size. 
+        -%>
+         <h5 class="index_title col-sm-9 col-lg-10">
          <% counter = document_counter_with_offset(document_counter) %>
          <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
          <%= link_to_document document, :label=>document_show_link_field(document), :counter => counter %>
         </h5>
 
         <% # bookmark functions for items/docs -%>
-        <%= render_index_doc_actions document, :wrapping_class => "documentFunctions col-sm-2" %>
+        <%= render_index_doc_actions document, :wrapping_class => "index-document-functions col-sm-3 col-lg-2" %>
       </div>
       


### PR DESCRIPTION
I was still having trouble with the 'bookmark' checkbox alignment, esp on small screens. 

![bookmarks-search-results-weird-collapse](https://f.cloud.github.com/assets/149304/1921957/789e9d60-7e00-11e3-832d-6044c982056d.png)

To fix and make it easier to deal with, I tried to stick closer to bootstrap -- removed all the floats involved, and now just plain using the standard bootstrap grid feature. 

Adjusted number of bootstrap columns to leave enough room for bookmarks checkbox and label (including longer 'In Bookmarks' label) at each size. 

Provided lower margin on collapse, to leave enough spacing between bookmark control and following. 

The class `documentFunctions` was being used on the 'show tools' as well as this bookmarks checkbox, pretty different elements in terms of layout, making it hard to style appropriately. For the index page 'bookmarks' use, changed to class `index-document-functions`. 

medium sized viewport:

![bookmark-fixed-not-collapsed](https://f.cloud.github.com/assets/149304/1921994/f3fb67d6-7e00-11e3-9657-085ba947fdfd.png)

collapsed small viewport:

![bookmark-fixed-collapsed](https://f.cloud.github.com/assets/149304/1921999/f9516190-7e00-11e3-812c-f1985b50e0ce.png)
