### PR TITLE
update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 ##########################################################################
-# Copyright 2008 Rector and Visitors of the University of Virginia
+# Copyright 2008-2014 Rector and Visitors of the University of Virginia, The Board of Trustees of the Leland Stanford Junior University, Johns Hopkins Universities, and Data Curation Experts
+# Additional copyright may be held by others, as reflected in the commit log
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The legal minds behind Hydra say this about copyright statements:

```
The copyright statement should start with the date and name of the originating author(s)–institutional or individual, as appropriate
If and when additional contributions are made beyond the original IP holders, the contributors may elect to append an additional copyright statement
contain this text string:  "Additional copyright may be held by others, as reflected in the commit history."
This will recognize the first committer(s), any subsequent committers, and indicate that additional contributors may hold partial copyright to contributions. 
For example, for code originally contributed by Stanford and then enhanced by Penn State & DCE, the copyright statement might read: 
    Copyright 2012 Stanford University
    Copyright 2013 Penn State University 
    Copyright 2013 DCE 
    Additional copyright may be held by others, as reflected in the commit history. 
```

I've updated the Blacklight LICENSE file to reflect this for the "top 5" committers institutions. If anyone else wants their institution reflected in the statement (instead of the catch-all "in the commit log"), feel free to tack it onto the pull request. 
