### PR TITLE
'Start Over' links should preserve the current view type across search sessions

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -355,12 +355,16 @@ module Blacklight::BlacklightHelperBehavior
     ', '
   end
 
-  def document_index_view_type
-    if blacklight_config.document_index_view_types.include? params[:view]
-      params[:view]
+  def document_index_view_type query_params=params
+    if blacklight_config.document_index_view_types.include? query_params[:view]
+      query_params[:view]
     else
-      blacklight_config.document_index_view_types.first
+      default_document_index_view_type
     end
+  end
+
+  def default_document_index_view_type
+    blacklight_config.document_index_view_types.first
   end
 
   def render_document_index documents = nil, locals = {}
@@ -455,6 +459,17 @@ module Blacklight::BlacklightHelperBehavior
     p[:q]=query
     link_url = catalog_index_path(p)
     link_to(query, link_url)
+  end
+
+  ##
+  # Get the path to the search action with any parameters (e.g. view type)
+  # that should be persisted across search sessions.
+  def start_over_path query_params = params
+    h = { }
+    current_index_view_type = document_index_view_type(query_params)
+    h[:view] = current_index_view_type unless current_index_view_type == default_document_index_view_type
+
+    search_action_url(h)
   end
 
   def render_document_index_label doc, opts

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -2,7 +2,7 @@
 
       <div id="appliedParams" class="clearfix constraints-container">
         <div class="pull-right">
-          <%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :class => "catalog_startOverLink btn btn-sm btn-text", :id=>"startOverLink" %>
+          <%=link_to t('blacklight.search.start_over'), start_over_path, :class => "catalog_startOverLink btn btn-sm btn-text", :id=>"startOverLink" %>
         </div>
         <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
         <%= render_constraints(params) %>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -12,7 +12,7 @@
     <div class="pull-right search-widgets">
         <%= link_back_to_catalog :class => 'btn' %>
         
-        <%=link_to "#{t('blacklight.search.start_over')}", catalog_index_path, :id=>"startOverLink", :class => 'btn' %>
+        <%=link_to "#{t('blacklight.search.start_over')}", start_over_path(current_search_session.try(:query_params) || {}), :id=>"startOverLink", :class => 'btn' %>
   	</div>
   </div>
 <% end %>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -327,6 +327,26 @@ describe BlacklightHelper do
        params[:view] = 'not_in_list'
        expect(document_index_view_type).to eq 'list'
      end
+
+     it "should pluck values from supplied params" do
+       blacklight_config.stub(:document_index_view_types) { ['list', 'asdf'] }
+       params[:view] = 'asdf'
+       expect(document_index_view_type(:view => 'list')).to eq 'list'
+     end
+   end
+
+   describe "start_over_path" do
+    it 'should be the catalog path with the current view type' do
+      blacklight_config.stub(:document_index_view_types) { ['list', 'abc'] }
+      helper.stub(:blacklight_config => blacklight_config)
+      expect(helper.start_over_path(:view => 'abc')).to eq catalog_index_url(:view => 'abc')
+    end
+
+    it 'should not include the current view type if it is the default' do
+      blacklight_config.stub(:document_index_view_types) { ['list', 'abc'] }
+      helper.stub(:blacklight_config => blacklight_config)
+      expect(helper.start_over_path(:view => 'list')).to eq catalog_index_url
+    end
    end
 
    describe "render_document_index" do

--- a/spec/views/catalog/_constraints.html.erb_spec.rb
+++ b/spec/views/catalog/_constraints.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "catalog/constraints" do
+  let :blacklight_config do
+    Blacklight::Configuration.new :document_index_view_types => ['list', 'xyz']
+  end
+
+  it "should render nothing if no constraints are set" do
+    view.stub(query_has_constraints?: false)
+    render partial: "catalog/constraints"
+    expect(rendered).to be_empty
+  end
+
+  it "should render a start over link" do
+    view.should_receive(:search_action_url).with({}).and_return('http://xyz')
+    view.stub(query_has_constraints?: true)
+    view.stub(:blacklight_config).and_return(blacklight_config)
+    render partial: "catalog/constraints"
+    expect(rendered).to have_selector("#startOverLink")
+    expect(rendered).to have_link("Start Over", :href => 'http://xyz')
+  end
+
+  it "should render a start over link with the current view type" do
+    view.should_receive(:search_action_url).with(view: 'xyz').and_return('http://xyz?view=xyz')
+    view.stub(query_has_constraints?: true)
+    params[:view] = 'xyz'
+    view.stub(:blacklight_config).and_return(blacklight_config)
+    render partial: "catalog/constraints"
+    expect(rendered).to have_selector("#startOverLink")
+    expect(rendered).to have_link("Start Over", :href => 'http://xyz?view=xyz')
+  end
+
+end


### PR DESCRIPTION
Fixes #714
