### PR TITLE
Add 'collapse' to facet configuration to control whether a facet should be collapsed (default) or displayed by default

### DIFF
--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -46,6 +46,14 @@ module Blacklight::FacetsHelperBehavior
     return display && display_facet.items.present?
   end
 
+  ##
+  # if the facet is 'active', don't collapse
+  # if the facet is configured to collapse (the default), collapse
+  # if the facet is configured not to collapse, don't collapse
+  def should_collapse_facet? facet_field
+    !facet_field_in_params?(facet_field.field) && facet_field.collapse
+  end
+
   # the name of the partial to use to render a facet field. Can be over-ridden for custom
   # display on a per-facet basis. 
   def facet_partial_name(display_facet = nil)

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,10 +1,10 @@
 <div class="panel panel-default facet_limit blacklight-<%= facet_field.field.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.field) %>">
-  <div class="<%= "collapsed" unless facet_field_in_params?(facet_field.field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#facet-<%= facet_field.label.parameterize %>">
+  <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#facet-<%= facet_field.label.parameterize %>">
     <h5 class="panel-title">
       <%= link_to facet_field.label, "#", :"data-no-turbolink" => true %>
     </h5>
   </div>
-  <div id="facet-<%= facet_field.label.parameterize %>" class="panel-collapse facet-content <%=  facet_field_in_params?(facet_field.field) ? 'in' : 'collapse' %>">
+  <div id="facet-<%= facet_field.label.parameterize %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'in' %>">
     <div class="panel-body">
       <%= yield %>
     </div>

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -7,6 +7,9 @@ module Blacklight
         self.tag = "#{self.field}_single"
         self.ex = "#{self.field}_single"
       end
+
+      self.collapse = true if self.collapse.nil?
+
       super
     end
   end

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -53,6 +53,32 @@ describe FacetsHelper do
     end
   end
 
+  describe "should_collapse_facet?" do
+    before do
+      @config = Blacklight::Configuration.new do |config|
+        config.add_facet_field 'basic_field'
+        config.add_facet_field 'no_collapse', collapse: false
+      end
+
+      helper.stub(blacklight_config: @config)
+    end
+
+    it "should be collapsed by default" do
+      expect(helper.should_collapse_facet?(@config.facet_fields['basic_field'])).to be_true
+    end
+
+    it "should not be collapsed if the configuration says so" do
+      expect(helper.should_collapse_facet?(@config.facet_fields['no_collapse'])).to be_false
+    end
+
+    it "should not be collapsed if it is in the params" do
+      params[:f] = { basic_field: [1], no_collapse: [2] }.with_indifferent_access
+      expect(helper.should_collapse_facet?(@config.facet_fields['basic_field'])).to be_false
+      expect(helper.should_collapse_facet?(@config.facet_fields['no_collapse'])).to be_false
+    end
+
+  end
+
   describe "facet_by_field_name" do
     it "should retrieve the facet from the response given a string" do
       facet_config = double(:query => nil)

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe "catalog/facet_layout" do
+
+  let :blacklight_config do
+    Blacklight::Configuration.new
+  end
+
+  let :facet_field do
+    Blacklight::Configuration::FacetField.new(field: 'some_field').normalize!
+  end
+
+  before do
+    view.stub(blacklight_config: blacklight_config)
+  end
+
+  it "should have a facet-specific class" do
+    render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
+    expect(rendered).to have_selector '.blacklight-some_field' 
+  end
+
+  it "should have a title with a link for a11y" do
+    render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
+    expect(rendered).to have_selector 'h5 a', text: 'Some Field'
+  end
+
+  it "should be collapsable" do
+    render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
+    expect(rendered).to have_selector '.panel-heading.collapsed'
+    expect(rendered).to have_selector '.collapse .panel-body'
+  end
+
+  it "should be configured to be open by default" do
+    facet_field.stub(collapse: false)
+    render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
+    expect(rendered).to_not have_selector '.panel-heading.collapsed'
+    expect(rendered).to have_selector '.in .panel-body'
+
+  end
+
+
+end


### PR DESCRIPTION
e.g.

``` ruby
config.add_facet_field 'some_field', collapse: false
config.add_facet_field 'some_field', collapse: true
config.add_facet_field 'some_field' # defaults to collapsed
```

Fixes #705
