### PR TITLE
Move blacklight_solr into SolrHelper

### DIFF
--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -1,7 +1,6 @@
 # -*- encoding : utf-8 -*-
 require 'kaminari'
 require 'rsolr'
-
 module Blacklight
 
   autoload :Configurable, 'blacklight/configurable'

--- a/lib/blacklight/base.rb
+++ b/lib/blacklight/base.rb
@@ -39,12 +39,4 @@ module Blacklight::Base
       redirect_to root_path
     end
   end
-
-  def blacklight_solr
-    @solr ||=  RSolr.connect(blacklight_solr_config)
-  end
-
-  def blacklight_solr_config
-    Blacklight.solr_config
-  end
 end

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -242,12 +242,4 @@ module Blacklight::Catalog
     def start_new_search_session?
       action_name == "index"
     end
-
-    def blacklight_solr
-      @solr ||=  RSolr.connect(blacklight_solr_config)
-    end
-
-    def blacklight_solr_config
-      Blacklight.solr_config
-    end
 end

--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -616,4 +616,11 @@ module Blacklight::SolrHelper
     blacklight_config.index.group
   end
 
+  def blacklight_solr
+    @solr ||=  RSolr.connect(blacklight_solr_config)
+  end
+
+  def blacklight_solr_config
+    Blacklight.solr_config
+  end
 end

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -26,10 +26,6 @@ describe 'Blacklight::SolrHelper' do
     @config = config
   end
 
-  def blacklight_solr
-    Blacklight.solr
-  end
-
   include Blacklight::SolrHelper
 
   before(:each) do
@@ -562,7 +558,7 @@ describe 'Blacklight::SolrHelper' do
 
       it "should use the configured request handler " do
         blacklight_config.stub(:default_solr_params).and_return({:qt => 'custom_request_handler'})
-        Blacklight.solr.should_receive(:send_and_receive) do |path, params|
+        blacklight_solr.should_receive(:send_and_receive) do |path, params|
           expect(path).to eq 'select'
           expect(params[:params][:'facet.field']).to eq ["format", "{!ex=pub_date_single}pub_date", "subject_topic_facet", "language_facet", "lc_1letter_facet", "subject_geo_facet", "subject_era_facet"]
           expect(params[:params][:"facet.query"]).to eq ["pub_date:[#{5.years.ago.year} TO *]", "pub_date:[#{10.years.ago.year} TO *]", "pub_date:[#{25.years.ago.year} TO *]"]
@@ -856,7 +852,7 @@ describe 'Blacklight::SolrHelper' do
 
     it "should use a provided document request handler " do
       blacklight_config.stub(:document_solr_request_handler => 'document')
-      Blacklight.solr.should_receive(:get).with('select', kind_of(Hash)).and_return({'response'=>{'docs'=>[]}})
+      blacklight_solr.should_receive(:get).with('select', kind_of(Hash)).and_return({'response'=>{'docs'=>[]}})
       expect { get_solr_response_for_doc_id(@doc_id)}.to raise_error Blacklight::Exceptions::InvalidSolrID
     end
 
@@ -1086,7 +1082,7 @@ describe 'Blacklight::SolrHelper' do
 #  more like this
 #  nearby on shelf
   it "should raise a Blacklight exception if RSolr can't connect to the Solr instance" do
-    Blacklight.solr.stub(:get).and_raise(Errno::ECONNREFUSED)
+    blacklight_solr.stub(:get).and_raise(Errno::ECONNREFUSED)
     expect { find(:a => 123) }.to raise_exception(/Unable to connect to Solr instance/)
   end
 
@@ -1152,7 +1148,7 @@ describe 'Blacklight::SolrHelper' do
 
       it "defaults to get" do
         expect(blacklight_config.http_method).to eq :get
-        Blacklight.solr.should_receive(:send_and_receive) do |path, params|
+        blacklight_solr.should_receive(:send_and_receive) do |path, params|
           expect(path).to eq 'select'
           expect(params[:method]).to eq :get
           expect(params[:params]).to include(:q)
@@ -1166,7 +1162,7 @@ describe 'Blacklight::SolrHelper' do
 
       it "keep value set to post" do
         expect(blacklight_config.http_method).to eq :post
-        Blacklight.solr.should_receive(:send_and_receive) do |path, params|
+        blacklight_solr.should_receive(:send_and_receive) do |path, params|
           expect(path).to eq 'select'
           expect(params[:method]).to eq :post
           expect(params[:data]).to include(:q)

--- a/spec/views/catalog/_paginate_compact.html.erb_spec.rb
+++ b/spec/views/catalog/_paginate_compact.html.erb_spec.rb
@@ -11,10 +11,6 @@ describe "catalog/_paginate_compact.html.erb" do
       @config = config
     end
 
-    def blacklight_solr
-      Blacklight.solr
-    end
-
     def facet_limit_for *args
       0
     end


### PR DESCRIPTION
so that you can use SolrHelper as a stand-alone module and you only need provide blacklight_config
