### PR TITLE
Deprecate Blacklight.solr

### DIFF
--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -30,6 +30,7 @@ module Blacklight
   autoload :Facet, 'blacklight/facet'
 
   extend SearchFields
+  extend Deprecation
   
   require 'blacklight/version'
   require 'blacklight/engine' if defined?(Rails)
@@ -52,6 +53,7 @@ module Blacklight
   end
 
   def self.solr
+    Deprecation.warn Blacklight, "Blacklight.solr is deprecated and will be removed in Blacklight 5.0"
     @solr ||=  RSolr.connect(Blacklight.solr_config)
   end
 


### PR DESCRIPTION
Blacklight.solr works well if there is a single static solr server, but we may want to support a per-request connection, so that certain types of requests use different connections.
