### PR TITLE
Add blacklight configuration for registering additional response formats...

### DIFF
--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -27,10 +27,29 @@ module Blacklight::Catalog
         format.html { }
         format.rss  { render :layout => false }
         format.atom { render :layout => false }
-
-        
         format.json do
           render json: render_search_results_as_json
+        end
+
+        additional_response_formats(format)
+      end
+    end
+
+    def additional_response_formats format
+      blacklight_config.index.respond_to.each do |key, config|
+        format.send key do
+          case config
+          when false
+            raise ActionController::RoutingError.new('Not Found')
+          when Hash
+            render config
+          when Proc
+            instance_exec &config
+          when Symbol, String
+            send config
+          else
+            # no-op, just render the page
+          end
         end
       end
     end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -20,7 +20,12 @@ module Blacklight
           :document_solr_request_handler => nil,
           :default_document_solr_params => {},
           :show => ViewConfig::Show.new(:partials => [:show_header, :show]),
-          :index => ViewConfig::Index.new(:partials => [:index_header, :thumbnail, :index], :title_field => unique_key, :display_type_field => 'format', :group => false),
+          :index => ViewConfig::Index.new(:partials => [:index_header, :thumbnail, :index],
+            :title_field => unique_key,
+            :display_type_field => 'format',
+            :group => false,
+            :respond_to => OpenStructWithHashAccess.new()
+            ),
           :view => NestedOpenStructWithHashAccess.new(ViewConfig, 'list'),
           :spell_max => 5,
           :max_per_page => 100,

--- a/spec/lib/blacklight/configuration_spec.rb
+++ b/spec/lib/blacklight/configuration_spec.rb
@@ -55,6 +55,18 @@ describe "Blacklight::Configuration" do
     end
   end
 
+  describe "config.index.respond_to" do
+    it "should have a list of additional formats for index requests to respond to" do
+      @config.index.respond_to.xml = true
+
+      @config.index.respond_to.csv = { :layout => false }
+
+      @config.index.respond_to.yaml = lambda { render text: "" }
+
+      expect(@config.index.respond_to.keys).to eq [:xml, :csv, :yaml]
+    end
+  end
+
   describe "spell_max" do
     it "should default to 5" do
       expect(Blacklight::Configuration.new.spell_max).to eq 5


### PR DESCRIPTION
... for the #index action

Options include:
- do the default

```
    config.index.respond_to.yaml = true
```
- don't render the format

```
    config.index.respond_to.yaml = true
```
- options for render

```
    config.index.respond_to.yaml = { layout: 'custom-layout' }
```
- custom proc to render

```
    config.index.respond_to.yaml = lambda { render text: "stuff" }
```
- controller method to render

```
    config.index.respond_to.yaml = :my_custom_yaml_serialization
```
