### PR TITLE
Add support to configure facet, index and show fields to inject addition...

### DIFF
--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -322,6 +322,13 @@ module Blacklight::SolrHelper
           if facet.sort
             solr_parameters[:"f.#{facet.field}.facet.sort"] = facet.sort
           end
+
+          if facet.solr_params
+            facet.solr_params.each do |k, v|
+              solr_parameters[:"f.#{facet.field}.#{k}"] = v
+            end
+          end
+
         end
 
         # Support facet paging and 'more'
@@ -341,10 +348,25 @@ module Blacklight::SolrHelper
 
     def add_solr_fields_to_query solr_parameters, user_parameters
       return unless blacklight_config.add_field_configuration_to_solr_request
+
+      blacklight_config.show_fields.each do |field_name, field|
+        if field.solr_params
+          field.solr_params.each do |k, v|
+            solr_parameters[:"f.#{field.field}.#{k}"] = v
+          end
+        end
+      end
+
       blacklight_config.index_fields.each do |field_name, field|
         if field.highlight
           solr_parameters[:hl] = true
           solr_parameters.append_highlight_field field.field
+        end
+
+        if field.solr_params
+          field.solr_params.each do |k, v|
+            solr_parameters[:"f.#{field.field}.#{k}"] = v
+          end
         end
       end
     end


### PR DESCRIPTION
...al field-specific solr parameters

Fixes #759.

e.g.:

``` ruby
config.add_index_field 'an_index_field', solr_params: { 'hl.alternativeField' => 'field_x'}
config.add_show_field 'a_show_field', solr_params: { 'hl.alternativeField' => 'field_y'}
config.add_field_configuration_to_solr_request!
config.add_facet_field 'some-field', solr_params: { 'facet.mincount' =>15 }
config.add_facet_fields_to_solr_request!
```

Will add:

   f.an_index_field.hl.alternativeField=field_x&
   f.a_show_field.hl.alternativeField=field_y&
   f.some-field.facet.mincount=15

To the query sent to solr.
