### PR TITLE
No need to check for Turbolinks defined.

### DIFF
--- a/app/assets/javascripts/blacklight/core.js
+++ b/app/assets/javascripts/blacklight/core.js
@@ -13,11 +13,12 @@ Blacklight = function() {
   }
 }();
 
-if (typeof Turbolinks !== "undefined") {
-  $(document).on('page:load', function() {
-    Blacklight.activate();  
-  });
-}
+// turbolinks triggers page:load events on page transition
+// If app isn't using turbolinks, this event will never be triggered, no prob. 
+$(document).on('page:load', function() {
+  Blacklight.activate();  
+});
+
 $(document).ready(function() {
   Blacklight.activate();  
 });


### PR DESCRIPTION
If there's no Turbolinks, we registered an event handler
for an event that will never be fired -- this should not harm
anything.

But the check introduces possible order-of-load errors, where
blacklight core accidentally ends up loaded before turbolinks,
so doesn't set up the event handler, but then turbolinks loads later,
so the event handler was needed, but didn't load. ran into this
with an engine that inserted it's 'require x.js' before turbolinks.
Best to avoid order-of-load dependencies if we can; we can.
