### PR TITLE
Consistently use #search_action_url (and #search_action_path) to provide...

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -15,7 +15,6 @@ class BookmarksController < CatalogController
   def search_action_url *args
     catalog_index_url *args
   end
-  helper_method :search_action_url
 
   before_filter :verify_user
 

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -364,7 +364,7 @@ module Blacklight::BlacklightHelperBehavior
         end
 
         Array(value).map do |v|
-          link_to render_field_value(v, field_config), search_action_url(add_facet_params(link_field, v, {}))
+          link_to render_field_value(v, field_config), search_action_path(add_facet_params(link_field, v, {}))
         end if field
       else
         value

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -111,11 +111,9 @@ module Blacklight::FacetsHelperBehavior
   # @param [String] facet item
   # @param [Hash] options
   # @option options [Boolean] :suppress_link display the facet, but don't link to it
-  # @option options [Rails::Engine] :route_set route set to use to render the link
   # @return [String]
-  def render_facet_value(facet_solr_field, item, options ={})    
-    scope = options.delete(:route_set) || self
-    path = scope.url_for(add_facet_params_and_redirect(facet_solr_field, item).merge(only_path: true))
+  def render_facet_value(facet_solr_field, item, options ={})
+    path = search_action_path(add_facet_params_and_redirect(facet_solr_field, item))
     content_tag(:span, :class => "facet-label") do
       link_to_unless(options[:suppress_link], facet_display_value(facet_solr_field, item), path, :class=>"facet_select")
     end + render_facet_count(item.hits)
@@ -128,7 +126,7 @@ module Blacklight::FacetsHelperBehavior
     content_tag(:span, :class => "facet-label") do
       content_tag(:span, facet_display_value(facet_solr_field, item), :class => "selected") +
       # remove link
-      link_to(content_tag(:span, '', :class => "glyphicon glyphicon-remove") + content_tag(:span, '[remove]', :class => 'sr-only'), remove_facet_params(facet_solr_field, item, params), :class=>"remove")
+      link_to(content_tag(:span, '', :class => "glyphicon glyphicon-remove") + content_tag(:span, '[remove]', :class => 'sr-only'), search_action_path(remove_facet_params(facet_solr_field, item, params)), :class=>"remove")
     end + render_facet_count(item.hits, :classes => ["selected"])
   end
 

--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -78,7 +78,7 @@ module Blacklight::RenderConstraintsHelperBehavior
     safe_join(values.map do |val|
       render_constraint_element( blacklight_config.facet_fields[facet].label,
                   facet_display_value(facet, val),
-                  :remove => url_for(remove_facet_params(facet, val, localized_params)),
+                  :remove => search_action_path(remove_facet_params(facet, val, localized_params)),
                   :classes => ["filter", "filter-" + facet.parameterize]
                 )
     end, "\n")

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -192,7 +192,7 @@ module Blacklight::Catalog
     # By default, any search action from a Blacklight::Catalog controller
     # should use the current controller when constructing the route.
     def search_action_url options = {}
-      url_for(options.merge(:action => 'index', :only_path => true))
+      url_for(options.merge(:action => 'index'))
     end
 
     # extract the pagination info from the response object

--- a/lib/blacklight/controller.rb
+++ b/lib/blacklight/controller.rb
@@ -23,7 +23,7 @@ module Blacklight::Controller
     # extra head content
     helper_method :has_user_authentication_provider?
     helper_method :blacklight_config
-    helper_method :search_action_url
+    helper_method :search_action_url, :search_action_path
 
 
     # This callback runs when a user first logs in
@@ -48,6 +48,15 @@ module Blacklight::Controller
     # which action the search form should use
     def search_action_url *args
       catalog_index_url *args
+    end
+
+    def search_action_path *args
+
+      if args.first.is_a? Hash
+        args.first[:only_path] = true
+      end
+
+      search_action_url *args
     end
 
     # Returns a list of Searches from the ids in the user's history.

--- a/spec/features/alternate_controller_spec.rb
+++ b/spec/features/alternate_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Alternate Controller Behaviors" do
   it "should have the correct per-page form" do
     visit alternate_index_path
-    page.should have_selector("form[action='#{alternate_index_path}']")
+    page.should have_selector("form[action='#{alternate_index_url}']")
     fill_in "q", :with=>"history"
     click_button 'search'
     expect(current_path).to match /#{alternate_index_path}/
@@ -15,7 +15,7 @@ describe "Alternate Controller Behaviors" do
 
   it "should have the correct search field form" do
     visit alternate_index_path
-    page.should have_selector("form[action='#{alternate_index_path}']")
+    page.should have_selector("form[action='#{alternate_index_url}']")
     fill_in "q", :with=>"history"
     click_button 'search'
     expect(current_path).to match /#{alternate_index_path}/
@@ -25,7 +25,7 @@ describe "Alternate Controller Behaviors" do
 
   it "should display document thumbnails" do
     visit alternate_index_path
-    page.should have_selector("form[action='#{alternate_index_path}']")
+    page.should have_selector("form[action='#{alternate_index_url}']")
     fill_in "q", :with=>"history"
     click_button 'search'
     expect(page).to have_selector ".document-thumbnail"

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -12,7 +12,7 @@ describe BlacklightHelper do
   end
 
   before(:each) do
-    helper.stub(:search_action_url) do |*args|
+    helper.stub(:search_action_path) do |*args|
       catalog_index_url *args
     end
   end
@@ -155,14 +155,14 @@ describe BlacklightHelper do
       doc = double()
       doc.should_receive(:get).with('link_to_search_true', :sep => nil).and_return('x')
       value = helper.render_index_field_value :document => doc, :field => 'link_to_search_true'
-      expect(value).to eq helper.link_to("x", helper.search_action_url(:f => { :link_to_search_true => ['x'] }))
+      expect(value).to eq helper.link_to("x", helper.search_action_path(:f => { :link_to_search_true => ['x'] }))
     end
 
     it "should check for a link_to_search with a field name" do
       doc = double()
       doc.should_receive(:get).with('link_to_search_named', :sep => nil).and_return('x')
       value = helper.render_index_field_value :document => doc, :field => 'link_to_search_named'
-      expect(value).to eq helper.link_to("x", helper.search_action_url(:f => { :some_field => ['x'] }))
+      expect(value).to eq helper.link_to("x", helper.search_action_path(:f => { :some_field => ['x'] }))
     end
 
     it "should gracefully handle when no highlight field is available" do
@@ -253,14 +253,14 @@ describe BlacklightHelper do
       doc = double()
       doc.should_receive(:get).with('link_to_search_true', :sep => nil).and_return('x')
       value = helper.render_document_show_field_value :document => doc, :field => 'link_to_search_true'
-      expect(value).to eq helper.link_to("x", helper.search_action_url(:f => { :link_to_search_true => ['x'] }))
+      expect(value).to eq helper.link_to("x", helper.search_action_path(:f => { :link_to_search_true => ['x'] }))
     end
 
     it "should check for a link_to_search with a field name" do
       doc = double()
       doc.should_receive(:get).with('link_to_search_named', :sep => nil).and_return('x')
       value = helper.render_document_show_field_value :document => doc, :field => 'link_to_search_named'
-      expect(value).to eq helper.link_to("x", helper.search_action_url(:f => { :some_field => ['x'] }))
+      expect(value).to eq helper.link_to("x", helper.search_action_path(:f => { :some_field => ['x'] }))
     end
 
     it "should gracefully handle when no highlight field is available" do

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -299,9 +299,13 @@ describe FacetsHelper do
       helper.stub(:facet_configuration_for_field).with('simple_field').and_return(double(:query => nil, :date => nil, :helper_method => nil, :single => false))
       helper.should_receive(:facet_display_value).and_return('Z')
       helper.should_receive(:add_facet_params_and_redirect).and_return({controller:'catalog'})
+      
+      helper.stub(:search_action_path) do |*args|
+        catalog_index_path *args
+      end
     end
     describe "simple case" do
-      let(:expected_html) { "<span class=\"facet-label\"><a class=\"facet_select\" href=\"/\">Z</a></span><span class=\"facet-count\">10</span>" }
+      let(:expected_html) { "<span class=\"facet-label\"><a class=\"facet_select\" href=\"/catalog\">Z</a></span><span class=\"facet-count\">10</span>" }
       it "should use facet_display_value" do
         result = helper.render_facet_value('simple_field', item)
         expect(result).to be_equivalent_to(expected_html).respecting_element_order
@@ -312,17 +316,6 @@ describe FacetsHelper do
       let(:expected_html) { "<span class=\"facet-label\">Z</span><span class=\"facet-count\">10</span>" }
       it "should suppress the link" do
         result = helper.render_facet_value('simple_field', item, :suppress_link => true)
-        expect(result).to be_equivalent_to(expected_html).respecting_element_order
-      end
-    end
-
-    describe "when a route_set is passed" do
-      let(:my_engine) { double("Engine") }
-      let(:expected_html) { "<span class=\"facet-label\"><a class=\"facet_select\" href=\"/\">Z</a></span><span class=\"facet-count\">10</span>" }
-
-      it "should use the engine scope" do
-        expect(my_engine).to receive(:url_for).and_return({controller: 'catalog'})
-        result = helper.render_facet_value('simple_field', item, route_set: my_engine)
         expect(result).to be_equivalent_to(expected_html).respecting_element_order
       end
     end

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -5,6 +5,9 @@ describe RenderConstraintsHelper do
   before do
     # the helper methods below infer paths from the current route
     controller.request.path_parameters["controller"] = 'catalog'
+    helper.stub(:search_action_path) do |*args|
+      catalog_index_path *args
+    end
   end
 
   describe '#render_constraints_query' do
@@ -23,7 +26,7 @@ describe RenderConstraintsHelper do
     it "should have a link relative to the current url" do
       result = helper.render_filter_element('type', ['journal'], {:q=>'biz'})
       # I'm not certain how the ampersand gets in there. It's not important.
-      expect(result).to have_selector "a[href='/?&q=biz']"
+      expect(result).to have_link "Remove constraint Type: journal", href: "/catalog?&q=biz"
     end
   end
 

--- a/spec/views/catalog/_constraints.html.erb_spec.rb
+++ b/spec/views/catalog/_constraints.html.erb_spec.rb
@@ -14,7 +14,7 @@ describe "catalog/constraints" do
   end
 
   it "should render a start over link" do
-    view.should_receive(:search_action_url).with({}).and_return('http://xyz')
+    view.should_receive(:search_action_path).with({}).and_return('http://xyz')
     view.stub(query_has_constraints?: true)
     view.stub(:blacklight_config).and_return(blacklight_config)
     render partial: "catalog/constraints"
@@ -23,7 +23,7 @@ describe "catalog/constraints" do
   end
 
   it "should render a start over link with the current view type" do
-    view.should_receive(:search_action_url).with(view: :xyz).and_return('http://xyz?view=xyz')
+    view.should_receive(:search_action_path).with(view: :xyz).and_return('http://xyz?view=xyz')
     view.stub(query_has_constraints?: true)
     params[:view] = 'xyz'
     view.stub(:blacklight_config).and_return(blacklight_config)

--- a/spec/views/catalog/_facets.html.erb_spec.rb
+++ b/spec/views/catalog/_facets.html.erb_spec.rb
@@ -5,6 +5,9 @@ describe "catalog/_facets" do
 
   before do
     view.stub(blacklight_config: blacklight_config)
+    view.stub(:search_action_path) do |*args|
+      catalog_index_url *args
+    end
   end
 
   context "without any facet fields" do


### PR DESCRIPTION
... Blacklight urls for facets, links to searches, etc
