### PR TITLE
Ensure the value set for @page_title is html_safe

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -275,6 +275,13 @@ module Blacklight::BlacklightHelperBehavior
   end
 
   ##
+  # Assign the @page_title instance variable to its default value
+  def document_page_title
+    t('blacklight.search.show.title_html', :document_title => document_show_html_title, :application_name => application_name) 
+  end
+
+
+  ##
   # Get the document's "title" to display in the <title> element.
   # (by default, use the #document_heading)
   #

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -2,8 +2,7 @@
 
   <%= render 'previous_next_doc' %>
 
-   
-<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name) -%>
+  <% @page_title = document_page_title %>
 <% content_for(:head) { render_link_rel_alternates } -%>
 <%# this should be in a partial -%>
 

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -194,7 +194,7 @@ en:
       index:
         label: '%{label}:'
       show:
-        title: '%{document_title} - %{application_name}'
+        title_html: '%{document_title} - %{application_name}'
         label: '%{label}:'
       rss_feed: 'RSS for results'
       atom_feed: 'Atom for results'

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -216,6 +216,15 @@ describe BlacklightHelper do
     end
   end
 
+  describe "document_page_title" do
+    before do
+      helper.stub(:document_show_html_title => 'Document title')
+    end
+    subject { helper.document_page_title }
+    it { should == "Document title - Blacklight" }
+    it { should be_html_safe }
+  end
+
   describe "render_document_show_field_value" do
     before do
       @config = Blacklight::Configuration.new.configure do |config|


### PR DESCRIPTION
so that characters such as `&#39;` aren't double escaped
