### PR TITLE
Removed #history_session which no longer serves any useful purpose.

### DIFF
--- a/lib/blacklight/catalog/search_context.rb
+++ b/lib/blacklight/catalog/search_context.rb
@@ -6,17 +6,10 @@ module Blacklight::Catalog::SearchContext
   # own controller.
   included do  
     helper_method :current_search_session, :search_session
-    before_filter :search_session, :history_session, :current_search_session
+    before_filter :current_search_session
   end
   
   protected
-
-  # sets up the session[:history] hash if it doesn't already exist.
-  # assigns all Search objects (that match the searches in session[:history]) to a variable @searches.
-  def history_session
-    session[:history] ||= []
-    @searches = searches_from_history # <- in BlacklightController
-  end
 
   # sets up the session[:search] hash if it doesn't already exist
   def search_session

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -70,11 +70,6 @@ describe CatalogController do
         before do
           controller.stub(:get_search_results) 
         end
-        it "should include :search key with hash" do
-          get :index
-          expect(session[:search]).to_not be_nil
-          expect(session[:search]).to be_kind_of(Hash)
-        end
         it "should include search hash with key :q" do
           get :index, :q => @user_query
           expect(session[:search]).to_not be_nil


### PR DESCRIPTION
Lazy init `session[:search]`
