### PR TITLE
Merge functionality from #query_solr into #find, and restore 2-arg (path...

### DIFF
--- a/lib/blacklight/solr/request.rb
+++ b/lib/blacklight/solr/request.rb
@@ -39,7 +39,7 @@ class Blacklight::Solr::Request < HashWithIndifferentAccess
   end
 
   def to_hash
-    reject {|key, value| ARRAY_KEYS.include?(key) && value.empty?}
+    reject {|key, value| ARRAY_KEYS.include?(key) && value.blank?}
   end
 
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -509,10 +509,7 @@ describe CatalogController do
       controller.stub(:has_user_authentication_provider?) { false }
         @mock_response = double()
         @mock_document = double()
-        @mock_response.stub(:docs => [], :total => 1, :facets => [], :facet_queries => {}, :facet_by_field_name => nil)
-        @mock_document = double()
-        controller.stub(:find => @mock_response, 
-                        :get_single_doc_via_search => @mock_document)
+        controller.stub(:get_single_doc_via_search => @mock_document)
     end
 
     it "should not show user util links" do


### PR DESCRIPTION
... + args) form of #find

Fixes #784 
