### PR TITLE
facet_in_params should not call facet_field_in_params

### DIFF
--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -166,7 +166,7 @@ module Blacklight::FacetsHelperBehavior
 
     value = facet_value_for_facet_item(item)
 
-    facet_field_in_params?(field) and params[:f][field].include?(value)
+    params[:f] and params[:f][field] and params[:f][field].include?(value)
   end
 
   ##


### PR DESCRIPTION
`blacklight_advanced_search` needs to override `facet_field_in_params?`,
so it looks in `params[:f_inclusive]`, not just `params[:f]`. 

But once it does this, it breaks the previous `facet_in_params?` (note slightly different method), 
since it assumed that if `facet_field_in_params?`, then `params[:f][field]`
must neccesarily exist. But we redefined it otherwise.

`facet_in_params` already needed to know about the internal details
of params structure, it already needed to look in `params[:f][field]`
itself -- now it just takes it's own responsiblity for making sure
`params[:f][field]` already exists before trying to look at it, instead
of assuming it knows the implementation of facet_field_in_params.

Getting blacklight_advanced_search to work without this patch is
going to take some hacks, so if a point release is possible it would
be helpful. But otherwise, can hack.
