### PR TITLE
expose more default values from blacklight_config

### DIFF
--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -10,6 +10,12 @@ class CatalogController < ApplicationController
       :qt => 'search',
       :rows => 10 
     }
+    
+    # solr path which will be added to solr base url before the other solr params.
+    #config.solr_path = 'select' 
+    
+    # items to show per page, each number in the array represent another option to choose from.
+    #config.per_page = [10,20,50,100]
 
     ## Default parameters to send on single-document requests to Solr. These settings are the Blackligt defaults (see SolrHelper#solr_doc_params) or 
     ## parameters included in the Blacklight-jetty document requestHandler.


### PR DESCRIPTION
I believe this 2 default values should be here and not hidden somewhere inside the default_values method. Definitely can save some time.
