### PR TITLE
removed unnecessary Bootstrap 2 class

### DIFF
--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="panel-body">
-  <ul class="nav nav-list">
+  <ul class="nav">
       <li>
         <%= render_show_doc_actions @document %>
       </li>


### PR DESCRIPTION
Removes an unnecessary Bootstrap 2 class `nav-list` I found while working on something else.  Documented [here](http://getbootstrap.com/migration/).  I can't find anything else in Blacklight that uses this class.
