### PR TITLE
Don't add filters just by including SearchContext.

### DIFF
--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -15,6 +15,8 @@ module Blacklight::Catalog
     # Hint: the SolrHelper #get_solr_response_for_doc_id method raises this error,
     # which is used in the #show action here.
     rescue_from Blacklight::Exceptions::InvalidSolrID, :with => :invalid_solr_id_error
+
+    record_search_parameters
   end
   
     # get search results from the solr index

--- a/lib/blacklight/catalog/search_context.rb
+++ b/lib/blacklight/catalog/search_context.rb
@@ -7,8 +7,13 @@ module Blacklight::Catalog::SearchContext
   included do  
     helper_method :current_search_session, :search_session
 
+  end
+
+  module ClassMethods
     # Save the submitted search parameters in the search session
-    before_filter :current_search_session, only: :index
+    def record_search_parameters opts = { only: :index}
+      before_filter :current_search_session, opts
+    end
   end
   
   protected


### PR DESCRIPTION
This allows the use of Blacklight::Base (which includes
Blacklight::SearchContext) onto controllers that aren't including
Blacklight::Catalog without adding unneeded filters.  If an implementer wants to
use the filter, they can use `record_search_parameters`.
