### PR TITLE
Move has_search_parameters? into Blacklight::Catalog

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -114,13 +114,6 @@ module Blacklight::CatalogHelperBehavior
   end
 
   ##
-  # Check if any search parameters have been set
-  # @return [Boolean] 
-  def has_search_parameters?
-    !params[:q].blank? or !params[:f].blank? or !params[:search_field].blank?
-  end
-
-  ##
   # Should we display the sort and per page widget?
   # 
   # @param [Blacklight::SolrResponse]

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -9,7 +9,7 @@ module Blacklight::Catalog
   # The following code is executed when someone includes blacklight::catalog in their
   # own controller.
   included do
-    helper_method :sms_mappings
+    helper_method :sms_mappings, :has_search_parameters?
 
     # Whenever an action raises SolrHelper::InvalidSolrID, this block gets executed.
     # Hint: the SolrHelper #get_solr_response_for_doc_id method raises this error,
@@ -150,6 +150,13 @@ module Blacklight::Catalog
         format.js { render :layout => false }
         format.html
       end
+    end
+
+    ##
+    # Check if any search parameters have been set
+    # @return [Boolean] 
+    def has_search_parameters?
+      !params[:q].blank? or !params[:f].blank? or !params[:search_field].blank?
     end
     
     protected    

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -635,6 +635,23 @@ describe CatalogController do
       expect(session).to eq(s)
     end
   end
+
+  describe "#has_search_parameters?" do
+    subject { controller.has_search_parameters? }
+    describe "none" do
+      before { controller.stub(params: { }) }
+      it { should be_false }
+    end
+    describe "with a query" do
+      before { controller.stub(params: { q: 'hello' }) }
+      it { should be_true }
+    end
+    describe "with a facet" do
+      before { controller.stub(params: { f: { "field" => ["value"]} }) }
+      it { should be_true }
+    end
+  end
+
 end
 
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -126,27 +126,22 @@ describe CatalogHelper do
 
   describe "should_autofocus_on_search_box?" do
     it "should be focused if we're on a catalog-like index page without query or facet parameters" do
-      helper.stub(:controller => CatalogController.new, :action_name => "index", :params => { })
+      helper.stub(controller: CatalogController.new, action_name: "index", has_search_parameters?: false)
       expect(helper.should_autofocus_on_search_box?).to be_true
     end
 
     it "should not be focused if we're not on a catalog controller" do
-      helper.stub(:controller => ApplicationController.new)
+      helper.stub(controller: ApplicationController.new)
       expect(helper.should_autofocus_on_search_box?).to be_false
     end
 
     it "should not be focused if we're not on a catalog controller index" do
-      helper.stub(:controller => CatalogController.new, :action_name => "show")
+      helper.stub(controller: CatalogController.new, action_name: "show")
       expect(helper.should_autofocus_on_search_box?).to be_false
     end
 
-    it "should not be focused if a search string is provided" do
-      helper.stub(:controller => CatalogController.new, :action_name => "index", :params => { :q => "hello"})
-      expect(helper.should_autofocus_on_search_box?).to be_false
-    end
-
-    it "should not be focused if a facet is selected" do
-      helper.stub(:controller => CatalogController.new, :action_name => "index", :params => { :f => { "field" => ["value"]}})
+    it "should not be focused if a search parameters are provided" do
+      helper.stub(controller: CatalogController.new, action_name: "index", has_search_parameters?: true)
       expect(helper.should_autofocus_on_search_box?).to be_false
     end
   end

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -1,30 +1,38 @@
 require 'spec_helper'
 
 describe "catalog/index.html.erb" do
-  it "should render the sidebar and content panes" do
-    view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
-    render
-    expect(rendered).to match /id="sidebar"/
-    expect(rendered).to match /id="content"/
+
+  describe "with no search parameters" do
+    before do
+      view.stub(:has_search_parameters?).and_return(false)
+      view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
+    end
+    it "should render the sidebar and content panes" do
+      render
+      expect(rendered).to match /id="sidebar"/
+      expect(rendered).to match /id="content"/
+    end
+
+    it "should render the search_sidebar partial " do
+      stub_template "catalog/_search_sidebar.html.erb" => "sidebar_content"
+      render
+      expect(rendered).to match /sidebar_content/
+    end
   end
 
-  it "should render the search_sidebar partial " do
-    stub_template "catalog/_search_sidebar.html.erb" => "sidebar_content"
+  describe "with search parameters" do
+    before do
+      view.stub(:has_search_parameters?).and_return(true)
+      stub_template "catalog/_results_pagination.html.erb" => ""
+      stub_template "catalog/_search_header.html.erb" => "header_content"
 
-    view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
-    render
-    expect(rendered).to match /sidebar_content/
-  end
-
-  it "should render the search_header partial " do
-    stub_template "catalog/_results_pagination.html.erb" => ""
-    stub_template "catalog/_search_header.html.erb" => "header_content"
-
-    view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
-    view.stub(:has_search_parameters?).and_return(true)
-    view.stub(:render_opensearch_response_metadata).and_return("")
-    assign(:response, double(:empty? => true))
-    render
-    expect(rendered).to match /header_content/
+      view.stub(:blacklight_config).and_return(Blacklight::Configuration.new)
+      view.stub(:render_opensearch_response_metadata).and_return("")
+      assign(:response, double(:empty? => true))
+    end
+    it "should render the search_header partial " do
+      render
+      expect(rendered).to match /header_content/
+    end
   end
 end


### PR DESCRIPTION
This is a convenient method to use in a custom blacklight
implementation. see
https://github.com/sul-dlss/spotlight/commit/5e817b99050b448da196543f78ace0225a893254#diff-7ef82825d38ed0d7271a7cc87c280e3cR16
