### PR TITLE
Generate config/jetty.yml into the host app if --jettywrapper is used;

### DIFF
--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -5,7 +5,7 @@ module Blacklight
     
     argument     :model_name  , type: :string , default: "user"
     class_option :devise      , type: :boolean, default: false, aliases: "-d", desc: "Use Devise as authentication logic."
-    class_option :jettywrapper, type: :boolean, default: false, aliases: "-d", desc: "Use jettywrapper to download and control Jetty"
+    class_option :jettywrapper, type: :boolean, default: false, desc: "Use jettywrapper to download and control Jetty"
     class_option :marc        , type: :boolean, default: false, aliases: "-m", desc: "Generate MARC-based demo ."
 
     desc """
@@ -18,12 +18,15 @@ module Blacklight
 
 
   Thank you for Installing Blacklight.
-         """ 
+         """
 
     def install_jettywrapper
       return unless options[:jettywrapper]
       gem "jettywrapper", "~> 1.7"
-      append_to_file "Rakefile", 
+
+      copy_file "config/jetty.yml"
+
+      append_to_file "Rakefile",
         "\nZIP_URL = \"https://github.com/projectblacklight/blacklight-jetty/archive/v4.6.0.zip\"\n" +
         "require 'jettywrapper'\n"
     end

--- a/lib/generators/blacklight/templates/config/jetty.yml
+++ b/lib/generators/blacklight/templates/config/jetty.yml
@@ -1,0 +1,10 @@
+development:
+  startup_wait: 15
+  jetty_port: 8983
+test:
+  startup_wait: 60
+  jetty_port: <%= ENV['TEST_JETTY_PORT'] || 8888 %>
+  <%= ENV['TEST_JETTY_PATH'] ? "jetty_home: " + ENV['TEST_JETTY_PATH'] : '' %>
+production:
+  startup_wait: 15
+  jetty_port: 8983

--- a/template.demo.rb
+++ b/template.demo.rb
@@ -1,8 +1,5 @@
 gem "blacklight"
 
-# copy the blacklight jetty.yml into their app
-create_file "config/jetty.yml", File.read(File.expand_path('../config/jetty.yml', __FILE__))
-
 run "bundle install"
 
 # run the blacklight install generator


### PR DESCRIPTION
fixes #819 by moving the jetty.yml into the gem's generator instead of
the template.
