### PR TITLE
update #url_for_document to use explicit configuration

### DIFF
--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -8,9 +8,12 @@ module Blacklight::UrlHelperBehavior
   # to provide more interesting routing to
   # documents
   def url_for_document doc
-    if controller.is_a? Blacklight::Catalog and doc.is_a? SolrDocument and
+    if respond_to?(:blacklight_config) and
+        blacklight_config.show.route and
         (!doc.respond_to?(:to_model) or doc.to_model.is_a? SolrDocument)
-      { controller: controller_name, action: :show, id: doc }
+      route = blacklight_config.show.route.merge(action: :show, id: doc)
+      route[:controller] = controller_name if route[:controller] == :current
+      route
     else
       doc
     end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -61,7 +61,15 @@ module Blacklight
             :respond_to => OpenStructWithHashAccess.new()
             ),
           # Additional configuration when displaying a single document
-          :show => ViewConfig::Show.new(:partials => [:show_header, :show]),
+          :show => ViewConfig::Show.new(
+            # default route parameters for 'show' requests
+            # set this to a hash with additional arguments to merge into 
+            # the route, or set `controller: :current` to route to the 
+            # current controller.
+            route: nil,
+            # partials to render for each document(see #render_document_partials) 
+            partials: [:show_header, :show]
+          ),
           # Configurations for specific types of index views
           :view => NestedOpenStructWithHashAccess.new(ViewConfig, 'list'),
           # Maxiumum number of spelling suggestions to offer

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -27,19 +27,31 @@ describe BlacklightUrlHelper do
     end
 
     it "should be a polymorphic routing-ready object" do
-      doc = double
+      doc = SolrDocument.new
       expect(helper.url_for_document(doc)).to eq doc
     end
 
-    it "should be a catalog controller-specific route" do
+    it "should allow for custom show routes" do
       doc = SolrDocument.new
+      helper.blacklight_config.show.route = { controller: 'catalog' }
       expect(helper.url_for_document(doc)).to eq({controller: 'catalog', action: :show, id: doc})
+    end
+
+    context "within bookmarks" do
+      let(:controller_class) { ::BookmarksController.new }
+
+      it "should use polymorphic routing" do
+        doc = SolrDocument.new
+        expect(helper.url_for_document(doc)).to eq doc
+      end
     end
 
     context "within an alternative catalog controller" do
       let(:controller_class) { ::AlternateController.new }
-
-      it "should be a catalog controller-specific route" do
+      before do
+        helper.blacklight_config.show.route = { controller: :current }
+      end
+      it "should support the :current controller configuration" do
         doc = SolrDocument.new
         expect(helper.url_for_document(doc)).to eq({controller: 'alternate', action: :show, id: doc})
       end


### PR DESCRIPTION
Add new Blacklight configuration:

``` ruby
config.show.route
```

that allows the configuration to provide additional routing parameters for determining routes for SolrDocument objects. 
