### PR TITLE
Support custom tranformation of display_type_field into partial name

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -443,7 +443,21 @@ module Blacklight::BlacklightHelperBehavior
 
     display_type ||= 'default'
 
-    # .to_s is necessary otherwise the default return value is not always a string
+    type_field_to_partial_name(document, display_type)
+  end
+
+  ##
+  # Return a partial name for rendering a document
+  # this method can be overridden in order to transform the value
+  #   (e.g. 'PdfBook' => 'pdf_book')
+  #
+  # @param [SolrDocument] document
+  # @param [String, Array] display_type a value suggestive of a partial
+  # @return [String] the name of the partial to render
+  # @example
+  #  type_field_to_partial_name(['a book-article'])
+  #  => 'a_book_article'
+  def type_field_to_partial_name(document, display_type)
     # using "_" as sep. to more closely follow the views file naming conventions
     # parameterize uses "-" as the default sep. which throws errors
     Array(display_type).join(" ").gsub("-","_").parameterize("_")

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -513,4 +513,23 @@ describe BlacklightHelper do
 
     end
   end
+  describe "#type_field_to_partial_name" do
+    let(:document) { double }
+    context "with default value" do
+      subject { helper.type_field_to_partial_name(document, 'default') }
+      it { should eq 'default' } 
+    end
+    context "with spaces" do
+      subject { helper.type_field_to_partial_name(document, 'one two three') }
+      it { should eq 'one_two_three' } 
+    end
+    context "with hyphens" do
+      subject { helper.type_field_to_partial_name(document, 'one-two-three') }
+      it { should eq 'one_two_three' } 
+    end
+    context "an array" do
+      subject { helper.type_field_to_partial_name(document, ['one', 'two', 'three']) }
+      it { should eq 'one_two_three' } 
+    end
+  end
 end


### PR DESCRIPTION
This enables implementers to override the type_field_to_partial_name
in order to use a field value like 'PdfBook' to render a partial like
'pdf_book'.
