### PR TITLE
Peg sprockets to ~> 2.11.0 and sass to ~> 3.2.15 for Rails 4.x builds

### DIFF
--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -6,5 +6,7 @@ if File.exists?(file)
   puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
   instance_eval File.read(file)
 end
+gem 'sass', '~> 3.2.15'
+gem 'sprockets', '~> 2.11.0'
 
 gem 'rails', '4.1.0.rc1'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -7,4 +7,7 @@ if File.exists?(file)
   instance_eval File.read(file)
 end
 
+gem 'sass', '~> 3.2.15'
+gem 'sprockets', '~> 2.11.0'
+
 gem 'rails', '4.0.3'


### PR DESCRIPTION
If we don't specify 2.11.0 we'll end up with sprockets 2.12.0 in the
main Gemfile.lock but since sass-rails gets generated (rails new) into
the test app it'll want sprockets 2.11.0 and we'll have a conflict

If we don't specify 3.2.15 we'll end up with sass 3.3.2 in the
main Gemfile.lock but since sass-rails gets generated (rails new) into
the test app it'll want sass 3.2.0 and we'll have a conflict
