### PR TITLE
extract partials and helper methods for reusable (or overridable) elements of the default blacklight layout

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -575,4 +575,10 @@ module Blacklight::BlacklightHelperBehavior
   def presenter_class
     Blacklight::DocumentPresenter
   end
+  
+  ##
+  # Open Search discovery tag for HTML <head> links
+  def opensearch_description_tag title, href
+    tag :link, href: href, title: title, type: "application/opensearchdescription+xml", rel: "search"
+  end
 end

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -14,7 +14,7 @@
     <![endif]-->
 
     <title><%= render_page_title %></title>
-    <link href="<%= opensearch_catalog_path(:format => 'xml', :only_path => false) %>" title="<%= application_name%>" type="application/opensearchdescription+xml" rel="search"/>
+    <%= opensearch_description_tag application_name, opensearch_catalog_path(:format => 'xml', :only_path => false) %>
     <%= favicon_link_tag asset_path('favicon.ico') %>
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application" %>
@@ -30,22 +30,10 @@
   <body class="<%= render_body_class %>">
   <%= render :partial => 'shared/header_navbar' %>
 
-  <div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-      </div>
-    </div>
-  </div>
+  <%= render partial: 'shared/ajax_modal' %>
 
-<!-- /container -->
   <div id="main-container" class="container">
-    <div class="row">
-      <div class="col-md-12">
-        <div id="main-flashes">
-          <%= render :partial=>'/flash_msg' %>
-        </div>
-      </div>
-    </div>
+    <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
     <div class="row">
       <%= yield %>

--- a/app/views/shared/_ajax_modal.html.erb
+++ b/app/views/shared/_ajax_modal.html.erb
@@ -1,0 +1,6 @@
+<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col-md-12">
+    <div id="main-flashes">
+      <%= yield %>
+    </div>
+  </div>
+</div>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -532,4 +532,24 @@ describe BlacklightHelper do
       it { should eq 'one_two_three' } 
     end
   end
+  
+  describe "#opensearch_description_tag" do
+    subject { helper.opensearch_description_tag 'title', 'href' }
+    
+    it "should have a search rel" do
+      expect(subject).to have_selector "link[rel='search']", visible: false
+    end
+    
+    it "should have the correct mime type" do
+      expect(subject).to have_selector "link[type='application/opensearchdescription+xml']", visible: false
+    end
+    
+    it "should have a title attribute" do
+      expect(subject).to have_selector "link[title='title']", visible: false
+    end
+    
+    it "should have an href attribute" do
+      expect(subject).to have_selector "link[href='href']", visible: false
+    end
+  end
 end


### PR DESCRIPTION
fixes #838 
