### PR TITLE
add blacklight:check rake tasks for checking solr and controller configurations

### DIFF
--- a/lib/railties/blacklight.rake
+++ b/lib/railties/blacklight.rake
@@ -19,6 +19,99 @@ namespace :blacklight do
     end
   end
 
-end
-  
+  namespace :check do
+    desc "Check the Solr connection and controller configuration"
+    task :solr, [:controller_name] => [:environment] do |_, args|
+      errors = 0
+      verbose = ENV.fetch('VERBOSE', false).present?
 
+      puts "[#{Blacklight.solr.uri}]"
+
+      print " - admin/ping: "
+      begin
+        response = Blacklight.solr.send_and_receive 'admin/ping', {}
+        puts response['status']
+        errors += 1 unless response['status'] == "OK"
+      rescue Exception => e
+        errors += 1
+        puts e.to_s
+      end
+
+      exit 1 if errors > 0
+    end
+
+    task :controller, [:controller_name] => [:environment] do |_, args|
+      errors = 0
+      verbose = ENV.fetch('VERBOSE', false).present?
+      controller = args[:controller_name].constantize.new if args[:controller_name]
+      controller ||= CatalogController.new
+
+      puts "[#{controller.class.to_s}]"
+
+      print " - find: "
+
+      begin
+        response = controller.find q: '{!lucene}*:*'
+        if response.header['status'] == 0
+          puts "OK"
+        else
+          errors += 1
+        end
+
+        if verbose
+          puts "\tstatus: #{response.header['status']}"
+          puts "\tnumFound: #{response.response['numFound']}"
+          puts "\tdoc count: #{response.docs.length}"
+          puts "\tfacet fields: #{response.facets.length}"
+        end
+      rescue Exception => e
+        errors += 1
+        puts e.to_s
+      end
+
+      print " - get_search_results: "
+  
+      begin
+        response, docs = controller.get_search_results({}, q: '{!lucene}*:*')
+
+        if response.header['status'] == 0 and docs.length > 0
+          puts "OK"
+        else
+          errors += 1
+        end
+
+        if verbose
+          puts "\tstatus: #{response.header['status']}"
+          puts "\tnumFound: #{response.response['numFound']}"
+          puts "\tdoc count: #{docs.length}"
+          puts "\tfacet fields: #{response.facets.length}"
+        end
+      rescue Exception => e
+        errors += 1
+        puts e.to_s
+      end
+
+      print " - get_solr_response_for_doc_id: "
+
+      begin
+        doc_id = response.docs.first[SolrDocument.unique_key]
+        response, doc = controller.get_solr_response_for_doc_id doc_id
+
+        if response.header['status'] == 0 and doc
+          puts "OK"
+        else
+          errors += 1
+        end
+
+        if verbose
+          puts "\tstatus: #{response.header['status']}"
+        end
+      rescue Exception => e
+        errors += 1
+        puts e.to_s
+      end
+
+      exit 1 if errors > 0
+    end
+  end
+end


### PR DESCRIPTION
I'm not sure how widely desired this is, but I think it will be handy for trying to teach Blacklight, and hopefully useful in other contexts too. Here are the important checks I could think of:

``` console
$ rake blacklight:check:solr
[http://127.0.0.1:8983/solr/]
 - admin/ping: OK
```

``` console
$ rake blacklight:check:controller
[CatalogController]
 - find: OK
 - get_search_results: OK
 - get_solr_response_for_doc_id: OK
```

``` console
$ rake blacklight:check:controller VERBOSE=true
[CatalogController]
 - find: OK
    status: 0
    numFound: 30
    doc count: 10
    facet fields: 9
 - get_search_results: OK
    status: 0
    numFound: 30
    doc count: 10
    facet fields: 7
 - get_solr_response_for_doc_id: OK
    status: 0
```

``` console
$ rake blacklight:check:controller[BookmarksController]
[BookmarksController]
 - find: OK
 - get_search_results: OK
 - get_solr_response_for_doc_id: OK
```

Fixes #812
