### PR TITLE
Add #should_render_field? support for all solr field types (index, show,

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -134,9 +134,7 @@ module Blacklight::BlacklightHelperBehavior
   # @param [Blacklight::Solr::Configuration::SolrField] solr_field
   # @return [Boolean]
   def should_render_index_field? document, solr_field
-    document.has?(solr_field.field) ||
-      (document.has_highlight_field? solr_field.field if solr_field.highlight) ||
-      solr_field.accessor
+    should_render_field?(solr_field, document) && document_has_value?(document, solr_field)
   end
 
   ##
@@ -146,9 +144,19 @@ module Blacklight::BlacklightHelperBehavior
   # @param [Blacklight::Solr::Configuration::SolrField] solr_field
   # @return [Boolean]
   def should_render_show_field? document, solr_field
-    document.has?(solr_field.field) ||
-      (document.has_highlight_field? solr_field.field if solr_field.highlight) ||
-      solr_field.accessor
+    should_render_field?(solr_field, document) && document_has_value?(document, solr_field)
+  end
+  
+  ##
+  # Check if a document has (or, might have, in the case of accessor methods) a value for
+  # the given solr field
+  # @param [SolrDocument] document
+  # @param [Blacklight::Solr::Configuration::SolrField] solr_field
+  # @return [Boolean]
+  def document_has_value? document, field_config
+    document.has?(field_config.field) ||
+      (document.has_highlight_field? field_config.field if field_config.highlight) ||
+      field_config.accessor
   end
 
   ##

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -60,22 +60,7 @@ module Blacklight::FacetsHelperBehavior
   def should_render_facet? display_facet
     # display when show is nil or true
     facet_config = facet_configuration_for_field(display_facet.name)
-
-    display = case facet_config.show
-    when Symbol
-      arity = method(facet_config.show).arity
-
-      if arity == 0
-        send(facet_config.show)
-      else 
-        send(facet_config.show, display_facet)
-      end
-    when Proc
-      facet_config.show.call self, facet_config, display_facet
-    else
-      facet_config.show
-    end
-
+    display = should_render_field?(facet_config, display_facet)
     return display && display_facet.items.present?
   end
 

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -5,9 +5,9 @@
   </button>
 
   <ul class="dropdown-menu">
-        <%- blacklight_config.sort_fields.each do |sort_key, field| %>
-          <li><%= link_to(field.label, url_for(params_for_search(:sort => sort_key))) %></li>
-        <%- end -%>
+      <%- blacklight_config.sort_fields.select { |sort_key, field_config| evaluate_configuration_conditional(field_config) }.each do |sort_key, field_config| %>
+        <li><%= link_to(field_config.label, url_for(params_for_search(:sort => sort_key))) %></li>
+      <%- end -%>
   </ul>
 </div>
 <% end %>

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -10,9 +10,9 @@ module Blacklight
 
       self.collapse = true if self.collapse.nil?
       self.show = true if self.show.nil?
+      self.if ||= self.show
 
       super
     end
   end
 end
-

--- a/lib/blacklight/configuration/search_field.rb
+++ b/lib/blacklight/configuration/search_field.rb
@@ -1,5 +1,5 @@
 module Blacklight
-  class Configuration::SearchField < OpenStructWithHashAccess
+  class Configuration::SearchField < Blacklight::Configuration::SolrField
     def normalize! blacklight_config = nil
       # Some normalization, calculate display_label from key,
       # and make sure we have a qt from defaults.             
@@ -7,6 +7,8 @@ module Blacklight
       self.field ||= self.key
       self.label ||= self.key.try(:titlecase)
       self.qt ||= blacklight_config.default_solr_params[:qt] if blacklight_config && blacklight_config.default_solr_params
+      self.if ||= self.include_in_simple_select
+      super
     end
 
     def validate!
@@ -14,4 +16,3 @@ module Blacklight
     end
   end
 end
-

--- a/lib/blacklight/configuration/solr_field.rb
+++ b/lib/blacklight/configuration/solr_field.rb
@@ -2,6 +2,8 @@ module Blacklight
   class Configuration::SolrField < OpenStructWithHashAccess
     def normalize! blacklight_config = nil
       self.label ||= default_label
+      self.if = true if self.if.nil?
+      self.unless = false if self.unless.nil?
       self
     end
   
@@ -18,4 +20,3 @@ module Blacklight
     end
   end
 end
-

--- a/lib/blacklight/configuration/sort_field.rb
+++ b/lib/blacklight/configuration/sort_field.rb
@@ -1,5 +1,5 @@
 module Blacklight
-  class Configuration::SortField < OpenStructWithHashAccess
+  class Configuration::SortField < Blacklight::Configuration::SolrField
     def normalize! blacklight_config = nil
       self.sort ||= self.field
 
@@ -8,6 +8,7 @@ module Blacklight
       self.field ||= self.sort
 
       self.key ||= self.field
+      super
     end
 
     def validate!

--- a/lib/blacklight/search_fields.rb
+++ b/lib/blacklight/search_fields.rb
@@ -38,15 +38,6 @@ module Blacklight::SearchFields
     blacklight_config.search_fields.values
   end
 
-  # Returns suitable argument to options_for_select method, to create
-  # an html select based on #search_field_list. Skips search_fields
-  # marked :include_in_simple_select => false
-  def search_field_options_for_select
-    blacklight_config.search_fields.collect do |key, field_def|
-      [field_def.label,  field_def.key] unless field_def.include_in_simple_select == false
-    end.compact
-  end
-
   # Looks up a search field blacklight_config hash from search_field_list having
   # a certain supplied :key. 
   def search_field_def_for_key(key)

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -136,6 +136,48 @@ describe BlacklightHelper do
       end
     end
   end
+  
+  describe "#should_render_index_field?" do
+    before do
+      helper.stub(should_render_field?: true, document_has_value?: true)
+    end
+    
+    it "should be true" do
+      expect(helper.should_render_index_field?(double, double)).to be_true
+    end
+    
+    it "should be false if the document doesn't have a value for the field" do
+      helper.stub(document_has_value?: false)
+      expect(helper.should_render_index_field?(double, double)).to be_false
+      
+    end
+    
+    it "should be false if the configuration has the field disabled" do
+      helper.stub(should_render_field?: false)
+      expect(helper.should_render_index_field?(double, double)).to be_false
+    end
+  end
+
+  describe "#should_render_show_field?" do
+    before do
+      helper.stub(should_render_field?: true, document_has_value?: true)
+    end
+    
+    it "should be true" do
+      expect(helper.should_render_show_field?(double, double)).to be_true
+    end
+    
+    it "should be false if the document doesn't have a value for the field" do
+      helper.stub(document_has_value?: false)
+      expect(helper.should_render_show_field?(double, double)).to be_false
+      
+    end
+    
+    it "should be false if the configuration has the field disabled" do
+      helper.stub(should_render_field?: false)
+      expect(helper.should_render_show_field?(double, double)).to be_false
+    end
+  end
 
   describe "render_index_field_value" do
     before do
@@ -336,13 +378,13 @@ describe BlacklightHelper do
       expect(value).to eq "123"
     end
   end
-
-  describe "#should_render_index_field?" do
+  
+  describe "#document_has_value?" do
     it "should if the document has the field value" do
       doc = double()
       doc.stub(:has?).with('asdf').and_return(true)
       field_config = double(:field => 'asdf')
-      helper.should_render_index_field?(doc, field_config).should == true
+      helper.document_has_value?(doc, field_config).should == true
     end
 
     it "should if the document has a highlight field value" do
@@ -350,7 +392,7 @@ describe BlacklightHelper do
       doc.stub(:has?).with('asdf').and_return(false)
       doc.stub(:has_highlight_field?).with('asdf').and_return(true)
       field_config = double(:field => 'asdf', :highlight => true)
-      helper.should_render_index_field?(doc, field_config).should == true
+      helper.document_has_value?(doc, field_config).should == true
     end
 
     it "should if the field has a model accessor" do
@@ -358,32 +400,7 @@ describe BlacklightHelper do
       doc.stub(:has?).with('asdf').and_return(false)
       doc.stub(:has_highlight_field?).with('asdf').and_return(false)
       field_config = double(:field => 'asdf', :highlight => true, :accessor => true)
-      helper.should_render_index_field?(doc, field_config).should == true
-    end
-  end
-
-  describe "#should_render_show_field?" do
-    it "should if the document has the field value" do
-      doc = double()
-      doc.stub(:has?).with('asdf').and_return(true)
-      field_config = double(:field => 'asdf')
-      expect(helper.should_render_show_field?(doc, field_config)).to be_true
-    end
-
-    it "should if the document has a highlight field value" do
-      doc = double()
-      doc.stub(:has?).with('asdf').and_return(false)
-      doc.stub(:has_highlight_field?).with('asdf').and_return(true)
-      field_config = double(:field => 'asdf', :highlight => true)
-      expect(helper.should_render_show_field?(doc, field_config)).to be_true
-    end
-
-    it "should if the field has a model accessor" do
-      doc = double()
-      doc.stub(:has?).with('asdf').and_return(false)
-      doc.stub(:has_highlight_field?).with('asdf').and_return(false)
-      field_config = double(:field => 'asdf', :highlight => true, :accessor => true)
-      helper.should_render_show_field?(doc, field_config).should == true
+      helper.document_has_value?(doc, field_config).should == true
     end
   end
 

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -65,7 +65,7 @@ describe FacetsHelper do
 
     it "should call a helper to determine if it should render a field" do
       a = double(:items => [1,2], :name=>'helper_with_an_arg_show')
-      helper.should_receive(:my_helper_with_an_arg).with(a).and_return(true)
+      helper.should_receive(:my_helper_with_an_arg).with(@config.facet_fields['helper_with_an_arg_show'], a).and_return(true)
       expect(helper.should_render_facet?(a)).to be_true
     end
 

--- a/spec/lib/blacklight/search_fields_spec.rb
+++ b/spec/lib/blacklight/search_fields_spec.rb
@@ -32,28 +32,6 @@ describe Blacklight::SearchFields do
   it "should fill in default qt where needed" do
     expect(@search_field_obj.search_field_def_for_key("all_fields").qt).to eq @config.default_solr_params[:qt]
   end
-  
-  it "should return proper options_for_select arguments" do
-
-    select_arguments = @search_field_obj.search_field_options_for_select
-
-    select_arguments.each_index do |index|
-       argument = select_arguments[index]
-       config_hash = @search_field_obj.search_field_list[index]
-
-       expect(argument).to have(2).items
-       expect(argument[0]).to eq config_hash.label
-       expect(argument[1]).to eq config_hash.key
-    end    
-  end
-
-  it "should not include fields in select if :display_in_simple_search=>false" do
-    select_arguments = @search_field_obj.search_field_options_for_select
-
-    expect(select_arguments).not_to include(["No Display", "no_display"])
-  end
-
-  
 
   it "should lookup field definitions by key" do
     expect(@search_field_obj.search_field_def_for_key("title").key).to eq "title"


### PR DESCRIPTION
sort, search, facets).

Solr fields support :if and :unless configuration, e.g.

``` ruby
  config.add_index_field if: false
  config.add_index_field if: :some_helper_method
  config.add_index_field if: lambda { |solr_field, document| false }
  config.add_index_field unless: true
```
