### PR TITLE
Extract explicit SolrDocument class references to make the model class configurable

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -205,4 +205,9 @@ module Blacklight::CatalogHelperBehavior
   def default_view_type_group_icon_classes view
     "glyphicon-#{view.to_s.parameterize } view-icon-#{view.to_s.parameterize}"
   end
+  
+  def current_bookmarks response = nil
+    response ||= @response
+    @current_bookmarks ||= current_or_guest_user.bookmarks_for_documents(response.documents).to_a
+  end
 end

--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -113,7 +113,7 @@ module Blacklight::ConfigurationHelperBehavior
 
   # Used in the document list partial (search view) for creating a link to the document show action
   def document_show_link_field document=nil
-    blacklight_config.view_config(document_index_view_type).title_field.to_sym
+    blacklight_config.view_config(document_index_view_type).title_field.try(:to_sym) || document.id
   end
 
   ##

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,13 +1,22 @@
 # -*- encoding : utf-8 -*-
 class Bookmark < ActiveRecord::Base
   
-  belongs_to :user
-  validates_presence_of :user_id, :scope=>:document_id
-  attr_accessible :id, :document_id, :title if Rails::VERSION::MAJOR < 4
+  belongs_to :user, polymorphic: true
+  belongs_to :document, polymorphic: true
 
+  validates_presence_of :user_id, :scope=>:document_id
+  attr_accessible :id, :document_id, :document_type, :title if Rails::VERSION::MAJOR < 4
 
   def document
-    SolrDocument.new SolrDocument.unique_key => document_id
+    document_type.new document_type.unique_key => document_id
+  end
+  
+  def document_type
+    (super.constantize if defined?(super)) || default_document_type
+  end
+  
+  def default_document_type
+    SolrDocument
   end
   
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,0 +1,5 @@
+class SolrDocument
+
+  include Blacklight::Solr::Document
+
+end

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -3,8 +3,8 @@
   # Note these two forms are pretty similar but for different :methods, classes, and labels. 
   # but it was simpler to leave them seperate instead of DRYing them, got confusing trying that.
   # the data-doc-id attribute is used by our JS that converts to a checkbox/label.
-  -%>  
-  <% unless current_or_guest_user.document_is_bookmarked? document.id %>  
+  -%>
+  <% if current_bookmarks.find { |x| x.document_id == document.id and x.document_type == document.class }.blank? %>  
 
       <%= form_tag( bookmark_path( document ), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>   
         <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_add") %>

--- a/db/migrate/20140320000000_add_polymorphic_type_to_bookmarks.rb
+++ b/db/migrate/20140320000000_add_polymorphic_type_to_bookmarks.rb
@@ -1,0 +1,8 @@
+# -*- encoding : utf-8 -*-
+class AddPolymorphicTypeToBookmarks < ActiveRecord::Migration
+  def change
+    add_column(:bookmarks, :document_type, :string)
+    
+    add_index :bookmarks, :user_id
+  end
+end

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -38,7 +38,7 @@ module Blacklight::Catalog
     
     # get single document from the solr index
     def show
-      @response, @document = get_solr_response_for_doc_id    
+      @response, @document = get_solr_response_for_doc_id   
 
       respond_to do |format|
         format.html {setup_next_and_previous_documents}
@@ -103,7 +103,7 @@ module Blacklight::Catalog
     
     # citation action
     def citation
-      @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
+      @response, @documents = get_solr_response_for_document_ids(params[:id])
       respond_to do |format|
         format.html
         format.js { render :layout => false }
@@ -113,7 +113,7 @@ module Blacklight::Catalog
     
     # Email Action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
     def email
-      @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
+      @response, @documents = get_solr_response_for_document_ids(params[:id])
       
       if request.post? and validate_email_params
         email = RecordMailer.email_record(@documents, {:to => params[:to], :message => params[:message]}, url_options)
@@ -136,7 +136,7 @@ module Blacklight::Catalog
     
     # SMS action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
     def sms 
-      @response, @documents = get_solr_response_for_field_values(SolrDocument.unique_key,params[:id])
+      @response, @documents = get_solr_response_for_document_ids(params[:id])
       
       if request.post? and validate_sms_params
         to = "#{params[:to].gsub(/[^\d]/, '')}@#{sms_mappings[params[:carrier]]}"

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -1,3 +1,5 @@
+require 'solr_document'
+
 module Blacklight
   ##
   # Blacklight::Configuration holds the configuration for a Blacklight::Controller, including
@@ -18,8 +20,6 @@ module Blacklight
     class << self
       def default_values
         @default_values ||= begin
-          unique_key = ((SolrDocument.unique_key if defined?(SolrDocument)) || 'id')
-
           {
           # HTTP method to use when making requests to solr; valid
           # values are :get and :post.
@@ -30,6 +30,7 @@ module Blacklight
           :solr_path => 'select',
           # Default values of parameters to send with every search request
           :default_solr_params => {},
+          :solr_document_model => SolrDocument,
           # The solr rqeuest handler to use when requesting only a single document 
           :document_solr_request_handler => 'document',
           # THe path to send single document requests to solr
@@ -50,7 +51,7 @@ module Blacklight
           # General configuration for all views
           :index => ViewConfig::Index.new(
             # solr field to use to render a document title
-            :title_field => unique_key,
+            :title_field => nil,
             # solr field to use to render format-specific partials
             :display_type_field => 'format',
             # partials to render for each document(see #render_document_partials)
@@ -159,6 +160,10 @@ module Blacklight
       field ||= sort_fields.values.first
 
       field
+    end
+    
+    def default_title_field
+      solr_document_model.unique_key || 'id'
     end
 
     ##

--- a/lib/blacklight/solr/document.rb
+++ b/lib/blacklight/solr/document.rb
@@ -151,7 +151,14 @@ module Blacklight::Solr::Document
     return @semantic_value_hash
   end
   
+  def destroyed?
+    false
+  end
   
+  def new_record?
+    false
+  end
+
   # Certain class-level methods needed for the document-specific
   # extendability architecture
   module ClassMethods
@@ -159,6 +166,14 @@ module Blacklight::Solr::Document
     attr_writer :unique_key
     def unique_key
       @unique_key ||= 'id' 
+    end
+    
+    def primary_key
+      'id'
+    end
+    
+    def base_class
+      self
     end
 
     # Returns array of hashes of registered extensions. Each hash

--- a/lib/blacklight/solr_response/response.rb
+++ b/lib/blacklight/solr_response/response.rb
@@ -1,0 +1,18 @@
+module Blacklight::SolrResponse::Response
+  def response
+    self[:response] || {}
+  end
+  
+  # short cut to response['numFound']
+  def total
+    response[:numFound].to_s.to_i
+  end
+  
+  def start
+    response[:start].to_s.to_i
+  end
+
+  def empty?
+    total == 0
+  end
+end

--- a/lib/blacklight/user.rb
+++ b/lib/blacklight/user.rb
@@ -1,5 +1,8 @@
 # -*- encoding : utf-8 -*-
 module Blacklight::User
+  
+  extend Deprecation
+  self.deprecation_horizon = 'blacklight 6.0'
 
   # This gives us an is_blacklight_user method that can be included in
   # the containing applications models. 
@@ -12,17 +15,27 @@ module Blacklight::User
     end
   end
 
+  def bookmarks_for_documents documents = []
+    if documents.length > 0
+      bookmarks.where(document_type: documents.first.class.base_class, document_id: documents.map { |x| x.id})
+    else
+      []
+    end
+  end
+
   def bookmarked_document_ids
+    Deprecation.warn self, "The User#bookmarked_document_ids method is deprecated and will be removed in Blacklight 6.0"
+
     self.bookmarks.pluck(:document_id)
   end
 
-  def document_is_bookmarked?(document_id)
-    bookmarked_document_ids.include? document_id.to_s
+  def document_is_bookmarked?(document)
+    bookmarks_for_documents([document]).any?
   end
     
   # returns a Bookmark object if there is one for document_id, else
   # nil. 
-  def existing_bookmark_for(document_id)
-    self.bookmarks.where(:document_id => document_id).first
+  def existing_bookmark_for(document)
+    bookmarks_for_documents([document]).first
   end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -14,6 +14,7 @@ describe BookmarksController do
     it "has a 500 status code when fails is success" do
       @controller.stub_chain(:current_or_guest_user, :existing_bookmark_for).and_return(false)
       @controller.stub_chain(:current_or_guest_user, :persisted?).and_return(true)
+      @controller.stub_chain(:current_or_guest_user, :bookmarks, :where, :exists?).and_return(false)  
       @controller.stub_chain(:current_or_guest_user, :bookmarks, :create).and_return(false)  
       xhr :put, :update, :id => 'iamabooboo', :format => :js
       expect(response.code).to eq "500"
@@ -21,6 +22,11 @@ describe BookmarksController do
   end
   
   describe "delete" do
+    before do
+      @controller.send(:current_or_guest_user).save
+      @controller.send(:current_or_guest_user).bookmarks.create! document_id: '2007020969', document_type: "SolrDocument"
+    end
+    
     it "has a 204 status code when delete is success" do
       xhr :delete, :destroy, :id => '2007020969', :format => :js
       expect(response).to be_success
@@ -30,7 +36,7 @@ describe BookmarksController do
    it "has a 500 status code when delete is not success" do
       bm = double(Bookmark)
       @controller.stub_chain(:current_or_guest_user, :existing_bookmark_for).and_return(bm)
-      @controller.stub_chain(:current_or_guest_user, :bookmarks, :delete).and_return(false)
+      @controller.stub_chain(:current_or_guest_user, :bookmarks, :where, :first).and_return(double('bookmark', delete: nil, destroyed?: false)) 
      
       xhr :delete, :destroy, :id => 'pleasekillme', :format => :js
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -303,7 +303,7 @@ describe CatalogController do
     describe "@document" do
       before do
         @mock_response = double()
-        @mock_response.stub(:docs => [{ :id => 'my_fake_doc' }])
+        @mock_response.stub(documents: [SolrDocument.new(id: 'my_fake_doc')])
         @mock_document = double()
         controller.stub(:find => @mock_response )
       end
@@ -327,6 +327,7 @@ describe CatalogController do
           "mock_export"
         end
       end
+      
       before do
         @mock_response = double()
         @mock_response.stub(:docs => [{ :id => 'my_fake_doc' }])
@@ -334,7 +335,7 @@ describe CatalogController do
         controller.stub(find: @mock_response)
       end
 
-       before(:each) do
+      before(:each) do
 
         # Rails3 needs this to propertly setup a new mime type and
         # render the results. 
@@ -346,8 +347,19 @@ describe CatalogController do
         SolrDocument.use_extension(FakeExtension)
       end
       
+      before do
+        @mock_response = double()
+        @mock_response.stub(:documents => [SolrDocument.new(id: 'my_fake_doc')])
+        @mock_document = double()
+        controller.stub(:find => @mock_response, 
+                        :get_single_doc_via_search => @mock_document)
+
+        controller.stub(:find => @mock_response, 
+                        :get_single_doc_via_search => @mock_document)
+      end
+
       it "should respond to an extension-registered format properly" do
-        get :show, :id => doc_id, :format => "mock" # This no longer works: :format => "mock"
+        get :show, :id => doc_id, :format => "mock"
         expect(response).to be_success
         expect(response.body).to match /mock_export/
       end
@@ -365,7 +377,7 @@ describe CatalogController do
     before do
       @mock_response = double()
       @mock_document = double()
-      @mock_response.stub(:docs => [{ :id => 'my_fake_doc' }, { :id => 'my_other_doc'}])
+      @mock_response.stub(documents:  [SolrDocument.new(id: 'my_fake_doc'), SolrDocument.new(id: 'my_other_doc')])
       @mock_document = double()
       controller.stub(find: @mock_response)
                       
@@ -382,7 +394,7 @@ describe CatalogController do
 
   describe "email/sms" do
     doc_id = '2007020969'
-    let(:mock_response) { double(docs: [{ :id => 'my_fake_doc' }, { :id => 'my_other_doc'}]) }
+    let(:mock_response) { double(documents: [SolrDocument.new(id: 'my_fake_doc'), SolrDocument.new(id: 'my_other_doc')]) }
     before do
       controller.stub(find: mock_response)
       request.env["HTTP_REFERER"] = "/catalog/#{doc_id}"
@@ -456,15 +468,15 @@ describe CatalogController do
 
   describe "errors" do
     it "should return status 404 for a record that doesn't exist" do
-      @mock_response = double(docs: [])
-      controller.stub(find: @mock_response)
+      @mock_response = double(documents: [])
+      controller.stub(:find => @mock_response)
       get :show, :id=>"987654321"
       expect(response.status).to eq 404
       expect(response.content_type).to eq Mime::HTML
     end
     it "should return status 404 for a record that doesn't exist even for non-html format" do
-      @mock_response = double(docs: [])
-      controller.stub(find: @mock_response)
+      @mock_response = double(documents: [])
+      controller.stub(:find => @mock_response)
 
       get :show, :id=>"987654321", :format => "xml"
       expect(response.status).to eq 404

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -122,6 +122,7 @@ describe BlacklightHelper do
       helper.stub(:blacklight_config).and_return(@config)
       helper.stub(:has_user_authentication_provider?).and_return(true)
       helper.stub(:current_or_guest_user).and_return(User.new)
+      helper.stub(current_bookmarks: [])
     end
     describe "render_index_doc_actions" do
       it "should render partials" do

--- a/spec/lib/blacklight/configuration_spec.rb
+++ b/spec/lib/blacklight/configuration_spec.rb
@@ -39,11 +39,6 @@ describe "Blacklight::Configuration" do
       expect(@config.index).to be_a_kind_of OpenStruct
     end
 
-    it "should introspect SolrDocument for sensible defaults  for show + index" do
-      expect(@config.view_config(:show).title_field).to eq 'id'
-      expect(@config.index.title_field).to eq 'id'
-    end
-
     it "should have ordered hashes for field configuration" do
       expect(@config.facet_fields).to be_a_kind_of ActiveSupport::OrderedHash
       expect(@config.index_fields).to be_a_kind_of ActiveSupport::OrderedHash

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -1049,7 +1049,6 @@ describe Blacklight::SolrHelper do
       expect(@document.id).to eq @doc_id
     end
     it 'should have non-nil values for required fields set in initializer' do
-      expect(@document.get(blacklight_config.view_config(:show).title_field)).not_to be_nil
       expect(@document.get(blacklight_config.view_config(:show).display_type_field)).not_to be_nil
     end
   end
@@ -1129,7 +1128,6 @@ describe Blacklight::SolrHelper do
     end
 
     it 'should have non-nil values for required fields set in initializer' do
-      expect(@doc[blacklight_config.view_config(:show).title_field]).not_to be_nil
       expect(@doc[blacklight_config.view_config(:show).display_type_field]).not_to be_nil
     end
 
@@ -1250,7 +1248,7 @@ describe Blacklight::SolrHelper do
     describe "#get_solr_response_for_field_values" do
       before do
         @mock_response = double()
-        @mock_response.stub(:docs => [])
+        @mock_response.stub(documents: [])
       end
       it "should contruct a solr query based on the field and value pair" do
         subject.should_receive(:find).with(hash_including(:q => "field_name:(value)")).and_return(@mock_response)

--- a/spec/lib/blacklight/user_spec.rb
+++ b/spec/lib/blacklight/user_spec.rb
@@ -5,12 +5,46 @@ describe "Blacklight::User" do
   subject { User.create! :email => 'xyz@example.com', :password => 'xyz12345' }
 
   def mock_bookmark document_id
-    Bookmark.new :document_id => document_id
+    Bookmark.new document_id: document_id, document_type: SolrDocument.to_s
+  end
+  
+  describe "#bookmarks_for_documents" do
+    before do
+      subject.bookmarks << mock_bookmark(1)
+      subject.bookmarks << mock_bookmark(2)
+      subject.bookmarks << mock_bookmark(3)
+    end
+    
+    it "should return all the bookmarks that match the given documents" do
+      bookmarks = subject.bookmarks_for_documents([SolrDocument.new(id: 1), SolrDocument.new(id: 2)])
+      expect(bookmarks).to have(2).items
+      expect(bookmarks.first.document_id).to eq "1"
+      expect(bookmarks.last.document_id).to eq "2"
+    end
+  end
+  
+  describe "#document_is_bookmarked?" do
+    before do
+      subject.bookmarks << mock_bookmark(1)
+    end
+    
+    it "should  be true if the document is bookmarked" do
+      expect(subject).to be_document_is_bookmarked(SolrDocument.new(id: 1))
+    end
+
+    it "should be false if the document is not bookmarked" do
+      expect(subject).to_not be_document_is_bookmarked(SolrDocument.new(id: 2))
+    end
   end
 
-  it "should know if it has a bookmarked document" do
-    subject.bookmarks << mock_bookmark(1)
-    expect(subject.document_is_bookmarked?(1)).to be_true
+  describe "#existing_bookmark_for" do
+    before do
+      subject.bookmarks << mock_bookmark(1)
+    end
+    
+    it "should return the bookmark for that document id" do
+      expect(subject.existing_bookmark_for(SolrDocument.new(id: 1))).to eq subject.bookmarks.first
+    end
   end
 
 end    

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,20 +1,15 @@
-# -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
 describe Bookmark do
-  before(:each) do
-    @bookmark = Bookmark.new
+  subject do
+    b = Bookmark.new 
+    b.user_id = 1
+    b.document = SolrDocument.new(id: 'u001')
+    b
   end
   
   it "should be valid" do
-    @bookmark.id = 1
-    @bookmark.user_id = 1
-    @bookmark.document_id = 'u001'
-    expect(@bookmark).to be_valid
-  end
-   
-  it "should require user_id" do
-    expect(@bookmark).to have(1).error_on(:user_id)
+    expect(subject).to be_valid
   end
 
   it "should belong to user" do
@@ -22,10 +17,20 @@ describe Bookmark do
   end
 
   it "should be valid after saving" do
-    @bookmark.id = 1
-    @bookmark.user_id = 1
-    @bookmark.document_id = 'u001'
-    @bookmark.save
-    expect(@bookmark).to be_valid
+    subject.save
+    expect(subject).to be_valid
+  end
+  
+  describe "#document_type" do
+    it "should be the class of the solr document" do
+      expect(subject.document_type).to eq SolrDocument
+    end
+  end
+  
+  describe "#document" do
+    it "should be a SolrDocument with just an id field" do
+      expect(subject.document).to be_a_kind_of SolrDocument
+      expect(subject.document.id).to eq 'u001'
+    end
   end
 end


### PR DESCRIPTION
Fixes #837 
