### PR TITLE
Deprecate SolrHelper#get_facet_pagination

### DIFF
--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -46,6 +46,7 @@
 
 module Blacklight::SolrHelper
   extend ActiveSupport::Concern
+  extend Deprecation
   include Blacklight::SearchFields
   include Blacklight::Facet
   include ActiveSupport::Benchmarkable
@@ -266,6 +267,7 @@ module Blacklight::SolrHelper
       :sort => response.params[:"f.#{facet_field}.facet.sort"] || response.params["facet.sort"]
     )
   end
+  deprecation_deprecate :get_facet_pagination
   
   # a solr query method
   # this is used when selecting a search result: we have a query and a 

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -706,8 +706,10 @@ describe Blacklight::SolrHelper do
   end
   
    describe "get_facet_pagination", :integration => true do
-    before(:each) do
-      @facet_paginator = subject.get_facet_pagination(@facet_field)
+    before do
+      Deprecation.silence(Blacklight::SolrHelper) do
+        @facet_paginator = subject.get_facet_pagination(@facet_field)
+      end
     end
     it 'should return a facet paginator' do
       expect(@facet_paginator).to be_a_kind_of(Blacklight::Solr::FacetPaginator)


### PR DESCRIPTION
This was replaced by `#get_facet_field_response` in 5.x, and constructing the Blacklight::FacetPaginator "model" is now the responsibility of the controller.
