### PR TITLE
re-unify bookmark#index and bookmark#export

### DIFF
--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -5,10 +5,7 @@ module BookmarksHelper
   # user's bookmarks in 'refworks marc txt' format -- we tell refworks
   # to expect that format. 
   def bookmarks_refworks_export_url(user_id = current_or_guest_user.id)
-    callback_url =  export_bookmarks_callback_url(
-                  encrypt_user_id(current_or_guest_user.id),
-                  :refworks_marc_txt, 
-                  params_for_search )
+    callback_url =  bookmarks_url(params_for_search.merge(format: :refworks_marc_txt, encrypted_user_id: encrypt_user_id(current_or_guest_user.id) ))
 
     "http://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(application_name)}&filter=MARC%20Format&encoding=65001&url=#{CGI.escape(callback_url)}"
   end

--- a/lib/blacklight/routes.rb
+++ b/lib/blacklight/routes.rb
@@ -61,7 +61,6 @@ module Blacklight
       def bookmarks(_)
         add_routes do |options|
           delete "bookmarks/clear", :to => "bookmarks#clear", :as => "clear_bookmarks"
-          get "bookmarks/export/:encrypted_user_id", :to => "bookmarks#export", :as => "export_bookmarks_callback"
           resources :bookmarks
         end
       end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -32,7 +32,7 @@ describe BookmarksController do
     end
   end
 
-  describe "export" do
+  describe ".refworks format" do
     render_views
 
     before(:all) do
@@ -52,7 +52,7 @@ describe BookmarksController do
         
         User.should_receive(:find).with(user_id).and_return(@user_with_3)
 
-        get :export, :format => :refworks_marc_txt, :encrypted_user_id => encrypted_user_id
+        get :index, :format => :refworks_marc_txt, :encrypted_user_id => encrypted_user_id
 
         expect(response.code).to eq "200"
         # For some reason having trouble getting actual doc.export_as(:refworks_marc_txt)


### PR DESCRIPTION
It's not clear to me what adding the `#export` action has over the changes I propose here. At the very least, this patch should make it easier for downstream applications or other plugins to add other types of token-based exports.
