### PR TITLE
add #document_index_views for retrieving the available catalog#index views, and support if/unless constraints as part of the view configuration

### DIFF
--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -2,7 +2,7 @@
 <div class="view-type">
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
-    <%  blacklight_config.view.keys.each do |view| %>
+    <%  document_index_views.each do |view, config| %>
     <%= link_to url_for(params.merge(:view => view)), :title => t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), :class => "btn btn-default view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
       <%= render_view_type_group_icon view %>
         <span class="caption"><%= t("blacklight.search.view.#{view}") %></span>

--- a/spec/helpers/configuration_helper_spec.rb
+++ b/spec/helpers/configuration_helper_spec.rb
@@ -30,9 +30,31 @@ describe BlacklightConfigurationHelper do
   end
 
   describe "#default_document_index_view_type" do
-    it "should be the first configured index view" do
-      blacklight_config.stub(view: { 'a' => true, 'b' => true})
-      expect(helper.default_document_index_view_type).to eq 'a'
+    it "should use the first view with default set to true" do
+      blacklight_config.view.a
+      blacklight_config.view.b
+      blacklight_config.view.b.default = true
+      expect(helper.default_document_index_view_type).to eq :b
+    end
+    
+    it "should default to the first configured index view" do
+      blacklight_config.stub(view: { a: true, b: true})
+      expect(helper.default_document_index_view_type).to eq :a
+    end
+  end
+  
+  describe "#document_index_views" do
+    before do
+      blacklight_config.view.abc = false
+      blacklight_config.view.def.if = false
+      blacklight_config.view.xyz.unless = true
+    end
+
+    it "should filter views using :if/:unless configuration" do
+      helper.document_index_views.should have_key :list
+      helper.document_index_views.should_not have_key :abc
+      helper.document_index_views.should_not have_key :def
+      helper.document_index_views.should_not have_key :xyz
     end
   end
 


### PR DESCRIPTION
ref sul-dlss/spotlight#581 : after this change, spotlight can be less destructive when applying exhibit-specific configurations.
