### PR TITLE
Delay requiring solr_document until we're actually loading an instance of Configuration

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -1,5 +1,3 @@
-require 'solr_document'
-
 module Blacklight
   ##
   # Blacklight::Configuration holds the configuration for a Blacklight::Controller, including
@@ -19,6 +17,7 @@ module Blacklight
     # the basic, required Blacklight fields
     class << self
       def default_values
+
         @default_values ||= begin
           {
           # HTTP method to use when making requests to solr; valid
@@ -30,7 +29,8 @@ module Blacklight
           :solr_path => 'select',
           # Default values of parameters to send with every search request
           :default_solr_params => {},
-          :solr_document_model => SolrDocument,
+          # the model to load solr response documents into; set below in #initialize_default_values
+          :solr_document_model => nil,
           # The solr rqeuest handler to use when requesting only a single document 
           :document_solr_request_handler => 'document',
           # THe path to send single document requests to solr
@@ -131,6 +131,10 @@ module Blacklight
       Marshal.load(Marshal.dump(self.class.default_values)).each do |k, v|
         self[k] ||=  v
       end
+    end
+    
+    def solr_document_model
+      self[:solr_document_model] || SolrDocument
     end
 
     ##


### PR DESCRIPTION
I was trying to update Spotlight to use blacklight master and got a bunch of weird initialization errors, e.g.:

```
/Volumes/TempStorage/Projects/spotlight/spec/internal/config/initializers/friendly_id.rb:12:in `<top (required)>': uninitialized constant FriendlyId (NameError)
    from /Users/cabeer/.rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.0.4/lib/rails/engine.rb:609:in `block (2 levels) in <class:Engine>'
    from /Users/cabeer/.rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.0.4/lib/rails/engine.rb:608:in `each'
    from /Users/cabeer/.rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.0.4/lib/rails/engine.rb:608:in `block in <class:Engine>'
```

I don't fully understand how the error I was seeing was related to this change, but it must be a runtime load error of some sort. 
