### PR TITLE
add #active_sort_fields helper to restrict configured sort fields to

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -11,7 +11,11 @@ module Blacklight::ConfigurationHelperBehavior
 
   # Used in the document_list partial (search view) for building a select element
   def sort_fields
-    blacklight_config.sort_fields.map { |key, x| [x.label, x.key] }
+    active_sort_fields.map { |key, x| [x.label, x.key] }
+  end
+  
+  def active_sort_fields
+    blacklight_config.sort_fields.select { |sort_key, field_config| should_render_field?(field_config) }
   end
 
   # Used in the search form partial for building a select tag
@@ -125,7 +129,7 @@ module Blacklight::ConfigurationHelperBehavior
   ##
   # Default sort field
   def default_sort_field
-    blacklight_config.sort_fields.first.last if blacklight_config.sort_fields.first
+    (active_sort_fields.select { |k,config| config.respond_to? :default and config.default }.first || active_sort_fields.first).try(:last)
   end
 
   ##

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,11 +1,11 @@
-<% if show_sort_and_per_page? and !blacklight_config.sort_fields.blank? %>
+<% if show_sort_and_per_page? and !active_sort_fields.blank? %>
 <div id="sort-dropdown" class="btn-group">
   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
       <%= link_to(t('blacklight.search.sort.label', :field =>current_sort_field.label), "#") %> <span class="caret"></span>
   </button>
 
   <ul class="dropdown-menu">
-      <%- blacklight_config.sort_fields.select { |sort_key, field_config| evaluate_configuration_conditional(field_config) }.each do |sort_key, field_config| %>
+      <%- active_sort_fields.each do |sort_key, field_config| %>
         <li><%= link_to(field_config.label, url_for(params_for_search(:sort => sort_key))) %></li>
       <%- end -%>
   </ul>

--- a/spec/helpers/configuration_helper_spec.rb
+++ b/spec/helpers/configuration_helper_spec.rb
@@ -17,8 +17,15 @@ describe BlacklightConfigurationHelper do
 
   describe "#sort_fields" do
     it "should convert the sort fields to select-ready values" do
-      blacklight_config.stub(sort_fields: { 'a' => double(key: 'a', label: 'a'), 'b' => double(key: 'b', label: 'b'),  })
+      blacklight_config.stub(sort_fields: { 'a' => double(key: 'a', label: 'a'), 'b' => double(key: 'b', label: 'b'), c: double(key: 'c', if: false)  })
       expect(helper.sort_fields).to eq [['a', 'a'], ['b', 'b']]
+    end
+  end
+
+  describe "#active_sort_fields" do
+    it "should restrict the configured sort fields to only those that should be displayed" do
+      blacklight_config.stub(sort_fields: { a: double(if: false, unless: false), b: double(if:true, unless: true) })
+      expect(helper.active_sort_fields).to be_empty
     end
   end
 
@@ -132,6 +139,18 @@ describe BlacklightConfigurationHelper do
     it "should be the first per-page value if a default isn't set" do
       helper.stub(blacklight_config: double(default_per_page: nil, per_page: [11, 22]))
       expect(helper.default_per_page).to eq 11
+    end
+  end
+  
+  describe "#default_sort_field" do
+    it "should be the configured default field" do
+      helper.stub(blacklight_config: double(sort_fields: { a: double(default: nil), b: double(key: 'b', default: true) }))
+      expect(helper.default_sort_field.key).to eq 'b'
+    end
+    
+    it "should be the first per-page value if a default isn't set" do
+      helper.stub(blacklight_config: double(sort_fields: { a: double(key: 'a', default: nil), b: double(key: 'b', default: nil) }))
+      expect(helper.default_sort_field.key).to eq 'a'
     end
   end
   


### PR DESCRIPTION
only those that should be displayed
