### PR TITLE
adds role="menu" to button dropdowns for keyboard accessibility

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -3,7 +3,7 @@
   <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
 <div id="per_page-dropdown" class="btn-group">
   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"><%= link_to(t(:'blacklight.search.per_page.button_label', :count => current_per_page), "#") %> <span class="caret"></span></button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>
       <li><%= link_to(label, url_for(params_for_search(:per_page => count))) %></li>
     <%- end -%>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -4,7 +4,7 @@
       <%= link_to(t('blacklight.search.sort.label', :field =>current_sort_field.label), "#") %> <span class="caret"></span>
   </button>
 
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu" role="menu">
       <%- active_sort_fields.each do |sort_key, field_config| %>
         <li><%= link_to(field_config.label, url_for(params_for_search(:sort => sort_key))) %></li>
       <%- end -%>


### PR DESCRIPTION
Per Jennifer Vine's comments about some accessibility issues in Blacklight. This patch enables down arrow to navigate search widget dropdown lists (sort-dropdown and per_page_dropdown).

http://www.w3.org/TR/wai-aria/roles#listbox
