### PR TITLE
DRY up default_sort_field lookup

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -129,7 +129,7 @@ module Blacklight::ConfigurationHelperBehavior
   ##
   # Default sort field
   def default_sort_field
-    (active_sort_fields.select { |k,config| config.respond_to? :default and config.default }.first || active_sort_fields.first).try(:last)
+    blacklight_config.default_sort_field
   end
 
   ##


### PR DESCRIPTION
Alternate implementations in helper method and config can create
weirdness if they don't match. Should just delegate to blacklight_config
implementation, which is what's used in most places.
