### PR TITLE
Ignore empty f[facet][] query param

### DIFF
--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -76,6 +76,7 @@ module Blacklight::RenderConstraintsHelperBehavior
     facet_config = facet_configuration_for_field(facet)
 
     safe_join(values.map do |val|
+      next if val.blank? # skip empty string
       render_constraint_element( blacklight_config.facet_fields[facet].label,
                   facet_display_value(facet, val),
                   :remove => search_action_path(remove_facet_params(facet, val, localized_params)),

--- a/lib/blacklight/request_builders.rb
+++ b/lib/blacklight/request_builders.rb
@@ -121,6 +121,7 @@ module Blacklight
         
         f_request_params.each_pair do |facet_field, value_list|
           Array(value_list).each do |value|
+            next if value.blank? # skip empty strings
             solr_parameters.append_filter_query facet_value_to_fq_string(facet_field, value)
           end              
         end      

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -29,4 +29,18 @@ describe RenderConstraintsHelper do
     end
   end
 
+  describe "#render_constraints_filters" do
+    before do
+      @config = Blacklight::Configuration.new do |config|
+        config.add_facet_field 'type'
+      end
+      helper.stub(:blacklight_config => @config)
+    end
+
+    it "should render nothing for empty facet limit param" do
+      rendered = helper.render_constraints_filters(:f=>{'type'=>['']})
+      expect(rendered).to be_blank
+    end
+  end
+
 end

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -191,6 +191,14 @@ describe Blacklight::SolrHelper do
       end
     end
 
+    describe "for an empty facet limit param" do
+      it "should not add any fq to solr" do
+        solr_params = subject.solr_search_params(:f => {"format" => [""]})
+
+        expect(solr_params[:fq]).to be_blank
+      end
+    end
+
     describe "with Multi Facets, No Query" do
       it 'should have fq set properly' do
         solr_params = subject.solr_search_params(:f => @multi_facets)


### PR DESCRIPTION
Previously this would result in a limit being applied
for a facet with an empty string value. I don't think this
is a real use case (it would be somewhat tricky to index
values in Solr this way even if you wanted to), and I
don't think this was intentional.

Seems better to ignore empty facet limit query params
like that, have them be no-ops that do not effect
the Solr query or the visible constraints. That's
what this does.

empty facet limit query params of course shouldn't happen
at all, and are probably mistakes, but could come from:
- a bug in some part of BL or plugin
- a bug in some external "deep link generating" tool
- user error manipulating the URL manually

I suggest it's better to have such a mistake be a no-op, then
to have it result in odd and disconcerting behavior as previous.

Previous behavior:
![empty facet query param](https://cloud.githubusercontent.com/assets/149304/3119018/28024252-e742-11e3-8591-c30f25f98200.png)
