### PR TITLE
check if show_sort_and_per_page? returns true before displaying content

### DIFF
--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -1,4 +1,4 @@
-<% if has_alternative_views? -%>
+<% if show_sort_and_per_page? and has_alternative_views? -%>
 <div class="view-type">
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">

--- a/spec/views/catalog/_view_type_group.html.erb_spec.rb
+++ b/spec/views/catalog/_view_type_group.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe "catalog/_view_type_group" do
 
   before do
     view.stub(blacklight_config: blacklight_config)
+    view.stub(:show_sort_and_per_page? => true)
   end
 
   it "should not display the group when there's only one option" do


### PR DESCRIPTION
Check if there are any results to display before rendering the view type widget content, as done in `app/views/catalog/_per_page_widget.html.erb` and `_sort_widget.html.erb`.
