### PR TITLE
allow results columns down to bootstrap  size

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,8 +1,8 @@
-<div id="sidebar" class="col-md-3">
+<div id="sidebar" class="col-md-3 col-sm-4">
   <%= render 'search_sidebar' %>
 </div>
 
-<div id="content" class="col-md-9">
+<div id="content" class="col-md-9 col-sm-8">
   <% unless has_search_parameters? %>
     <%# if there are no input/search related params, display the "home" partial -%>
     <%= render 'home' %>


### PR DESCRIPTION
Pull request for #888 per @jcoyne's suggested resolution
- Will match the breakpoint for facets collapsing behind a 'show' icon
- For expected typical content, seems to work fine at this size,
  with better functionality than collapsing to single-column
- will still collapse to single column below 'sm' size, the
  same point that facets collapse to be hidden behind a 'show' icon
