### PR TITLE
Use glyphicon sep between filter name and value

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -62,7 +62,10 @@ span.constraints-label {
   .filterName:after
   {
     @extend .text-muted;
-    content: "\276F";
+    font-family: 'Glyphicons Halflings';
+    /* glyphicon-chevron-right */
+    content: "\e080";
+    font-size: 70%;
     padding-left: $caret-width-base;
   }
 


### PR DESCRIPTION
Separator is added in CSS. Previously a unicode "heavy right-pointing
angle quotation mark ornament", but Windows Chrome and iOS Safari
were having trouble displaying that. Instead, use glphyicon
right chevron, at 70% size for reasonable display.

Ought to resolve #927, although I have no way to test on iOS Safari. Confirmed fix on Windows Chrome. 
