### PR TITLE
Removes the link from constraints text

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -56,6 +56,7 @@ span.constraints-label {
     &:hover, &:active {
       background-color: $btn-default-bg;
       border-color: $btn-default-border;
+      box-shadow: none;
     }
   }
 

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -1,34 +1,33 @@
-<%- # local params:
-    # label 
+<%  # local params:
+    # label
     # value
     # options =>
     #   :remove => url for a remove constraint link
     #   :classes => array of classes to add to container span
     options ||= {}
--%>
+%>
 
 <span class="btn-group appliedFilter constraint <%= options[:classes].join(" ") if options[:classes] %>">
-<a href="#" class="constraint-value btn btn-sm btn-default btn-disabled">
-      <%- unless label.blank? -%>
-        <span class="filterName"><%= label %></span> 
-      <%- end -%>
-      <%- unless value.blank? -%>
-        <span class="filterValue"><%= value %></span>
-      <%- end -%>          
-        </a>
+  <span class="constraint-value btn btn-sm btn-default btn-disabled">
+    <% unless label.blank? %>
+      <span class="filterName"><%= label %></span>
+    <% end %>
+    <% unless value.blank? %>
+      <span class="filterValue"><%= value %></span>
+    <% end %>
+  </span>
+  <% unless options[:remove].blank? %>
+    <% accessible_remove_label = content_tag :span, class: 'sr-only' do
+        if label.blank?
+          t('blacklight.search.filters.remove.value', value: value)
+        else
+          t('blacklight.search.filters.remove.label_value', label: label, value: value)
+        end
+      end
+    %>
 
-      <%- unless options[:remove].blank? -%>
-        <% accessible_remove_label = content_tag :span, :class => 'sr-only' do               
-                if label.blank?
-                  t('blacklight.search.filters.remove.value', :value => value)
-                else
-                  t('blacklight.search.filters.remove.label_value', :label => label, :value => value)
-                end 
-                end             
-        %>    
-
-        <%= link_to(content_tag(:span, '', :class => 'glyphicon glyphicon-remove') + accessible_remove_label,
-					options[:remove], :class => 'btn btn-default btn-sm remove dropdown-toggle'
-				) %>
-      <%- end -%>
+    <%= link_to(content_tag(:span, '', class: 'glyphicon glyphicon-remove') + accessible_remove_label,
+			options[:remove], class: 'btn btn-default btn-sm remove dropdown-toggle'
+		) %>
+  <%- end -%>
 </span>

--- a/spec/views/catalog/_constraints_element.html.erb_spec.rb
+++ b/spec/views/catalog/_constraints_element.html.erb_spec.rb
@@ -7,8 +7,10 @@ describe "catalog/_constraints_element.html.erb" do
     end
     it "should render label and value" do
       expect(rendered).to have_selector("span.appliedFilter.constraint") do |s|
+        expect(s).to have_css("span.constraint-value")
+        expect(s).to_not have_css("a.constraint-value")
         expect(s).to have_selector "span.filterName", :content => "my label"
-        expect(s).to have_selector "span.filterValue", :content => "my value" 
+        expect(s).to have_selector "span.filterValue", :content => "my value"
       end
     end
   end
@@ -20,7 +22,7 @@ describe "catalog/_constraints_element.html.erb" do
     it "should include remove link" do
       expect(rendered).to have_selector("span.appliedFilter") do |s|
         expect(s).to have_selector(".remove[href='http://remove']")
-      end    
+      end
     end
 
     it "should have an accessible remove label" do
@@ -37,7 +39,7 @@ describe "catalog/_constraints_element.html.erb" do
     it "should not include checkmark" do
       expect(rendered).to have_selector("span.appliedFilter") do |s|
         expect(s).to_not have_selector("img[src$='checkmark.gif']")
-      end   
+      end
     end
   end
 
@@ -60,6 +62,6 @@ describe "catalog/_constraints_element.html.erb" do
     end
 
   end
- 
+
 
 end


### PR DESCRIPTION
Fixes #938 

This PR rewrites the `_constraints_element.html.erb` partial and removes the anchor element from the constraint text. This is what we are implementing in SearchWorks https://github.com/sul-dlss/SearchWorks/pull/376

![screen shot 2014-06-30 at 11 32 56 am](https://cloud.githubusercontent.com/assets/1656824/3435654/dad60eea-0097-11e4-92b6-bed530b45ed7.png)
