### PR TITLE
Allow :route_set option for #render_constraints_query

### DIFF
--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -33,12 +33,13 @@ module Blacklight::RenderConstraintsHelperBehavior
   # @return [String]
   def render_constraints_query(localized_params = params)
     # So simple don't need a view template, we can just do it here.
+    scope = localized_params.delete(:route_set) || self
     return "".html_safe if localized_params[:q].blank?
 
     render_constraint_element(constraint_query_label(localized_params),
           localized_params[:q],
           :classes => ["query"],
-          :remove => url_for(localized_params.merge(:q=>nil, :action=>'index')))
+          :remove => scope.url_for(localized_params.merge(:q=>nil, :action=>'index')))
   end
 
   ##

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -17,8 +17,13 @@ describe RenderConstraintsHelper do
   end
 
   describe '#render_constraints_query' do
+    let(:my_engine) { double("Engine") }
     it "should have a link relative to the current url" do
       expect(helper.render_constraints_query(:q=>'foobar', :f=>{:type=>'journal'})).to have_selector "a[href='/?f%5Btype%5D=journal']"
+    end
+    it "should accept an optional route set" do
+      expect(my_engine).to receive(:url_for).and_return('/?f%5Btype%5D=journal')
+      expect(helper.render_constraints_query(:q=>'foobar', :f=>{:type=>'journal'}, :route_set => my_engine)).to have_selector "a[href='/?f%5Btype%5D=journal']"
     end
   end
 


### PR DESCRIPTION
At the suggestion of @jcoyne, this allows us to pass a `route_set` option in the parameters hash which is then applied to the `url_for` method.  This is useful for applications like Sufia, which are themselves engines that are using Blacklight.

Also, the EngineCart option prevents Spring from starting up which was cause troubles when trying to run the continuous integration task multiple times.
