### PR TITLE
use blacklight-jetty 4.9.0

### DIFF
--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -27,7 +27,7 @@ module Blacklight
       copy_file "config/jetty.yml"
 
       append_to_file "Rakefile",
-        "\nZIP_URL = \"https://github.com/projectblacklight/blacklight-jetty/archive/v4.6.0.zip\"\n" +
+        "\nZIP_URL = \"https://github.com/projectblacklight/blacklight-jetty/archive/v4.9.0.zip\"\n" +
         "require 'jettywrapper'\n"
     end
 

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -1,4 +1,4 @@
-ZIP_URL = "https://github.com/projectblacklight/blacklight-jetty/archive/v4.6.0.zip"
+ZIP_URL = "https://github.com/projectblacklight/blacklight-jetty/archive/v4.9.0.zip"
 
 require 'jettywrapper'
 require 'engine_cart/rake_task'
@@ -41,4 +41,3 @@ namespace :blacklight do
   task :generate => ['engine_cart:generate'] do
   end
 end
-


### PR DESCRIPTION
Anyone want to quibble with requiring java 7 to run the tests, and making java 7 the default requirement for using blacklight-jetty (e.g. in a development environment)?

The version of blacklight-jetty is configured in the application, so it should be trivial to change if someone can't use java 7.
