### PR TITLE
back_to_search should return the catalog path if last search is nil

### DIFF
--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -115,7 +115,11 @@ module Blacklight::UrlHelperBehavior
       query_params[:page] = ((counter - 1)/ per_page) + 1
     end
 
-    link_url = scope.url_for(query_params)
+    link_url = if query_params.empty?
+      search_action_path(only_path: true)
+    else
+      scope.url_for(query_params)
+    end
     label = opts.delete(:label)
 
     if link_url =~ /bookmarks/


### PR DESCRIPTION
presently it just links to the current document url.
This doesn't present itself in blacklight, because the back_to_search is
guarded in the view and doesn't display unless there is a next or
previous document. In my custom app, I want to put it on the page
regardless.
