### PR TITLE
made words break when too long in facet labels

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.css.scss
+++ b/app/assets/stylesheets/blacklight/_facets.css.scss
@@ -52,6 +52,22 @@
     }
   }
 
+  @mixin hyphens-auto {
+    // breaks long words apart so they don't cause the containing div to
+    // be too big
+    // from http://kenneth.io/blog/2012/03/04/word-wrapping-hypernation-using-css/
+    -ms-word-break: break-all;
+    word-break: break-all;
+
+    // Non standard for webkit
+    word-break: break-word;
+
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
+  }
+
   .facet-label {
     display: table-cell;
     padding-right: 1em;
@@ -59,6 +75,8 @@
     text-indent: -15px;
     padding-left: 15px;
     padding-bottom: $padding-base-vertical;
+
+    @include hyphens-auto;
   }
 
   .facet-count {


### PR DESCRIPTION
When a word is too long in the facet labels, it causes its container to explode into the main content when the browser window is narrow. This PR fixes that by allowing the browser to break some words onto the next line.

In the images below I've placed a long word in the label that starts with G.
### Before
#### Chrome

Note the totals that have escaped
![before-chrome](https://cloud.githubusercontent.com/assets/74879/3738561/4003cf44-1742-11e4-9cf6-05307d99b3ce.png)
### After
#### Chrome

Once Chrome supports the `hyphen` directive, we should get a nice hyphen for words that are broken (this hyphen isn't included when copying the text).
![after-chrome](https://cloud.githubusercontent.com/assets/74879/3738595/854c8fdc-1742-11e4-88a1-dd01e2fe2ad0.png)
#### Safari

![after-safari](https://cloud.githubusercontent.com/assets/74879/3738598/914eacd4-1742-11e4-9fd1-83dbbce2e2a0.png)
#### Firefox

![after-firefox](https://cloud.githubusercontent.com/assets/74879/3738600/95c439f0-1742-11e4-8ffe-8957ff94b1ce.png)
#### IE9

The label has a box around it because it was selected in the dom tree; it won't show up normally.
![after-ie9](https://cloud.githubusercontent.com/assets/74879/3738605/9c3833d6-1742-11e4-868d-510719b23f64.png)
