### PR TITLE
Don't show "more" link for every facet.

### DIFF
--- a/lib/blacklight/solr/facet_paginator.rb
+++ b/lib/blacklight/solr/facet_paginator.rb
@@ -37,7 +37,7 @@ module Blacklight::Solr
     def initialize(all_facet_values, arguments)
       # to_s.to_i will conveniently default to 0 if nil
       @offset = arguments[:offset].to_s.to_i 
-      @limit =  arguments[:limit].to_s.to_i
+      @limit = arguments[:limit]
       # count is solr's default
       @sort = arguments[:sort] || "count" 
 
@@ -82,7 +82,7 @@ module Blacklight::Solr
     deprecation_deprecate :has_next?
 
     def last_page?
-      total_count <= limit
+      limit.nil? || total_count <= limit
     end
 
     def first_page?
@@ -112,10 +112,10 @@ module Blacklight::Solr
     end
 
     private
-      # setting limit to 0 implies no limit
+      # setting limit to nil implies no limit
       # @return an array of facets on the page
       def items_for_limit(values)
-        limit == 0 ? values : values.take(limit)
+        limit.nil? ? values : values.take(limit)
       end
   end
 end

--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -327,8 +327,8 @@ module Blacklight::SolrHelper
     a << response.documents.map {|doc| doc[solr_params[:fl]].to_s }
   end
   
-  
-  
+  DEFAULT_FACET_LIMIT = 10
+
   # Look up facet limit for given facet_field. Will look at config, and
   # if config is 'true' will look up from Solr @response if available. If
   # no limit is avaialble, returns nil. Used from #solr_search_params
@@ -349,8 +349,8 @@ module Blacklight::SolrHelper
       else
         limit.to_i - 1 # we added 1 to find out if we needed to paginate
       end
-    elsif (facet.limit and facet.limit != true)
-      facet.limit
+    elsif facet.limit
+      facet.limit == true ? DEFAULT_FACET_LIMIT : facet.limit
     end
   end
 

--- a/spec/lib/blacklight/facet_paginator_spec.rb
+++ b/spec/lib/blacklight/facet_paginator_spec.rb
@@ -75,12 +75,13 @@ describe 'Blacklight::Solr::FacetPaginator' do
     it "should return all the items" do
       expect(subject.items).to eq seven_facet_values
     end
+    it { should be_last_page }
   end
 
   describe "#as_json" do
     subject { Blacklight::Solr::FacetPaginator.new([f1], offset: 0, limit: nil).as_json }
     it "should be well structured" do
-      expect(subject).to eq("items" => [{"hits"=>"792", "value"=>"Book"}], "limit" => 0,
+      expect(subject).to eq("items" => [{"hits"=>"792", "value"=>"Book"}], "limit" => nil,
        "offset" => 0, "sort" => "count")
     end
   end

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -1224,9 +1224,8 @@ describe Blacklight::SolrHelper do
       expect(subject.facet_limit_for("subject_topic_facet")).to be_nil
       
       expect(subject.solr_search_params).not_to have_key(:"f.subject_topic_facet.facet.limit")
-      
     end
-    
+
     describe "for 'true' configured values" do
       let(:blacklight_config) do
         config = Blacklight::Configuration.new
@@ -1248,6 +1247,9 @@ describe Blacklight::SolrHelper do
         allow(@response).to receive(:facet_by_field_name).with("language_facet").and_return(double(limit: 16))
         subject.instance_variable_set(:@response, @response)
         expect(subject.facet_limit_for("language_facet")).to eq 15
+      end
+      it "should default to 10" do
+        expect(subject.facet_limit_for("language_facet")).to eq 10
       end
     end
   end


### PR DESCRIPTION
Show "more" link when the facet limit is set to `true` or an integer
value. Fixes #958
