### PR TITLE
Adding span label to facet heading for screen reader

### DIFF
--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,7 +1,10 @@
 <div class="panel panel-default facet_limit blacklight-<%= facet_field.field.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.field) %>">
   <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
     <h5 class="panel-title">
-      <%= link_to facet_field_label(facet_field.field), "#", :"data-no-turbolink" => true %>
+      <%= link_to("#", :"data-no-turbolink" => true) do %>
+          <span class="sr-only"><%= t("blacklight.search.facets.sr.label")%></span>
+          <%= facet_field_label(facet_field.field) %>
+      <% end %>
     </h5>
   </div>
   <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'in' %>">

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -182,6 +182,8 @@ en:
         more: 'more »'
         selected:
           remove: '[remove]'
+        sr:
+          label: 'Filter your results by'
       group:
         more: 'more »'
       filters:

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -182,6 +182,8 @@ es:
         more: 'más »'
         selected:
           remove: '[borrar]'
+        sr:
+          label: 'Filtre sus resultados'
       group:
         more: 'más »'
       filters:

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -198,6 +198,8 @@ fr:
         more: 'plus »'
         selected:
           remove: '[ X ]'
+        sr:
+          label: 'Filtrez vos résultats par'
       group:
         more: 'plus »'
       filters:

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -200,6 +200,8 @@ pt-BR:
         more: 'mais »'
         selected:
           remove: '[remover]'
+        sr:
+          label: 'Refine sua busca'
       filters:
         title: 'Sua busca por:'
         label: '%{label}:'

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -24,6 +24,7 @@ describe "catalog/facet_layout" do
   it "should have a title with a link for a11y" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
     expect(rendered).to have_selector 'h5 a', text: 'Some Field'
+    expect(rendered).to have_selector 'span.sr-only', text: t("blacklight.search.facets.sr.label")
   end
 
   it "should be collapsable" do


### PR DESCRIPTION
This adds more information to the link so that a vision impaired user understands what each facet link.
