### PR TITLE
hide pagination for screen readers

### DIFF
--- a/app/views/kaminari/blacklight_compact/_paginator.html.erb
+++ b/app/views/kaminari/blacklight_compact/_paginator.html.erb
@@ -18,7 +18,7 @@
   <%# #render checks if total_pages > 1, so we can't put our fallback 
   in here .. -%>
   <%= paginator.render do -%>
-    <div class="page_links">
+    <div aria-hidden="true" class="page_links">
       <%= prev_page_tag %> | 
       <span class="page_entries">
         <%= page_entries_info %>
@@ -27,7 +27,7 @@
     </div>
   <% end -%>
 <% else -%>
-    <div class="page_links">
+    <div aria-hidden="true" class="page_links">
       <span class="page_entries">
         <%= page_entries_info %>
       </span>


### PR DESCRIPTION
This was confusing some people during user tests at PSU. They suggested we hide it.