### PR TITLE
Add col-sm-* to catalog/show.html

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,4 +1,4 @@
-<div id="content" class="col-md-9 show-document">
+<div id="content" class="col-md-9 col-sm-8 show-document">
 
   <%= render 'previous_next_doc' %>
 
@@ -29,6 +29,6 @@
 
 </div>
 
-<div id="sidebar" class="col-md-3">
+<div id="sidebar" class="col-md-3 col-sm-4">
    <%= render_document_sidebar_partial %>
 </div>


### PR DESCRIPTION
So it's still two-column at size bootstrap 'sm'. catalog/index
was changed to still be two-column at 'sm' here: 8a51ec61fc02

Should catalog/show be changed to match? If so, this does it.
