### PR TITLE
solr_facet_params defaults to sort=index

### DIFF
--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -224,7 +224,7 @@ module Blacklight::SolrHelper
     # override any field-specific default in the solr request handler. 
     solr_params[:"f.#{facet_field}.facet.limit"]  = limit + 1
     solr_params[:"f.#{facet_field}.facet.offset"] = ( input.fetch(Blacklight::Solr::FacetPaginator.request_keys[:page] , 1).to_i - 1 ) * ( limit )
-    solr_params[:"f.#{facet_field}.facet.sort"] = input[  Blacklight::Solr::FacetPaginator.request_keys[:sort] ] if  input[  Blacklight::Solr::FacetPaginator.request_keys[:sort] ]   
+    solr_params[:"f.#{facet_field}.facet.sort"] = input[  Blacklight::Solr::FacetPaginator.request_keys[:sort] ] || "index"
     solr_params[:rows] = 0
 
     return solr_params

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -663,6 +663,10 @@ describe Blacklight::SolrHelper do
       solr_params = subject.solr_facet_params(@facet_field)
       expect(solr_params[:"f.#{@facet_field}.facet.limit"]).to eq 21
     end
+    it "defaults sort to index" do
+      solr_params = subject.solr_facet_params(@facet_field)
+      expect(solr_params[:"f.#{@facet_field}.facet.sort"]).to eq "index"
+    end
 
     describe 'if facet_list_limit is defined in controller' do
       before do


### PR DESCRIPTION
The Blacklight action for listing individual facet values (eg from a 'more' click on facet)
in the default/common case does not send a facet.sort parameter, so gets the Solr default
of sort by 'count'. 

However, the parts of BL that display the individual facet list assume that if no explicit sort is given, the sort will be 'index' (ie alphabetical, more or less). 

This leads to a mis-match you can see in the demo app, where the values are sorted by 'count',
but in the sort choices at the bottom of the screen, the 'A-Z Sort' choice is mistakenly shown as selected. 

Eg: http://demo.projectblacklight.org/catalog/facet/language_facet

![screenshot 2014-08-21 16 09 42](https://cloud.githubusercontent.com/assets/149304/4002963/07e74fc2-2972-11e4-8796-a9db937038d4.png)

This commit makes 'index' the default sort in fetching again, as the UX expects, and as used to be the case in older versions of BL when the UX was written. 

This is just the simplest thing to make the common case seen in the demo app consistent again. Things that might be nice but we are not doing here:
- There may still be some cases with a mis-match, I don't entirely understand the stuff around `input[  Blacklight::Solr::FacetPaginator.request_keys[:sort] ]`
- ideally this would be configurable, different installations might want different default sorts on the facet drill-down page (or even different for different facets). This doesn't do that either. 

It just restores the common standard case, as displayed in the demo app, to consistency with as simple code as possible, returning BL to how it worked in past versions (not entirely sure when it changed). 
