### PR TITLE
Update Blacklight::SolrResponse::FacetItem to use the same logic as Solr when calculating default values

### DIFF
--- a/lib/blacklight/solr_response/facets.rb
+++ b/lib/blacklight/solr_response/facets.rb
@@ -35,16 +35,37 @@ module Blacklight::SolrResponse::Facets
     end
 
     def limit
-      @options[:limit]
+      @options[:limit] || solr_default_limit
     end
 
     def sort
-      @options[:sort] || 'index'
+      @options[:sort] || solr_default_sort
     end
 
     def offset
-      @options[:offset] || 0
+      @options[:offset] || solr_default_offset
     end
+    
+    private
+    # Per https://wiki.apache.org/solr/SimpleFacetParameters#facet.limit
+    def solr_default_limit
+      100
+    end
+    
+    # Per https://wiki.apache.org/solr/SimpleFacetParameters#facet.sort
+    def solr_default_sort
+      if limit > 0
+        'count'
+      else
+        'index'
+      end
+    end
+    
+    # Per https://wiki.apache.org/solr/SimpleFacetParameters#facet.offset
+    def solr_default_offset
+      0
+    end
+    
   end
   
   # @response.facets.each do |facet|

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe "Facets" do
@@ -5,5 +6,30 @@ describe "Facets" do
     visit catalog_facet_path("language_facet")
     expect(page).to have_selector(".modal-title", :text => "Language")
     expect(page).to have_selector(".facet_select", :text => "Tibetan")
+  end
+  
+  it "should paginate through a facet's values" do
+    visit catalog_facet_path("subject_topic_facet")
+    expect(page).to have_selector '.facet-values li:first', text: "Japanese drama"
+    expect(page).to have_link "A-Z Sort"
+    expect(page).to have_selector '.sort_options .active', text: "Numerical Sort"
+    within ".modal-footer" do
+      click_on "Next »"
+    end
+    expect(page).to have_selector '.facet-values li:first', text: "Jewish law"
+    expect(page).to have_link "« Previous"
+  end
+  
+  it "should be able to change the facet sort" do
+    visit catalog_facet_path("subject_topic_facet")
+    expect(page).to have_selector '.facet-values li:first', text: "Japanese drama"
+    within ".modal-footer" do
+      click_on "A-Z Sort"
+    end
+    expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
+    expect(page).to have_link "Numerical Sort"
+    expect(page).to have_selector '.sort_options .active', text: "A-Z Sort"
+    
+    
   end
 end

--- a/spec/lib/blacklight/solr_response/facets_spec.rb
+++ b/spec/lib/blacklight/solr_response/facets_spec.rb
@@ -7,8 +7,8 @@ describe Blacklight::SolrResponse::Facets do
       subject { Blacklight::SolrResponse::Facets::FacetField.new "my_field", [] }
 
       its(:name) { should eq "my_field" }
-      its(:limit) { should eq nil }
-      its(:sort) { should eq 'index' }
+      its(:limit) { should eq 100 }
+      its(:sort) { should eq 'count' }
       its(:offset) { should eq 0 }
     end
 
@@ -40,8 +40,8 @@ describe Blacklight::SolrResponse::Facets do
         expect(subject.facet_by_field_name('my_field').limit).to eq 15
       end
 
-      it "should be nil if no value is found" do
-        expect(subject.facet_by_field_name('my_field').limit).to be_nil
+      it "should be the solr default limit if no value is found" do
+        expect(subject.facet_by_field_name('my_field').limit).to eq 100
       end
     end
 
@@ -74,7 +74,12 @@ describe Blacklight::SolrResponse::Facets do
         expect(subject.facet_by_field_name('my_field').sort).to eq 'alpha'
       end
 
-      it "should default to index if no value is found" do
+      it "should default to count if no value is found and the default limit is used" do
+        expect(subject.facet_by_field_name('my_field').sort).to eq 'count'
+      end
+      
+      it "should default to index if no value is found and the limit is unlimited" do
+        request_params['facet.limit'] = -1
         expect(subject.facet_by_field_name('my_field').sort).to eq 'index'
       end
     end


### PR DESCRIPTION
Fixes #976
