### PR TITLE
update selector for bookmark count to handle any data-role bookmark-coun...

### DIFF
--- a/app/assets/javascripts/blacklight/bookmark_toggle.js
+++ b/app/assets/javascripts/blacklight/bookmark_toggle.js
@@ -6,12 +6,12 @@
       $(Blacklight.do_bookmark_toggle_behavior.selector).bl_checkbox_submit({
          //css_class is added to elements added, plus used for id base
          css_class: "toggle_bookmark",
- 	 success: function(checked, response) {
-		    if (response.bookmarks) {
-			$('#bookmarks_nav span[data-role=bookmark-counter]').text(response.bookmarks.count);
-		    }
-	          }
-      }); 
+         success: function(checked, response) {
+           if (response.bookmarks) {
+             $('[data-role=bookmark-counter]').text(response.bookmarks.count);
+           }
+         }
+      });
     };
     Blacklight.do_bookmark_toggle_behavior.selector = "form.bookmark_toggle"; 
 


### PR DESCRIPTION
...ter

Updates selector for counter to use only `data-role=bookmark-counter`

This allows people with customized templates to use the bookmark counters elsewhere. Also standardizes spacing.
