### PR TITLE
remove redundant asset_path in favicon link tag

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -15,7 +15,7 @@
 
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_path(:format => 'xml', :only_path => false) %>
-    <%= favicon_link_tag asset_path('favicon.ico') %>
+    <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
Removes a redundant `asset_path` in favicon link path. Rails `favicon_link_tag` will already look in the asset path for the file. Will also cause in issue with sprockets-rails 2.1.4

https://github.com/rails/sprockets-rails/issues/167
