### PR TITLE
Construct index, show and facet field labels from the field name if no field name is available.

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -58,36 +58,39 @@ module Blacklight::ConfigurationHelperBehavior
   ##
   # Look up the label for the index field
   def index_field_label document, field
-    label = index_fields(document)[field].label
+    field_config = index_fields(document)[field]
 
     solr_field_label(
-      label, 
       :"blacklight.search.fields.index.#{field}",
-      :"blacklight.search.fields.#{field}"
+      :"blacklight.search.fields.#{field}",
+      (field_config.label if field_config),
+      field.to_s.humanize
     )
   end
 
   ##
   # Look up the label for the show field
   def document_show_field_label document, field
-    label = document_show_fields(document)[field].label
-    
+    field_config = document_show_fields(document)[field]
+
     solr_field_label(
-      label, 
       :"blacklight.search.fields.show.#{field}",
-      :"blacklight.search.fields.#{field}"
+      :"blacklight.search.fields.#{field}",
+      (field_config.label if field_config),
+      field.to_s.humanize
     )
   end
 
   ##
   # Look up the label for the facet field
   def facet_field_label field
-    label = blacklight_config.facet_fields[field].label
+    field_config = blacklight_config.facet_fields[field]
 
     solr_field_label(
-      label, 
       :"blacklight.search.fields.facet.#{field}",
-      :"blacklight.search.fields.#{field}"
+      :"blacklight.search.fields.#{field}",
+      (field_config.label if field_config),
+      field.to_s.humanize
     )
   end
 
@@ -103,14 +106,8 @@ module Blacklight::ConfigurationHelperBehavior
   #     before falling  back to the label
   #   @param [Symbol] any number of additional keys
   #   @param [Symbol] ...
-  def solr_field_label label, *i18n_keys
-    if label.is_a? Symbol
-      return t(label)
-    end
-
+  def solr_field_label *i18n_keys
     first, *rest = i18n_keys
-
-    rest << label
 
     t(first, default: rest)
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -111,5 +111,10 @@ describe "Search Page" do
     expect(page).to have_content "Welcome!"
     expect(page).to_not have_selector "#q[value='history']"
   end
+
+  it "should gracefully handle searches with invalid facet parameters" do
+    visit root_path f: { missing_s: [1]}
+    expect(page).to have_content "No results found for your search"
+  end
 end
 

--- a/spec/helpers/configuration_helper_spec.rb
+++ b/spec/helpers/configuration_helper_spec.rb
@@ -92,7 +92,7 @@ describe BlacklightConfigurationHelper do
     let(:document) { double }
     it "should look up the label to display for the given document and field" do
       allow(helper).to receive(:index_fields).and_return({ "my_field" => double(label: "some label") })
-      allow(helper).to receive(:solr_field_label).with("some label", :"blacklight.search.fields.index.my_field", :"blacklight.search.fields.my_field")
+      allow(helper).to receive(:solr_field_label).with(:"blacklight.search.fields.index.my_field", :"blacklight.search.fields.my_field", "some label", "My field")
       helper.index_field_label document, "my_field"
     end
   end
@@ -101,7 +101,7 @@ describe BlacklightConfigurationHelper do
     let(:document) { double }
     it "should look up the label to display for the given document and field" do
       allow(helper).to receive(:document_show_fields).and_return({ "my_field" => double(label: "some label") })
-      allow(helper).to receive(:solr_field_label).with("some label", :"blacklight.search.fields.show.my_field", :"blacklight.search.fields.my_field")
+      allow(helper).to receive(:solr_field_label).with(:"blacklight.search.fields.show.my_field", :"blacklight.search.fields.my_field", "some label", "My field")
       helper.document_show_field_label document, "my_field"
     end
   end
@@ -110,14 +110,14 @@ describe BlacklightConfigurationHelper do
     let(:document) { double }
     it "should look up the label to display for the given document and field" do
       allow(blacklight_config).to receive(:facet_fields).and_return({ "my_field" => double(label: "some label") })
-      allow(helper).to receive(:solr_field_label).with("some label", :"blacklight.search.fields.facet.my_field", :"blacklight.search.fields.my_field")
+      allow(helper).to receive(:solr_field_label).with(:"blacklight.search.fields.facet.my_field", :"blacklight.search.fields.my_field", "some label", "My field")
       helper.facet_field_label "my_field"
     end
   end
 
   describe "#solr_field_label" do
     it "should look up the label as an i18n string" do
-      allow(helper).to receive(:t).with(:some_key).and_return "my label"
+      allow(helper).to receive(:t).with(:some_key, default: []).and_return "my label"
       label = helper.solr_field_label :some_key
 
       expect(label).to eq "my label"
@@ -126,7 +126,7 @@ describe BlacklightConfigurationHelper do
     it "should pass the provided i18n keys to I18n.t" do
       allow(helper).to receive(:t).with(:key_a, default: [:key_b, "default text"])
 
-      label = helper.solr_field_label "default text", :key_a, :key_b
+      label = helper.solr_field_label :key_a, :key_b, "default text"
     end
   end
   


### PR DESCRIPTION
Fixes one of the problems in #974 
