### PR TITLE
add input types email and tel for forms

### DIFF
--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -7,7 +7,7 @@
         <%= t('blacklight.email.form.to') %>
       </label>
       <div class="col-sm-10">
-        <%= text_field_tag :to, params[:to], class: 'form-control' %>
+        <%= email_field_tag :to, params[:to], class: 'form-control' %>
       </div>
     </div>
 

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -6,7 +6,7 @@
         <%= t('blacklight.sms.form.to') %>
       </label>
       <div class="col-sm-10">
-        <%= text_field_tag :to, params[:to], class: 'form-control' %>
+        <%= telephone_field_tag :to, params[:to], class: 'form-control' %>
       </div>
     </div>
     <div class="form-group">


### PR DESCRIPTION
Enables browser specific behavior for email and telephone fields. Enhancements also come from most mobile devices.
