### PR TITLE
Fix Solr error when faceting with a negative integer value.

### DIFF
--- a/lib/blacklight/request_builders.rb
+++ b/lib/blacklight/request_builders.rb
@@ -8,11 +8,11 @@ module Blacklight
     extend ActiveSupport::Concern
 
     included do
-      # We want to install a class-level place to keep 
+      # We want to install a class-level place to keep
       # solr_search_params_logic method names. Compare to before_filter,
       # similar design. Since we're a module, we have to add it in here.
       # There are too many different semantic choices in ruby 'class variables',
-      # we choose this one for now, supplied by Rails. 
+      # we choose this one for now, supplied by Rails.
       class_attribute :solr_search_params_logic
 
       # Set defaults. Each symbol identifies a _method_ that must be in
@@ -29,14 +29,14 @@ module Blacklight
     # Solr parameters can come from a number of places. From lowest
     # precedence to highest:
     #  1. General defaults in blacklight config (are trumped by)
-    #  2. defaults for the particular search field identified by  params[:search_field] (are trumped by) 
-    #  3. certain parameters directly on input HTTP query params 
+    #  2. defaults for the particular search field identified by  params[:search_field] (are trumped by)
+    #  3. certain parameters directly on input HTTP query params
     #     * not just any parameter is grabbed willy nilly, only certain ones are allowed by HTTP input)
-    #     * for legacy reasons, qt in http query does not over-ride qt in search field definition default. 
+    #     * for legacy reasons, qt in http query does not over-ride qt in search field definition default.
     #  4.  extra parameters passed in as argument.
     #
     # spellcheck.q will be supplied with the [:q] value unless specifically
-    # specified otherwise. 
+    # specified otherwise.
     #
     # Incoming parameter :f is mapped to :fq solr parameter.
     def solr_search_params(user_params = params || {})
@@ -46,7 +46,7 @@ module Blacklight
         end
       end
     end
-    
+
     ####
     # Start with general defaults from BL config. Need to use custom
     # merge to dup values, to avoid later mutating the original by mistake.
@@ -55,11 +55,11 @@ module Blacklight
         solr_parameters[key] = value.dup rescue value
       end
     end
-    
+
     ##
-    # Take the user-entered query, and put it in the solr params, 
-    # including config's "search field" params for current search field. 
-    # also include setting spellcheck.q. 
+    # Take the user-entered query, and put it in the solr params,
+    # including config's "search field" params for current search field.
+    # also include setting spellcheck.q.
     def add_query_to_solr(solr_parameters, user_parameters)
       ###
       # Merge in search field configured values, if present, over-writing general
@@ -68,20 +68,20 @@ module Blacklight
       # legacy behavior of user param :qt is passed through, but over-ridden
       # by actual search field config if present. We might want to remove
       # this legacy behavior at some point. It does not seem to be currently
-      # rspec'd. 
+      # rspec'd.
       solr_parameters[:qt] = user_parameters[:qt] if user_parameters[:qt]
-      
+
       search_field_def = search_field_def_for_key(user_parameters[:search_field])
-      if (search_field_def)     
+      if (search_field_def)
         solr_parameters[:qt] = search_field_def.qt
         solr_parameters.merge!( search_field_def.solr_parameters) if search_field_def.solr_parameters
       end
-      
+
       ##
       # Create Solr 'q' including the user-entered q, prefixed by any
-      # solr LocalParams in config, using solr LocalParams syntax. 
+      # solr LocalParams in config, using solr LocalParams syntax.
       # http://wiki.apache.org/solr/LocalParams
-      ##         
+      ##
       if (search_field_def && hash = search_field_def.solr_local_parameters)
         local_params = hash.collect do |key, val|
           key.to_s + "=" + solr_param_quote(val, :quote => "'")
@@ -90,7 +90,7 @@ module Blacklight
       else
         solr_parameters[:q] = user_parameters[:q] if user_parameters[:q]
       end
-            
+
 
       ##
       # Set Solr spellcheck.q to be original user-entered query, without
@@ -101,58 +101,58 @@ module Blacklight
       # TODO: Change calling code to expect this as a symbol instead of
       # a string, for consistency? :'spellcheck.q' is a symbol. Right now
       # rspec tests for a string, and can't tell if other code may
-      # insist on a string. 
+      # insist on a string.
       solr_parameters["spellcheck.q"] = user_parameters[:q] unless solr_parameters["spellcheck.q"]
     end
 
     ##
     # Add any existing facet limits, stored in app-level HTTP query
-    # as :f, to solr as appropriate :fq query. 
-    def add_facet_fq_to_solr(solr_parameters, user_params)   
+    # as :f, to solr as appropriate :fq query.
+    def add_facet_fq_to_solr(solr_parameters, user_params)
 
       # convert a String value into an Array
       if solr_parameters[:fq].is_a? String
         solr_parameters[:fq] = [solr_parameters[:fq]]
       end
 
-      # :fq, map from :f. 
+      # :fq, map from :f.
       if ( user_params[:f])
-        f_request_params = user_params[:f] 
-        
+        f_request_params = user_params[:f]
+
         f_request_params.each_pair do |facet_field, value_list|
           Array(value_list).each do |value|
             next if value.blank? # skip empty strings
             solr_parameters.append_filter_query facet_value_to_fq_string(facet_field, value)
-          end              
-        end      
+          end
+        end
       end
     end
-    
+
     ##
     # Add appropriate Solr facetting directives in, including
     # taking account of our facet paging/'more'.  This is not
-    # about solr 'fq', this is about solr facet.* params. 
+    # about solr 'fq', this is about solr facet.* params.
     def add_facetting_to_solr(solr_parameters, user_params)
       # While not used by BL core behavior, legacy behavior seemed to be
       # to accept incoming params as "facet.field" or "facets", and add them
       # on to any existing facet.field sent to Solr. Legacy behavior seemed
       # to be accepting these incoming params as arrays (in Rails URL with []
       # on end), or single values. At least one of these is used by
-      # Stanford for "faux hieararchial facets". 
+      # Stanford for "faux hieararchial facets".
       if user_params.has_key?("facet.field") || user_params.has_key?("facets")
         solr_parameters[:"facet.field"].concat( [user_params["facet.field"], user_params["facets"]].flatten.compact ).uniq!
-      end                
+      end
 
       blacklight_config.facet_fields.select { |field_name,facet|
         facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request)
       }.each do |field_name, facet|
         solr_parameters[:facet] ||= true
 
-        case 
+        case
           when facet.pivot
             solr_parameters.append_facet_pivot with_ex_local_param(facet.ex, facet.pivot.join(","))
           when facet.query
-            solr_parameters.append_facet_query facet.query.map { |k, x| with_ex_local_param(facet.ex, x[:fq]) } 
+            solr_parameters.append_facet_query facet.query.map { |k, x| with_ex_local_param(facet.ex, x[:fq]) }
           else
             solr_parameters.append_facet_fields with_ex_local_param(facet.ex, facet.field)
         end
@@ -199,17 +199,17 @@ module Blacklight
 
     ###
     # copy paging params from BL app over to solr, changing
-    # app level per_page and page to Solr rows and start. 
+    # app level per_page and page to Solr rows and start.
     def add_paging_to_solr(solr_params, user_params)
 
       # user-provided parameters should override any default row
       solr_params[:rows] = user_params[:rows].to_i unless user_params[:rows].blank?
       solr_params[:rows] = user_params[:per_page].to_i unless user_params[:per_page].blank?
-      
+
       # configuration defaults should only set a default value, not override a value set elsewhere (e.g. search field parameters)
       solr_params[:rows] ||= blacklight_config.default_per_page unless blacklight_config.default_per_page.blank?
       solr_params[:rows] ||= blacklight_config.per_page.first unless blacklight_config.per_page.blank?
-      
+
       # set a reasonable default
       Rails.logger.info "Solr :rows parameter not set (by the user, configuration, or default solr parameters); using 10 rows by default"
       solr_params[:rows] ||= 10
@@ -230,9 +230,9 @@ module Blacklight
         # no sort param provided, use default
         solr_parameters[:sort] = sort_field.sort unless sort_field.sort.blank?
       elsif sort_field = blacklight_config.sort_fields[user_params[:sort]]
-        # check for sort field key  
+        # check for sort field key
         solr_parameters[:sort] = sort_field.sort unless sort_field.sort.blank?
-      else 
+      else
         # just pass the key through
         solr_parameters[:sort] = user_params[:sort]
       end
@@ -257,7 +257,7 @@ module Blacklight
 
     ##
     # Convert a facet/value pair into a solr fq parameter
-    def facet_value_to_fq_string(facet_field, value) 
+    def facet_value_to_fq_string(facet_field, value)
       facet_config = blacklight_config.facet_fields[facet_field]
 
       local_params = []
@@ -277,7 +277,13 @@ module Blacklight
         when (value.is_a?(TrueClass) or value.is_a?(FalseClass) or value == 'true' or value == 'false'),
              (value.is_a?(Integer) or (value.to_i.to_s == value if value.respond_to? :to_i)),
              (value.is_a?(Float) or (value.to_f.to_s == value if value.respond_to? :to_f))
-          "#{prefix}#{facet_field}:#{value}"
+          then
+            if value[0] != '-'
+              "#{prefix}#{facet_field}:#{value}"
+            else
+              "#{prefix}#{facet_field}:\\#{value}"
+            end
+
         when value.is_a?(Range)
           "#{prefix}#{facet_field}:[#{value.first} TO #{value.last}]"
         else


### PR DESCRIPTION
I found a bug when trying to facet a query with a negative integer. Solr returned an error because the negative symbol ("-") is a special character in Lucene query syntax. This pull should scape that character and fix the error.
