### PR TITLE
When serializing numeric data to fq, ensure we properly escape the data

### DIFF
--- a/lib/blacklight/request_builders.rb
+++ b/lib/blacklight/request_builders.rb
@@ -277,7 +277,7 @@ module Blacklight
         when (value.is_a?(TrueClass) or value.is_a?(FalseClass) or value == 'true' or value == 'false'),
              (value.is_a?(Integer) or (value.to_i.to_s == value if value.respond_to? :to_i)),
              (value.is_a?(Float) or (value.to_f.to_s == value if value.respond_to? :to_f))
-          "#{prefix}#{facet_field}:#{value}"
+          "#{prefix}#{facet_field}:#{RSolr.escape(value.to_s)}"
         when value.is_a?(Range)
           "#{prefix}#{facet_field}:[#{value.first} TO #{value.last}]"
         else

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -252,11 +252,15 @@ describe Blacklight::SolrHelper do
       end
 
       it "should pass floats through" do
-        expect(subject.send(:facet_value_to_fq_string, "facet_name", 1.11)).to eq "facet_name:1.11"
+        expect(subject.send(:facet_value_to_fq_string, "facet_name", 1.11)).to eq "facet_name:1\\.11"
       end
 
       it "should pass floats through" do
-        expect(subject.send(:facet_value_to_fq_string, "facet_name", "1.11")).to eq "facet_name:1.11"
+        expect(subject.send(:facet_value_to_fq_string, "facet_name", "1.11")).to eq "facet_name:1\\.11"
+      end
+
+      it "should escape negative integers" do
+        expect(subject.send(:facet_value_to_fq_string, "facet_name", -1)).to eq "facet_name:\\-1"
       end
 
       it "should pass date-type fields through" do


### PR DESCRIPTION
Numeric data may contain character sequences that require escape, e.g. "-1"
