### PR TITLE
Fix zero results page to display 'try searching everything' link when the query is scoped to a given field

### DIFF
--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -4,9 +4,9 @@
   <ul>
     <li><%= t 'blacklight.search.zero_results.use_fewer_keywords' %></li>
 
-    <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field -%>
+    <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) -%>
       <li><%= t 'blacklight.search.zero_results.search_fields', :search_fields => search_field_label(params) %> - 
-      <%= link_to t('blacklight.search.zero_results.search_everything'), url_for(params_for_search(:search_field=>blacklight_config.default_search_field.key)) %>
+      <%= link_to t('blacklight.search.zero_results.search_everything', field: blacklight_config.default_search_field.label), url_for(params_for_search(:search_field=>blacklight_config.default_search_field.key)) %>
       </li>
     <%- end %>
 

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -48,6 +48,17 @@ describe "Search Results" do
     search_for 'asdfghj'
     expect(page).to have_content "No results found for your search"
   end
+
+  it "should provide search hints if there are no results" do
+    visit root_path
+    fill_in "q", with: "inmul"
+    select "Author", from: "search_field"
+    click_button 'search'
+    expect(page).to have_content "No results found for your search"
+    expect(page).to have_content "you searched by Author"
+    click_on "try searching everything"
+    expect(page).to have_xpath("//a[contains(@href, #{77826928})]")
+  end
 end
 
 


### PR DESCRIPTION
Fixes #921 
