### PR TITLE
Use ellipses to truncate long constraint values at responsive breakpoints

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.css.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.css.scss
@@ -52,7 +52,25 @@ span.constraints-label {
 {
   .constraint-value {
     cursor: default;
-    
+    text-overflow: ellipsis;
+    overflow: hidden;
+
+    @media (max-width: $screen-xs-max) {
+      max-width: $screen-xs-min / 2;
+    }
+
+    @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+      max-width: $screen-sm-min / 2;
+    }
+
+    @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+      max-width: $screen-md-min / 2;
+    }
+
+    @media (min-width: $screen-lg-min) {
+      max-width: $screen-lg-min / 2;
+    }
+
     &:hover, &:active {
       background-color: $btn-default-bg;
       border-color: $btn-default-border;

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -13,7 +13,7 @@
       <span class="filterName"><%= label %></span>
     <% end %>
     <% unless value.blank? %>
-      <span class="filterValue"><%= value %></span>
+      <%= content_tag :span, value, class: 'filterValue', title: value %>
     <% end %>
   </span>
   <% unless options[:remove].blank? %>


### PR DESCRIPTION
Fixes #925, maybe, @jronallo?

@jkeck, I saw we were truncating values in searchworks. Do you think these values are close enough to searchworks, or could they use some tweaking?

For reference:

``` css

// Extra small screen / phone
$screen-xs:                  480px !default;
$screen-sm:                  768px !default;
$screen-md:                  992px !default;
$screen-lg:                  1200px !default;
```

![screen shot 2014-11-10 at 2 34 23 pm](https://cloud.githubusercontent.com/assets/111218/4985127/08a22610-692a-11e4-8201-60e30612d1a4.png)
![screen shot 2014-11-10 at 2 34 40 pm](https://cloud.githubusercontent.com/assets/111218/4985128/08ba5726-692a-11e4-8a25-38da03a58ac7.png)
![screen shot 2014-11-10 at 2 34 28 pm](https://cloud.githubusercontent.com/assets/111218/4985130/08c174e8-692a-11e4-97c9-c8f15f247c89.png)
![screen shot 2014-11-10 at 2 34 35 pm](https://cloud.githubusercontent.com/assets/111218/4985129/08c07c64-692a-11e4-8a23-651fa2399c64.png)
