### PR TITLE
Define a logger instance method if one is not provided

### DIFF
--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -58,6 +58,12 @@ module Blacklight::SolrHelper
 
     include Blacklight::RequestBuilders
 
+    # ActiveSupport::Benchmarkable requires a logger method
+    unless instance_methods.include? :logger
+      def logger
+        nil
+      end
+    end
   end
 
   ##

--- a/spec/lib/blacklight/solr_helper_spec.rb
+++ b/spec/lib/blacklight/solr_helper_spec.rb
@@ -28,10 +28,6 @@ describe Blacklight::SolrHelper do
     def params
       {}
     end
-
-    def logger
-      Rails.logger
-    end
   end
 
   subject { SolrHelperTestClass.new blacklight_config, blacklight_solr }


### PR DESCRIPTION
Fixes #964 
