### PR TITLE
Improve styling of out-of-the-box navbar-toggle element on an inverse navbar

### DIFF
--- a/app/assets/stylesheets/blacklight/_layout.css.scss
+++ b/app/assets/stylesheets/blacklight/_layout.css.scss
@@ -3,3 +3,9 @@
 .navbar + .navbar {
   margin-top: -$navbar-margin-bottom;
 }
+
+.navbar-inverse .navbar-toggle {
+  &:focus, &:hover {
+    border-color: $gray-light;
+  }
+}

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,7 +1,7 @@
 <div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#user-util-collapse">
+    <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>


### PR DESCRIPTION
focus + hover:
![screen shot 2014-11-11 at 3 32 11 pm](https://cloud.githubusercontent.com/assets/111218/5002645/f43f4728-69b7-11e4-8dde-e1c30f1463d7.png)

active:
![screen shot 2014-11-11 at 3 31 55 pm](https://cloud.githubusercontent.com/assets/111218/5002644/f43d4b58-69b7-11e4-9be5-e07718450e4d.png)

Fixes #895? @mejackreed ?
