### PR TITLE
Correct the path for the endnote link on the show page

### DIFF
--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -304,7 +304,8 @@ module Blacklight::UrlHelperBehavior
     end
   end
 
-  def endnote_catalog_path opts = {}
+  # For exporting a single endnote document. (endnote_catalog_path is defined by blacklight-marc and it is used for multiple document export)
+  def single_endnote_catalog_path opts = {}
     catalog_path(opts.merge(format: 'endnote'))
   end
 

--- a/lib/blacklight/catalog/component_configuration.rb
+++ b/lib/blacklight/catalog/component_configuration.rb
@@ -11,7 +11,7 @@ module Blacklight
 
       add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
       add_show_tools_partial(:refworks, if: :render_refworks_action?, modal: false)
-      add_show_tools_partial(:endnote, if: :render_endnote_action? )
+      add_show_tools_partial(:endnote, if: :render_endnote_action?, modal: false, path: :single_endnote_catalog_path )
       add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
       add_show_tools_partial(:sms, callback: :sms_action, validator: :validate_sms_params)
       add_show_tools_partial(:citation)

--- a/spec/helpers/component_helper_spec.rb
+++ b/spec/helpers/component_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe '#document_action_path' do
+  before do
+    allow(helper).to receive_messages(controller_name: 'catalog')
+  end
+
+  let(:document_action_config) { Blacklight::Configuration::ToolConfig.new(tool_config) }
+  let(:document) { SolrDocument.new(id: '123') }
+
+  subject { helper.document_action_path(document_action_config, id: document) }
+
+  context "for endnote" do
+    let(:tool_config) { { if: :render_refworks_action?, partial: "document_action",
+      name: :endnote, key: :endnote, path: :single_endnote_catalog_path } }
+
+    it { is_expected.to eq '/catalog/123.endnote' }
+  end
+end


### PR DESCRIPTION
Fixes #1041
blacklight_marc already defines a endnote_catalog_path, so we need to
use a unique name for that path.
