### PR TITLE
Blacklight::SolrRepository should preserve the class of the incoming params

### DIFF
--- a/lib/blacklight/solr_repository.rb
+++ b/lib/blacklight/solr_repository.rb
@@ -16,7 +16,11 @@ module Blacklight
     # @param [String] document's unique key value
     # @param [Hash] additional solr query parameters
     def find id, params = {}
-      solr_response = send_and_receive blacklight_config.document_solr_path || blacklight_config.solr_path, {qt: blacklight_config.document_solr_request_handler}.merge(blacklight_config.default_document_solr_params.merge(params).merge(blacklight_config.document_unique_id_param => id))
+      doc_params = params.reverse_merge(qt: blacklight_config.document_solr_request_handler)
+                         .reverse_merge(blacklight_config.default_document_solr_params)
+                         .merge(blacklight_config.document_unique_id_param => id)
+      
+      solr_response = send_and_receive blacklight_config.document_solr_path || blacklight_config.solr_path, doc_params
       raise Blacklight::Exceptions::InvalidSolrID.new if solr_response.documents.empty?
       solr_response
     end
@@ -25,7 +29,7 @@ module Blacklight
     # Execute a search query against solr
     # @param [Hash] solr query parameters
     def search params = {}
-      send_and_receive blacklight_config.solr_path, { qt: blacklight_config.qt }.merge(params)
+      send_and_receive blacklight_config.solr_path, params.reverse_merge(qt: blacklight_config.qt)
     end
 
     ##

--- a/spec/lib/blacklight/solr_repository_spec.rb
+++ b/spec/lib/blacklight/solr_repository_spec.rb
@@ -42,6 +42,14 @@ describe Blacklight::SolrRepository do
       allow(subject.blacklight_solr).to receive(:send_and_receive).with('select', hash_including(params: { id: '123', qt: 'abc'})).and_return(mock_response)
       expect(subject.find("123", {qt: 'abc'})).to be_a_kind_of Blacklight::SolrResponse
     end
+
+    it "should preserve the class of the incoming params" do
+      doc_params = HashWithIndifferentAccess.new
+      allow(subject.blacklight_solr).to receive(:send_and_receive).with('select', anything).and_return(mock_response)
+      response = subject.find("123", doc_params)
+      expect(response).to be_a_kind_of Blacklight::SolrResponse
+      expect(response.params).to be_a_kind_of HashWithIndifferentAccess
+    end
   end
 
   describe "#search" do
@@ -66,6 +74,16 @@ describe Blacklight::SolrRepository do
       blacklight_config.qt = 'xyz'
       allow(subject.blacklight_solr).to receive(:send_and_receive).with('select', hash_including(params: { qt: 'abc'})).and_return(mock_response)
       expect(subject.search({qt: 'abc'})).to be_a_kind_of Blacklight::SolrResponse
+    end
+    
+    it "should preserve the class of the incoming params" do
+      search_params = HashWithIndifferentAccess.new
+      search_params[:q] = "query"
+      allow(subject.blacklight_solr).to receive(:send_and_receive).with('select', anything).and_return(mock_response)
+      
+      response = subject.search(search_params)
+      expect(response).to be_a_kind_of Blacklight::SolrResponse
+      expect(response.params).to be_a_kind_of HashWithIndifferentAccess
     end
   end
 


### PR DESCRIPTION
Fixes #1039 and fixes #1040.
