### PR TITLE
Avoid a deprecation warning in Rails 4.2

### DIFF
--- a/app/views/catalog/index.rss.builder
+++ b/app/views/catalog/index.rss.builder
@@ -4,7 +4,7 @@ xml.rss(:version=>"2.0") {
   xml.channel {
           
     xml.title(t('blacklight.search.title', :application_name => application_name))
-    xml.link(catalog_index_url(params))
+    xml.link(search_action_url(params))
     xml.description(t('blacklight.search.title', :application_name => application_name))
     xml.language('en-us')
     @document_list.each do |doc|

--- a/lib/blacklight/controller.rb
+++ b/lib/blacklight/controller.rb
@@ -40,14 +40,15 @@ module Blacklight::Controller
   def blacklight_config
     default_catalog_controller.blacklight_config
   end
-   
+
     protected
 
     # Default route to the search action (used e.g. in global partials). Override this method
     # in a controller or in your ApplicationController to introduce custom logic for choosing
     # which action the search form should use
-    def search_action_url *args
-      catalog_index_url *args
+    def search_action_url options = {}
+      # Rails 4.2 deprecated url helpers accepting string keys for 'controller' or 'action'
+      catalog_index_url(options.except(:controller, :action))
     end
 
     def search_action_path *args


### PR DESCRIPTION
The deprecation is triggered by passing string keys for controller or
action to the url helper.
