### PR TITLE
removes redundant class

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-  <%= form_tag search_action_url, :method => :get, :class => 'search-query-form form-inline clearfix navbar-form' do %>
+  <%= form_tag search_action_url, :method => :get, :class => 'search-query-form clearfix navbar-form' do %>
     <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
 
     <% unless search_fields.empty? %>


### PR DESCRIPTION
Removes a redundant class that is already mixed-in to `navbar-form`.

https://github.com/twbs/bootstrap-sass/blob/41ea576e9d611a9b2fffe4b1e0759ee7824858bc/assets/stylesheets/bootstrap/_forms.scss#L404