### PR TITLE
Allow blacklight configuration to provide multiple title field options

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -138,7 +138,14 @@ module Blacklight::ConfigurationHelperBehavior
 
   # Used in the document list partial (search view) for creating a link to the document show action
   def document_show_link_field document=nil
-    blacklight_config.view_config(document_index_view_type).title_field.try(:to_sym) || document.id
+    fields = Array(blacklight_config.view_config(document_index_view_type).title_field)
+
+    field = fields.first if document.nil?
+    field ||= fields.find { |f| document.has? f }
+    field &&= field.try(:to_sym)
+    field ||= document.id
+
+    field
   end
 
   ##

--- a/lib/blacklight/document_presenter.rb
+++ b/lib/blacklight/document_presenter.rb
@@ -20,7 +20,14 @@ module Blacklight
     # @param [SolrDocument] document
     # @return [String]
     def document_heading
-      render_field_value(@document[@configuration.view_config(:show).title_field] || @document.id)
+      fields = Array(@configuration.view_config(:show).title_field)
+      f = fields.find { |field| @document.has? field }
+
+      if f.nil?
+        render_field_value(@document.id)
+      else
+        render_field_value(@document[f])
+      end
     end
 
     ##
@@ -31,7 +38,14 @@ module Blacklight
     # @return [String]
     def document_show_html_title
       if @configuration.view_config(:show).html_title_field
-        render_field_value(@document[@configuration.view_config(:show).html_title_field])
+        fields = Array(@configuration.view_config(:show).html_title_field)
+        f = fields.find { |field| @document.has? field }
+
+        if f.nil?
+          render_field_value(@document.id)
+        else
+          render_field_value(@document[f])
+        end
       else
         document_heading
       end

--- a/spec/helpers/configuration_helper_spec.rb
+++ b/spec/helpers/configuration_helper_spec.rb
@@ -88,6 +88,28 @@ describe BlacklightConfigurationHelper do
     end
   end
 
+  describe "#document_show_link_field" do
+    let(:document) { SolrDocument.new id: 123, a: 1, b: 2, c: 3 }
+
+    it "should allow single values" do
+      blacklight_config.index.title_field = :a
+      f = helper.document_show_link_field document
+      expect(f).to eq :a
+    end
+    
+    it "should retrieve the first field with data" do
+      blacklight_config.index.title_field = [:zzz, :b]
+      f = helper.document_show_link_field document
+      expect(f).to eq :b
+    end
+
+    it "should fallback on the id" do
+      blacklight_config.index.title_field = [:zzz, :yyy]
+      f = helper.document_show_link_field document
+      expect(f).to eq 123
+    end
+  end
+
   describe "#index_field_label" do
     let(:document) { double }
     it "should look up the label to display for the given document and field" do

--- a/spec/lib/document_presenter_spec.rb
+++ b/spec/lib/document_presenter_spec.rb
@@ -213,4 +213,48 @@ describe Blacklight::DocumentPresenter do
       expect(subject.render_field_value('a', double(:separator => nil, :itemprop => 'some-prop'))).to have_selector("span[@itemprop='some-prop']", :text => "a") 
     end
   end
+
+  describe "#document_heading" do
+    it "should fallback to an id" do
+      allow(document).to receive(:id).and_return "xyz"
+      expect(subject.document_heading).to eq document.id
+    end
+
+    it "should return the value of the field" do
+      config.show.title_field = :x
+      allow(document).to receive(:has?).with(:x).and_return(true)
+      allow(document).to receive(:[]).with(:x).and_return("value")
+      expect(subject.document_heading).to eq "value"
+    end
+
+    it "should return the first present value" do
+      config.show.title_field = [:x, :y]
+      allow(document).to receive(:has?).with(:x).and_return(false)
+      allow(document).to receive(:has?).with(:y).and_return(true)
+      allow(document).to receive(:[]).with(:y).and_return("value")
+      expect(subject.document_heading).to eq "value"
+    end
+  end
+
+  describe "#document_show_html_title" do
+    it "should fallback to an id" do
+      allow(document).to receive(:id).and_return "xyz"
+      expect(subject.document_show_html_title).to eq document.id
+    end
+
+    it "should return the value of the field" do
+      config.show.html_title_field = :x
+      allow(document).to receive(:has?).with(:x).and_return(true)
+      allow(document).to receive(:[]).with(:x).and_return("value")
+      expect(subject.document_show_html_title).to eq "value"
+    end
+
+    it "should return the first present value" do
+      config.show.html_title_field = [:x, :y]
+      allow(document).to receive(:has?).with(:x).and_return(false)
+      allow(document).to receive(:has?).with(:y).and_return(true)
+      allow(document).to receive(:[]).with(:y).and_return("value")
+      expect(subject.document_show_html_title).to eq "value"
+    end
+  end
 end


### PR DESCRIPTION
and have presenter methods select the first, present field.

Fixes sul-dlss/spotlight#901