### PR TITLE
Test against blacklight_config.solr_document_model, not SolrDocument.

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -272,7 +272,7 @@ module Blacklight::BlacklightHelperBehavior
   #   @options options [Symbol] :tag
   def render_document_heading(*args)
     options = args.extract_options!
-    if args.first.is_a? SolrDocument
+    if args.first.is_a? blacklight_config.solr_document_model
       document = args.shift
       tag = options[:tag]
     else


### PR DESCRIPTION
If a custom Solr document model is specified, `render_document_heading` does not detect it as its first argument because it tests for a `SolrDocument` instance.

It should instead check for the class specified in `blacklight_config.solr_document_model`