### PR TITLE
show back to search and start over for 1 result show pages

### DIFF
--- a/app/assets/stylesheets/blacklight/_catalog.scss
+++ b/app/assets/stylesheets/blacklight/_catalog.scss
@@ -164,13 +164,13 @@ label.toggle_bookmark
   padding-bottom: $padding-base-vertical;
 }
 
-#sortAndPerPage, #previousNextDocument {
+#sortAndPerPage, .pagination-search-widgets {
   border-bottom: 1px solid $pagination-border;
   margin-bottom: 1em;
   padding-bottom: 1em;
 }
 
-#previousNextDocument {
+.pagination-search-widgets {
   @extend .clearfix;
   padding-top: 1px;
   padding-bottom: $padding-base-vertical;

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,18 +1,20 @@
 <% #Using the Bootstrap Pagination class  -%>
-<% if @previous_document || @next_document %>
-	<div id="previousNextDocument">
+<% #DEPRECATED - using id="previousNextDocument" as a selector is deprecated and will be removed in Blacklight 6.0 %>
+<div id='previousNextDocument' class='pagination-search-widgets'>
+  <% if @previous_document || @next_document %>
     <div class="page_links">
       <%= link_to_previous_document @previous_document %> |
 
       <%= item_page_entry_info %> |
 
       <%= link_to_next_document @next_document %>
-      </div>
-
+    </div>
+  <% end %>
+  <% if current_search_session %>
     <div class="pull-right search-widgets">
-        <%= link_back_to_catalog :class => 'btn' %>
-        
-        <%=link_to "#{t('blacklight.search.start_over')}", start_over_path(current_search_session.try(:query_params) || {}), :id=>"startOverLink", :class => 'btn' %>
-  	</div>
-  </div>
-<% end %>
+      <%= link_back_to_catalog class: 'btn' %>
+
+      <%=link_to t('blacklight.search.start_over'), start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn' %>
+    </div>
+  <% end %>
+</div>

--- a/spec/features/search_context_spec.rb
+++ b/spec/features/search_context_spec.rb
@@ -8,12 +8,12 @@ describe "Search Results context", js: true do
     search_id =  Search.last.id.to_s
     click_on 'Pluvial nectar of blessings'
     expect(page).to have_content "« Previous | 10 of 30 | Next »"
-    prev = page.find("#previousNextDocument .previous")
+    prev = page.find(".pagination-search-widgets .previous")
     expect(prev['data-context-href']).to eq "/catalog/2003546302/track?counter=9&search_id=#{search_id}"
 
     click_on "« Previous"
 
-    prev = page.find("#previousNextDocument .previous")
+    prev = page.find(".pagination-search-widgets .previous")
     expect(prev['data-context-href']).to eq "/catalog/2004310986/track?counter=8&search_id=#{search_id}"
   end
   
@@ -22,6 +22,15 @@ describe "Search Results context", js: true do
     first('.index_title a').click
     expect(page).to have_content "« Previous | 1 of 30 | Next »"
     expect(page.current_url).to_not have_content "/track"
+  end
+
+  it 'should show "Back to Search" and "Start Over links"' do
+    search_for 'Bod kyi naṅ chos ṅo sprod sñiṅ bsdus'
+    first('.index_title a').click
+    within '.pagination-search-widgets' do
+      expect(page).to have_css 'a', text: 'Back to Search'
+      expect(page).to have_css 'a', text: 'Start Over'
+    end
   end
   
   context "navigating between search results using context pagination" do

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -13,6 +13,7 @@ describe "catalog/show.html.erb" do
   before :each do
     allow(view).to receive_messages(:has_user_authentication_provider? => false)
     allow(view).to receive_messages(:render_document_sidebar_partial => "Sidebar")
+    allow(view).to receive_messages(current_search_session: nil)
     assign :document, document
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
   end


### PR DESCRIPTION
This pull request modifies a show page to include the "Back to Search" and "Start Over" buttons from a navigated search that only includes 1 search result. Previously both the pagination and search buttons were both inside `#previousNextDocument` and only shown `if @previous_document || @next_document`. I think this logic should be decoupled and that these are separate concerns. 

GeoBlacklight usability testing indicated not showing "Back to Search" and "Start Over" on every show page navigated from a search was confusing for users.  It also was not clear to users why this was happening.