### PR TITLE
Render atom and rss feeds using the document partial rendering pipeline,...

### DIFF
--- a/app/views/catalog/_document_default.atom.builder
+++ b/app/views/catalog/_document_default.atom.builder
@@ -1,0 +1,56 @@
+xml.entry do
+  
+  
+  xml.title   document.to_semantic_values[:title][0] || presenter(document).render_document_index_label(document_show_link_field(document))
+  
+  # updated is required, for now we'll just set it to now, sorry
+  xml.updated Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
+  
+  xml.link    "rel" => "alternate", "type" => "text/html", "href" => polymorphic_url(url_for_document(document))
+  # add other doc-specific formats, atom only lets us have one per
+  # content type, so the first one in the list wins.
+  xml << render_link_rel_alternates(document, :unique => true)      
+  
+  xml.id polymorphic_url(url_for_document(document))
+  
+  
+  if document.to_semantic_values[:author][0]   
+    xml.author { xml.name(document.to_semantic_values[:author][0]) }
+  end
+  
+  with_format("html") do
+    xml.summary "type" => "html" do
+      xml.text! render_document_partial(document,
+      :index,
+      :document_counter => document_counter)
+    end
+  end
+  
+  #If they asked for a format, give it to them. 
+  if (params["content_format"] &&
+    document.export_formats[params["content_format"].to_sym])
+    
+    type = document.export_formats[params["content_format"].to_sym][:content_type]
+    
+    xml.content :type => type do |content_element|
+      data = document.export_as(params["content_format"])
+      
+      # encode properly. See:
+      # http://tools.ietf.org/html/rfc4287#section-4.1.3.3
+      type = type.downcase
+      if (type.downcase =~ /\+|\/xml$/)
+        # xml, just put it right in              
+        content_element << data
+      elsif (type.downcase =~ /text\//)
+        # text, escape
+        content_element.text! data
+      else
+        #something else, base64 encode it
+        content_element << Base64.encode64(data)
+      end
+    end
+    
+  end
+  
+  
+end

--- a/app/views/catalog/_document_default.rss.builder
+++ b/app/views/catalog/_document_default.rss.builder
@@ -1,0 +1,5 @@
+xml.item do  
+  xml.title( document.to_semantic_values[:title][0] || presenter(document).render_document_index_label(document_show_link_field(document)) )                              
+  xml.link(polymorphic_url(url_for_document(document)))                                   
+  xml.author( document.to_semantic_values[:author][0] ) if document.to_semantic_values[:author][0]       
+end

--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -45,63 +45,9 @@ xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
   # updated is required, for now we'll just set it to now, sorry
   xml.updated Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
   
-  @document_list.each_with_index do |doc, document_counter|
-    xml.entry do
-      xml.title   doc.to_semantic_values[:title][0] || doc.id
-
-      # updated is required, for now we'll just set it to now, sorry
-      xml.updated Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
-      
-      xml.link    "rel" => "alternate", "type" => "text/html", "href" => polymorphic_url(doc)
-      # add other doc-specific formats, atom only lets us have one per
-      # content type, so the first one in the list wins.
-      xml << render_link_rel_alternates(doc, :unique => true)      
-      
-      xml.id      polymorphic_url(doc)
-      
-      
-      if doc.to_semantic_values[:author][0]   
-        xml.author { xml.name(doc.to_semantic_values[:author][0]) }
-      end
-      
-      with_format("html") do
-        xml.summary "type" => "html" do
-          xml.text! render_document_partial(doc,
-                                            :index,
-                                            :document_counter => document_counter)
-        end
-      end
-      
-      #If they asked for a format, give it to them. 
-      if (params["content_format"] &&
-          doc.export_formats[params["content_format"].to_sym])
-          
-          type = doc.export_formats[params["content_format"].to_sym][:content_type]
-          
-          xml.content :type => type do |content_element|
-            data = doc.export_as(params["content_format"])
-                    
-            # encode properly. See:
-            # http://tools.ietf.org/html/rfc4287#section-4.1.3.3
-            type = type.downcase
-            if (type.downcase =~ /\+|\/xml$/)
-              # xml, just put it right in              
-              content_element << data
-            elsif (type.downcase =~ /text\//)
-              # text, escape
-              content_element.text! data
-            else
-              #something else, base64 encode it
-              content_element << Base64.encode64(data)
-            end
-          end
-          
-      end
-
-      
-    end
+  @document_list.each_with_index do |document, document_counter|
+    xml << Nokogiri::XML.fragment(render_document_partials(document, blacklight_config.view_config(:atom).partials, document_counter: document_counter))
   end
-
 end
 
 

--- a/app/views/catalog/index.rss.builder
+++ b/app/views/catalog/index.rss.builder
@@ -7,12 +7,8 @@ xml.rss(:version=>"2.0") {
     xml.link(search_action_url(params))
     xml.description(t('blacklight.search.title', :application_name => application_name))
     xml.language('en-us')
-    @document_list.each do |doc|
-      xml.item do  
-        xml.title( doc.to_semantic_values[:title][0] || doc.id )                              
-        xml.link(polymorphic_url(doc))                                   
-        xml.author( doc.to_semantic_values[:author][0] ) if doc.to_semantic_values[:author][0]       
-      end
+    @document_list.each_with_index do |document, document_counter|
+      xml << Nokogiri::XML.fragment(render_document_partials(document, blacklight_config.view_config(:rss).partials, document_counter: document_counter))
     end
           
   }

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -78,7 +78,16 @@ module Blacklight
           ),
           :navbar => OpenStructWithHashAccess.new(partials: { }),
           # Configurations for specific types of index views
-          :view => NestedOpenStructWithHashAccess.new(ViewConfig, 'list'),
+          :view => NestedOpenStructWithHashAccess.new(ViewConfig,
+            'list',
+            atom: {
+              if: false, # by default, atom should not show up as an alternative view
+              partials: [:document]
+            },
+            rss: {
+              if: false, # by default, rss should not show up as an alternative view
+              partials: [:document]
+          }),
           # Maxiumum number of spelling suggestions to offer
           :spell_max => 5,
           # Maximum number of results to show per page


### PR DESCRIPTION
... and use url_for_document (to be consistent with HTML views)

Fixes #1067 