### PR TITLE
Ensure config#solr_response_model and config#solr_document_model are not...

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -252,8 +252,16 @@ module Blacklight
       end
       alias_method :inheritable_copy, :deep_copy
     else
-      alias_method :deep_copy, :deep_dup
-      alias_method :inheritable_copy, :deep_dup
+      ##
+      # Rails 4.x provides `#deep_dup`, but it aggressively `#dup`'s class names
+      # too. These model names should not be `#dup`'ed or we might break ActiveModel::Naming.
+      def deep_copy
+        deep_dup.tap do |copy|
+          copy.solr_response_model = self.solr_response_model
+          copy.solr_document_model = self.solr_document_model
+        end
+      end
+      alias_method :inheritable_copy, :deep_copy
     end
 
     ##

--- a/spec/lib/blacklight/configuration_spec.rb
+++ b/spec/lib/blacklight/configuration_spec.rb
@@ -84,6 +84,16 @@ describe "Blacklight::Configuration" do
       expect(@config.facet_fields).to_not include(@mock_facet)
     end
 
+    it "should not dup solr_response_model or solr_document_model" do
+      @config.solr_response_model = Blacklight::SolrResponse
+      @config.solr_document_model = SolrDocument
+
+      config_copy = @config.inheritable_copy
+
+      expect(config_copy.solr_response_model).to eq Blacklight::SolrResponse
+      expect(config_copy.solr_document_model).to eq SolrDocument
+    end
+
     it "should provide cloned copies of mutable data structures" do
       @config.a = { value: 1 }
       @config.b = [1,2,3]


### PR DESCRIPTION
... deep-dup'ed to preserve the original classes

Fixes #1061

If those class names are dup'ed, methods that expect ActiveModel::Naming don't
behave correctly