### PR TITLE
SearchBuilder deprecation warning should just include the class name

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -52,7 +52,7 @@ module Blacklight
       Blacklight::Solr::Request.new.tap do |request_parameters|
         @processor_chain.each do |method_name|
           if @scope.respond_to?(method_name, true)
-            Deprecation.warn Blacklight::SearchBuilder, "Building search parameters by calling #{method_name} on #{@scope.to_s}. This behavior will be deprecated in Blacklight 6.0"
+            Deprecation.warn Blacklight::SearchBuilder, "Building search parameters by calling #{method_name} on #{@scope.class}. This behavior will be deprecated in Blacklight 6.0"
             @scope.send(method_name, request_parameters, blacklight_params)
           else
             send(method_name, request_parameters)


### PR DESCRIPTION
With deprecation 0.2.0, the deprecation warnings can be squelched after the first display, but only if the message is static.