### PR TITLE
Don't mutate params to SearchBuilder

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -16,7 +16,7 @@ module Blacklight
     ##
     # Set the parameters to pass through the processor chain
     def with blacklight_params = {}
-      @blacklight_params = blacklight_params
+      @blacklight_params = blacklight_params.dup
       self
     end
 

--- a/spec/lib/blacklight/search_builder_spec.rb
+++ b/spec/lib/blacklight/search_builder_spec.rb
@@ -11,6 +11,14 @@ describe Blacklight::SearchBuilder do
       subject.with(params)
       expect(subject.blacklight_params).to eq params
     end
+
+    it "should dup the params" do
+      params = {}
+      subject.with(params).where('asdf')
+      expect(subject.blacklight_params).not_to eq params
+      expect(subject.blacklight_params[:q]).to eq 'asdf'
+      expect(params[:q]).not_to eq 'asdf'
+    end
   end
 
   describe "#processor_chain" do


### PR DESCRIPTION
`SearchBuilder#where` mutates the blacklight params directly. It should have its own copy.