### PR TITLE
add in more link purpose for screen readers

### DIFF
--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -3,7 +3,9 @@
   <%= render_facet_limit_list paginator, field_name %>
 
   <% unless paginator.last_page? || params[:action] == "facet" %>
-    <li class="more_facets_link"><%= link_to t('blacklight.search.facets.more'), 
-       search_facet_url(id: field_name), class: "more_facets_link" %></li>
+    <li class="more_facets_link">
+      <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field.label), 
+        search_facet_url(id: field_name), class: "more_facets_link" %>
+    </li>
   <% end %>
 </ul>

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -183,7 +183,9 @@ de:
           count: 'Numerisch ordnen'
           index: 'A-Z Ordnen'
         count: '%{number}'
+        # i18n key 'more' is deprecated and will be removed in Blacklight 6.0
         more: 'mehr »'
+        more_html: 'mehr <span class="sr-only">%{field_name}</span> »'
         selected:
           remove: '[entfernen]'
       group:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -183,7 +183,9 @@ en:
           count: 'Numerical Sort'
           index: 'A-Z Sort'
         count: '%{number}'
+        # i18n key 'more' is deprecated and will be removed in Blacklight 6.0 
         more: 'more »'
+        more_html: 'more <span class="sr-only">%{field_name}</span> »'
         selected:
           remove: '[remove]'
       group:

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -183,7 +183,9 @@ es:
           count: 'Ordenación numérica'
           index: 'Ordenación A-Z'
         count: '%{number}'
+        # i18n key 'more' is deprecated and will be removed in Blacklight 6.0
         more: 'más »'
+        more_html: 'más <span class="sr-only">%{field_name}</span> »'
         selected:
           remove: '[borrar]'
       group:

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -199,7 +199,9 @@ fr:
           count: 'Du + au - fréquent'
           index: 'Tri de A à Z'
         count: '%{number}'
+        # i18n key 'more' is deprecated and will be removed in Blacklight 6.0
         more: 'plus »'
+        more_html: 'plus <span class="sr-only">%{field_name}</span> »'
         selected:
           remove: '[ X ]'
       group:

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -203,7 +203,9 @@ pt-BR:
           count: 'Ordenar por Número'
           index: 'Ordem Alfabética A-Z'
         count: '%{number}'
+        # i18n key 'more' is deprecated and will be removed in Blacklight 6.0
         more: 'mais »'
+        more_html: 'mais <span class="sr-only">%{field_name}</span> »'
         selected:
           remove: '[remover]'
       filters:

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -32,4 +32,12 @@ describe "Facets" do
     
     
   end
+  describe '"More" links' do
+    it 'has default more link with sr-only text' do
+      visit root_path
+      within '#facet-language_facet' do
+        expect(page).to have_css 'li.more_facets_link', text: 'more Language'
+      end
+    end
+  end
 end


### PR DESCRIPTION
More links should have purpose. Screen reader users might find links that read to them "more >>" confusing without the visual context. Each link should convey the purpose of that link. 

http://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html

This enhancement adds the field name as `sr-only` text to the link making these more purposeful

cc @jvine