### PR TITLE
Fix so that ruby 1.9 can find the SolrDocument class

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -179,11 +179,12 @@ module Blacklight
         self[k] ||=  v
       end
     end
-    
+
     def document_model
-      super || SolrDocument
+      super || ::SolrDocument
     end
     alias_method :solr_document_model, :document_model
+
     # only here to support alias_method
     def document_model= *args
       super


### PR DESCRIPTION
See
https://travis-ci.org/projectblacklight/blacklight_advanced_search/builds/52804516