### PR TITLE
Use Solr 4.10.4

### DIFF
--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -1,4 +1,4 @@
-ZIP_URL = "https://github.com/projectblacklight/blacklight-jetty/archive/v4.10.3.zip"
+ZIP_URL = "https://github.com/projectblacklight/blacklight-jetty/archive/v4.10.4.zip"
 
 require 'jettywrapper'
 require 'engine_cart/rake_task'


### PR DESCRIPTION
... to silence those duplicate key warnings under Ruby 2.2.