### PR TITLE
Add default search builder processor chains so the consumer doesn't need...

### DIFF
--- a/lib/blacklight/solr/search_builder.rb
+++ b/lib/blacklight/solr/search_builder.rb
@@ -1,6 +1,8 @@
 module Blacklight::Solr
   class SearchBuilder < Blacklight::SearchBuilder
-    
+
+    self.default_processor_chain = [:default_solr_parameters, :add_query_to_solr, :add_facet_fq_to_solr, :add_facetting_to_solr, :add_solr_fields_to_query, :add_paging_to_solr, :add_sorting_to_solr, :add_group_config_to_solr ]
+
     ####
     # Start with general defaults from BL config. Need to use custom
     # merge to dup values, to avoid later mutating the original by mistake.

--- a/spec/lib/blacklight/search_builder_spec.rb
+++ b/spec/lib/blacklight/search_builder_spec.rb
@@ -5,6 +5,14 @@ describe Blacklight::SearchBuilder do
   let(:blacklight_config) { Blacklight::Configuration.new }
   let(:scope) { double blacklight_config: blacklight_config }
   subject { described_class.new processor_chain, scope }
+
+  context "with default processor chain" do
+    subject { described_class.new true, scope }
+    it "should use the class-level default_processor_chain" do
+      expect(subject.processor_chain).to eq []
+    end
+  end
+
   describe "#with" do
     it "should set the blacklight params" do
       params = {}

--- a/spec/lib/blacklight/solr/search_builder_spec.rb
+++ b/spec/lib/blacklight/solr/search_builder_spec.rb
@@ -17,6 +17,13 @@ describe Blacklight::Solr::SearchBuilder do
 
   subject { search_builder.with(user_params) }
 
+  context "with default processor chain" do
+    subject { described_class.new true, context }
+    it "should use the class-level default_processor_chain" do
+      expect(subject.processor_chain).to eq described_class.default_processor_chain
+    end
+  end
+
   context "with a complex parameter environment" do
     subject { search_builder.with(user_params).processed_parameters }
 


### PR DESCRIPTION
... to know what the appropriate  options are.

It was a little confusing to me, explaining the new `SearchBuilder` to @jronallo, that we ask the consumer of the search builder to identify the appropriate methods to run. It seems like that's probably a property of the `SearchBuilder` instead.

I suspect we left it as-is for backwards compatibility and ease-of-migration, but this patch allows the consumer to defer to the `SearchBuilder` to provide that information. I don't see a good way to make this the out-of-the-box default in BL 5, though.