### PR TITLE
Require java 1.7+ for running jetty out of the box

### DIFF
--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,10 +1,13 @@
 development:
   startup_wait: 15
   jetty_port: 8983 
+  java_version: ">= 1.7"
 test:
   startup_wait: 60
   jetty_port: <%= ENV['TEST_JETTY_PORT'] || 8888 %> 
   <%= ENV['TEST_JETTY_PATH'] ? "jetty_home: " + ENV['TEST_JETTY_PATH'] : '' %>
+  java_version: ">= 1.7"
 production:
   startup_wait: 15
   jetty_port: 8983
+  java_version: ">= 1.7"

--- a/lib/generators/blacklight/templates/config/jetty.yml
+++ b/lib/generators/blacklight/templates/config/jetty.yml
@@ -1,10 +1,13 @@
 development:
   startup_wait: 15
   jetty_port: 8983
+  java_version: ">= 1.7"
 test:
   startup_wait: 60
   jetty_port: <%= ENV['TEST_JETTY_PORT'] || 8888 %>
   <%= ENV['TEST_JETTY_PATH'] ? "jetty_home: " + ENV['TEST_JETTY_PATH'] : '' %>
+  java_version: ">= 1.7"
 production:
   startup_wait: 15
   jetty_port: 8983
+  java_version: ">= 1.7"


### PR DESCRIPTION
https://github.com/projecthydra/jettywrapper/pull/44 adds support for requiring a version of java to run jettywrapper. 

We need to require Java 1.7 to match the solr requirement to fix the problem @thatandromeda  reported in #1069.