### PR TITLE
Blacklight::Elasticsearch [WIP]

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -131,7 +131,7 @@ module Blacklight::BlacklightHelperBehavior
   # @param [Blacklight::SolrResponse] response
   # @return [Boolean]
   def should_show_spellcheck_suggestions? response
-    response.total <= spell_check_max and response.spelling.words.size > 0
+    response.total <= spell_check_max and response.spelling and response.spelling.words.size > 0
   end
 
   ##

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,15 @@
+class Document < ActiveRecord::Base
+  include Blacklight::Document
+  
+  def to_partial_path
+    'catalog/document'
+  end
+
+  def key? k
+    attributes.has_key? k.to_s
+  end
+
+  def _source
+    self
+  end
+end

--- a/app/models/elasticsearch_document.rb
+++ b/app/models/elasticsearch_document.rb
@@ -1,0 +1,72 @@
+require 'elasticsearch/persistence/model'
+
+class ElasticsearchDocument
+  include Blacklight::Document
+  include Elasticsearch::Persistence::Model
+
+  def self.facetable field, type
+    attribute field, type, mapping: { 
+      fields: {
+        field: { type: 'string' },
+        raw: { type: 'string', index: 'not_analyzed' }
+      }
+    } 
+  end
+  
+  def self.sortable field, type
+    attribute field, type, mapping: { 
+      fields: {
+        field: { type: 'string' },
+        raw: { type: 'string', index: 'not_analyzed' }
+      }
+    } 
+  end
+
+  facetable :lc_1letter_facet, String
+  attribute :author_t, String
+  attribute :marc_display, String
+  attribute :published_display, String
+  attribute :author_display, String
+  attribute :lc_callnum_display, String
+  attribute :title_t, String
+  attribute :pub_date, String
+  sortable :pub_date_sort, String
+  facetable :format, String
+  attribute :material_type_display, String
+  facetable :lc_b4cutter_facet, String
+  attribute :title_display, String
+  sortable :title_sort, String
+  sortable :author_sort, String
+  attribute :title_addl_t, String
+  attribute :author_addl_t, String
+  facetable :lc_alpha_facet, String
+  facetable :language_facet, String
+  attribute :subtitle_display, String
+  attribute :author_vern_display, String
+  attribute :subject_addl_t, String
+  facetable :subject_era_facet, String
+  attribute :isbn_t, String
+  facetable :subject_geo_facet, String
+  facetable :subject_topic_facet, String
+  attribute :title_series_t, String
+  attribute :subtitle_t, String
+  attribute :title_vern_display, String
+  attribute :published_vern_display, String
+  attribute :subtitle_vern_display, String
+  attribute :subject_t, String
+  attribute :title_added_entry_t, String
+  attribute :url_suppl_display, String
+  
+  def to_partial_path
+    'catalog/document'
+  end
+
+  def key? k
+    attributes.include? k.to_sym
+  end
+
+  def _source
+    self
+  end
+
+end

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |s|
   s.add_dependency "rsolr",     "~> 1.0.11"  # Library for interacting with rSolr.
   s.add_dependency "bootstrap-sass", "~> 3.2"
   s.add_dependency "deprecation"
+  s.add_dependency "elasticsearch-model"
+  s.add_dependency "elasticsearch-rails"
+  s.add_dependency "elasticsearch-persistence"
 
   s.add_development_dependency "jettywrapper", ">= 1.7.0"
   s.add_development_dependency "blacklight-marc", "~> 5.0"

--- a/db/migrate/2015_create_document.rb
+++ b/db/migrate/2015_create_document.rb
@@ -1,0 +1,48 @@
+# -*- encoding : utf-8 -*-
+class CreateDocument < ActiveRecord::Migration
+  def self.up
+    create_table :documents do |t|
+      
+      t.string :lc_1letter_facet
+      t.string :author_t
+      t.string :marc_display
+      t.string :published_display
+      t.string :author_display
+      t.string :lc_callnum_display
+      t.string :title_t
+      t.string :pub_date
+      t.string :pub_date_sort
+      t.string :format
+      t.string :material_type_display
+      t.string :lc_b4cutter_facet
+      t.string :title_display
+      t.string :title_sort
+      t.string :author_sort
+      t.string :title_addl_t
+      t.string :author_addl_t
+      t.string :lc_alpha_facet
+      t.string :language_facet
+      t.string :subtitle_display
+      t.string :author_vern_display
+      t.string :subject_addl_t
+      t.string :subject_era_facet
+      t.string :isbn_t
+      t.string :subject_geo_facet
+      t.string :subject_topic_facet
+      t.string :title_series_t
+      t.string :subtitle_t
+      t.string :title_vern_display
+      t.string :published_vern_display
+      t.string :subtitle_vern_display
+      t.string :subject_t
+      t.string :title_added_entry_t
+      t.string :url_suppl_display
+
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :documents
+  end
+end

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -36,6 +36,7 @@ module Blacklight
   autoload :Facet, 'blacklight/facet'
   
   autoload :Elasticsearch,       'blacklight/elasticsearch'
+  autoload :Ar,       'blacklight/ar'
 
   extend SearchFields
   extend Deprecation
@@ -85,6 +86,8 @@ module Blacklight
       Blacklight::Elasticsearch::Repository
     when "solr"
       Blacklight::SolrRepository
+    when "ar"
+      Blacklight::Ar::Repository
     else
       raise "No connection adapter found"
     end

--- a/lib/blacklight/ar.rb
+++ b/lib/blacklight/ar.rb
@@ -1,0 +1,145 @@
+module Blacklight
+  module Ar
+    class Repository < Blacklight::AbstractRepository
+
+      class SingleDocumentResponse
+        def initialize doc
+          @doc = doc
+        end
+
+        def documents
+          [@doc]
+        end
+      end
+      
+      class FacetResponse
+        attr_reader :name, :counts
+
+        def initialize name, counts
+          @name = name
+          @counts = counts
+        end
+
+        def items
+          counts.map do |key, count|
+            OpenStruct.new(name: name, value: key, hits: count)
+          end
+        end
+
+        def sort; end
+        def offset; end
+        def limit; end
+      end
+
+      class Aggregations
+        def initialize response
+          @response = response
+        end
+
+        def [] key
+          FacetResponse.new(key, @response.response.group(key).count)
+        end
+      end
+      
+      class SearchResponse
+        attr_reader :response, :params
+        
+        include Kaminari::PageScopeMethods
+        include Kaminari::ConfigurationMethods::ClassMethods
+
+        def initialize response, params
+          @response = response
+          @params = params
+        end
+
+        def grouped?
+          false
+        end
+
+        def results
+          response
+        end
+
+        def total
+          response.total_count
+        end
+
+        alias_method :documents, :results
+
+        delegate :empty?, to: :results
+
+        def aggregations
+          Aggregations.new(self)
+        end
+
+        alias_method :total_count, :total
+        
+        def start
+          params.start
+        end
+        alias_method :offset_value, :start
+        
+        def limit_value
+          params.per
+        end
+        alias_method :rows, :limit_value
+
+        def sort
+          params.send(:sort)
+        end
+
+        def spelling
+          nil
+        end
+
+      end
+
+      ##
+      # Find a single document result (by id) using the document configuration
+      # @param [String] document's unique key value
+      def find id, params = {}
+        response = SingleDocumentResponse.new(blacklight_config.document_model.find(id))
+        response
+      end
+
+      ##
+      # Execute a search query
+      # @param [Hash] elastic search query parameters
+      def search params = {}
+        Rails.logger.info "AR parameters: #{params.inspect}"
+        SearchResponse.new(params.search(blacklight_config.document_model), params)
+      end
+    end
+
+    class SearchBuilder < Blacklight::SearchBuilder
+      self.default_processor_chain = []
+
+      attr_accessor :scopes
+
+      def initialize *args
+        super
+        self.scopes = []
+      end
+
+      def query *args
+        self
+      end
+
+      def search model
+        scope = model.page(page).per(per).padding(start % per)
+
+        if sort
+          scope = scope.order(sort)
+        end
+        
+        (blacklight_params[:f] || {}).each do |field, values|
+          scope = scope.where(field => Array(values))
+        end
+
+        scope.all
+      end
+
+
+    end
+  end
+end

--- a/lib/blacklight/catalog/search_context.rb
+++ b/lib/blacklight/catalog/search_context.rb
@@ -103,6 +103,8 @@ module Blacklight::Catalog::SearchContext
     end
   rescue Blacklight::Exceptions::InvalidRequest => e
     logger.warn "Unable to setup next and previous documents: #{e}"
+  rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+    logger.warn "Unable to setup next and previous documents: #{e}"
   end
 
 end

--- a/lib/blacklight/elasticsearch.rb
+++ b/lib/blacklight/elasticsearch.rb
@@ -1,0 +1,6 @@
+module Blacklight
+  module Elasticsearch
+    autoload :Repository, "blacklight/elasticsearch/repository"
+    autoload :SearchBuilder, "blacklight/elasticsearch/search_builder"
+  end
+end

--- a/lib/blacklight/elasticsearch/repository.rb
+++ b/lib/blacklight/elasticsearch/repository.rb
@@ -1,0 +1,106 @@
+module Blacklight::Elasticsearch
+  class Repository < Blacklight::AbstractRepository
+    class SingleDocumentResponse
+      def initialize doc
+        @doc = doc
+      end
+
+      def documents
+        [@doc]
+      end
+    end
+
+    class FacetResponse
+      attr_reader :name, :aggregation
+
+      def initialize name, aggregation
+        @name = name
+        @aggregation = aggregation
+      end
+
+      def items
+        aggregation.buckets.map do |b|
+          OpenStruct.new(name: name, value: b['key'], hits: b['doc_count'])
+        end
+      end
+
+      def sort; end
+      def offset; end
+      def limit; end
+    end
+    
+    class SearchResponse
+      attr_reader :response, :params
+      
+      include Kaminari::PageScopeMethods
+      include Kaminari::ConfigurationMethods::ClassMethods
+
+      def initialize response, params
+        @response = response
+        @params = params
+      end
+
+      def grouped?
+        false
+      end
+
+      delegate :results, :total, to: :response
+
+      alias_method :documents, :results
+
+      delegate :empty?, to: :results
+
+      def facet_by_field_name field_name
+        if agg = response.response.aggregations[field_name]
+          FacetResponse.new(field_name, agg)
+        end
+      end
+
+      def facet_pivot *args
+        {}
+      end
+
+      def facet_queries *args
+        []
+      end
+
+      alias_method :total_count, :total
+      
+      def start
+        params['from'] || 0
+      end
+      alias_method :offset_value, :start
+      
+      def limit_value
+        params['size'] || response.size
+      end
+      alias_method :rows, :limit_value
+
+      def sort
+        nil
+      end
+
+      def spelling
+        nil
+      end
+
+    end
+
+    ##
+    # Find a single document result (by id) using the document configuration
+    # @param [String] document's unique key value
+    def find id, params = {}
+      response = SingleDocumentResponse.new(blacklight_config.document_model.find(id))
+      response
+    end
+
+    ##
+    # Execute a search query
+    # @param [Hash] elastic search query parameters
+    def search params = {}
+      Rails.logger.info "ES parameters: #{params.inspect}"
+      SearchResponse.new(blacklight_config.document_model.search(params), params)
+    end
+
+  end
+end

--- a/lib/blacklight/elasticsearch/search_builder.rb
+++ b/lib/blacklight/elasticsearch/search_builder.rb
@@ -1,0 +1,88 @@
+module Blacklight::Elasticsearch
+  class SearchBuilder < Blacklight::SearchBuilder
+    self.default_processor_chain = [:default_parameters, :build_query, :add_filters, :add_aggregations, :add_pagination, :add_sort]
+
+    ####
+    # Start with general defaults from BL config. Need to use custom
+    # merge to dup values, to avoid later mutating the original by mistake.
+    def default_parameters(es_parameters)
+      return unless blacklight_config.default_elasticsearch_params
+
+      blacklight_config.default_elasticsearch_params.each do |key, value|
+        es_parameters[key] = if value.respond_to? :deep_dup
+          value.deep_dup
+        elsif value.respond_to? :dup and value.duplicable?
+          value.dup
+        else
+          value
+        end
+      end
+    end
+
+    def build_query(es_parameters)
+      return unless blacklight_params[:q]
+      es_parameters[:query] ||= {}
+      
+      if blacklight_params[:q].is_a? Hash
+        es_parameters[:query][:match] ||= {}
+
+        blacklight_params[:q].each do |k,v|
+          es_parameters[:query][:match][k] = v
+        end
+        return
+      end
+
+      if search_field and search_field.template
+        es_parameters[:query][:template] = search_field.template.dup
+        es_parameters[:query][:template][:params] ||= {}
+        es_parameters[:query][:template][:params][:q] = blacklight_params[:q]
+      else
+        es_parameters[:query][:match] ||= {}
+        es_parameters[:query][:match][:_all] = blacklight_params[:q]
+      end
+    end
+    
+    def add_filters(es_parameters)
+      if blacklight_params[:f]
+        es_parameters[:query] ||= {}
+        es_parameters[:query][:filtered] ||= {}
+        es_parameters[:query][:filtered][:filter] ||= {}
+        es_parameters[:query][:filtered][:filter][:term] ||= {}
+        
+        
+        blacklight_params[:f].each_pair do |facet_field, value_list|
+          
+          facet_config = blacklight_config.facet_fields[facet_field]
+
+          field = facet_config.field if facet_config
+          field ||= facet_field
+
+          es_parameters[:query][:filtered][:filter][:term][field] ||= value_list
+        end      
+      end
+    end
+
+    def add_aggregations(es_parameters)
+      es_parameters[:aggregations] ||= {}
+
+      blacklight_config.facet_fields.select { |field_name,facet|
+        facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request)
+      }.each do |key, facet_config|
+        es_parameters[:aggregations][facet_config.field] = { terms: { field: facet_config.field } }
+      end
+    end
+
+    def add_pagination(es_parameters)
+      es_parameters[:from] = start
+      es_parameters[:size] = rows
+    end
+
+    def add_sort(es_parameters)
+      es_parameters[:sort] = sort unless sort.blank?
+    end
+
+    def query(*args)
+      super.except(:fl, :facet)
+    end
+  end
+end

--- a/lib/blacklight/routes.rb
+++ b/lib/blacklight/routes.rb
@@ -122,7 +122,7 @@ module Blacklight
           args = {only: [:show]}
           args[:constraints] = options[:constraints] if options[:constraints]
 
-          resources :solr_document, args.merge(path: primary_resource, controller: primary_resource) do
+          resources :elasticsearch_document, args.merge(path: primary_resource, controller: primary_resource) do
             member do
               post "track"
             end

--- a/lib/railties/blacklight.rake
+++ b/lib/railties/blacklight.rake
@@ -18,6 +18,10 @@ namespace :blacklight do
       docs = YAML::load(File.open(args[:file]))
 
       case Blacklight.default_index
+      when Blacklight::Ar::Repository
+        docs.each do |h|
+          Document.create!(h.except('timestamp'))
+        end
       when Blacklight::Elasticsearch::Repository
         ElasticsearchDocument.create_index! force: true
         docs.each do |h|

--- a/lib/railties/blacklight.rake
+++ b/lib/railties/blacklight.rake
@@ -12,11 +12,23 @@ namespace :blacklight do
 
   namespace :index do
     desc "Put sample data into solr"
-    task :seed do
-      docs = YAML::load(File.open(File.join(Blacklight.root, 'solr', 'sample_solr_documents.yml')))
-      conn = Blacklight.default_index.connection
-      conn.add docs
-      conn.commit
+    task :seed, [:file] => [:environment] do |t, args|
+      args.with_defaults(file: File.join(Blacklight.root, 'solr', 'sample_solr_documents.yml'))
+
+      docs = YAML::load(File.open(args[:file]))
+
+      case Blacklight.default_index
+      when Blacklight::Elasticsearch::Repository
+        ElasticsearchDocument.create_index! force: true
+        docs.each do |h|
+          ElasticsearchDocument.new(h.except('timestamp')).save
+        end
+      when Blacklight::SolrRepository
+        conn = Blacklight.default_index.connection
+
+        conn.add docs
+        conn.commit
+      end
     end
   end
 


### PR DESCRIPTION
The Elasticsearch-specific stuff should be spun off into a separate gem, but I'm playing around here to try to identify parts of Blacklight that also need to change.

- [x] search queries
- [x] basic facets
- [x] constraints
- [x] catalog#show page
- [x] previous + next document search context
- [x] sorting
- [x] fielded search
- [x] facets with blacklight keys different than the field name

Todo:

- [ ] other aggregation types (namely, query, pivot)
