### PR TITLE
Extract fluent interfaces for SearchBuilder start/page/rows

### DIFF
--- a/lib/blacklight/solr/search_builder.rb
+++ b/lib/blacklight/solr/search_builder.rb
@@ -167,10 +167,12 @@ module Blacklight::Solr
     # copy paging params from BL app over to solr, changing
     # app level per_page and page to Solr rows and start. 
     def add_paging_to_solr(solr_params)
-      # user-provided parameters should override any default row
-      solr_params[:rows] = rows(solr_params[:rows])
-      if page > 1
-        solr_params[:start] = solr_params[:rows].to_i * (page - 1)
+      rows(solr_params[:rows] || 10) if rows.nil?
+
+      solr_params[:rows] = rows
+
+      if start != 0
+        solr_params[:start] = start
       end
     end
 

--- a/spec/lib/blacklight/search_builder_spec.rb
+++ b/spec/lib/blacklight/search_builder_spec.rb
@@ -100,31 +100,33 @@ describe Blacklight::SearchBuilder do
   end
 
   describe "#rows" do
+
+    it "should be nil if no value is set" do
+      blacklight_config.default_per_page = nil
+      blacklight_config.per_page = []
+      expect(subject.rows).to be_nil
+    end
+
+    it "should set the number of rows" do
+      expect(subject.rows(17).rows).to eq 17
+    end
+
     it "should be the per_page parameter" do
-      expect(subject.with(per_page: 5).send(:rows)).to eq 5
+      expect(subject.with(per_page: 5).rows).to eq 5
     end
 
     it "should support the legacy 'rows' parameter" do
-      expect(subject.with(rows: 10).send(:rows)).to eq 10
-    end
-
-    it "should use the provided default" do
-      expect(subject.send(:rows, 17)).to eq 17
+      expect(subject.with(rows: 10).rows).to eq 10
     end
 
     it "should be set to the configured default" do
       blacklight_config.default_per_page = 42
-      expect(subject.send(:rows)).to eq 42
-    end
-
-    it "should default to 10" do
-      blacklight_config.default_per_page = nil
-      expect(subject.send(:rows)).to eq 10
+      expect(subject.rows).to eq 42
     end
 
     it "should limit the number of rows to the configured maximum" do
       blacklight_config.max_per_page = 1000
-      expect(subject.send(:rows, 1001)).to eq 1000
+      expect(subject.rows(1001).rows).to eq 1000
     end
   end
 

--- a/spec/lib/blacklight/solr/search_builder_spec.rb
+++ b/spec/lib/blacklight/solr/search_builder_spec.rb
@@ -40,7 +40,6 @@ describe Blacklight::Solr::SearchBuilder do
                              :qf => "fieldOne^2.3 fieldTwo fieldThree^0.4",
                              :pf => "",
                              :spellcheck => 'false',
-                             :rows => "55",
                              :sort => "request_params_sort" }
                           )
       end
@@ -60,10 +59,6 @@ describe Blacklight::Solr::SearchBuilder do
 
       it "should fall through to BL general defaults for qt not otherwise specified " do
         expect(subject[:qt]).to eq blacklight_config[:default_solr_params][:qt]
-      end
-
-      it "should take rows from search field definition where specified" do
-        expect(subject[:rows]).to eq "55"
       end
 
       it "should take q from request params" do


### PR DESCRIPTION
Different SearchBuilder implementations may want to handle pagination differently, and a fluent interface makes that much easier than trying to extract it out of params.