### PR TITLE
Configurable show classes

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -118,6 +118,15 @@ module Blacklight::CatalogHelperBehavior
   end
 
   ##
+  # Render the main content partial for a document
+  #
+  # @param [SolrDocument]
+  # @return [String]
+  def render_document_main_content_partial(document = @document)
+    render partial: 'show_main_content'
+  end
+
+  ##
   # Should we display the sort and per page widget?
   # 
   # @param [Blacklight::SolrResponse]

--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -1,0 +1,34 @@
+# Methods added to this helper will be available to all templates in the hosting
+# application
+module Blacklight
+  # A module for useful methods used in layout configuration
+  module LayoutHelperBehavior
+    ##
+    # Classes added to a document's show content div
+    # @return [String]
+    def show_content_classes
+      "#{main_content_classes} show-document"
+    end
+
+    ##
+    # Classes added to a document's sidebar div
+    # @return [String]
+    def show_sidebar_classes
+      sidebar_classes
+    end
+
+    ##
+    # Classes used for sizing the main content of a Blacklight page
+    # @return [String]
+    def main_content_classes
+      'col-md-9 col-sm-8'
+    end
+
+    ##
+    # Classes used for sizing the sidebar content of a Blacklight page
+    # @return [String]
+    def sidebar_classes
+      'col-md-3 col-sm-4'
+    end
+  end
+end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -1,0 +1,3 @@
+module LayoutHelper
+  include Blacklight::LayoutHelperBehavior
+end

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,19 @@
+<%= render 'previous_next_doc' %>
+
+<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
+<% content_for(:head) { render_link_rel_alternates } %>
+
+<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+  <div id="doc_<%= @document.id.to_s.parameterize %>">
+    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+  </div>
+</div>
+
+<% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+  <!-- 
+       // COinS, for Zotero among others. 
+       // This document_partial_name(@document) business is not quite right,
+       // but has been there for a while. 
+  -->
+  <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+<% end %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,8 +1,8 @@
-<div id="sidebar" class="col-md-3 col-sm-4">
+<div id="sidebar" class="<%= sidebar_classes %>">
   <%= render 'search_sidebar' %>
 </div>
 
-<div id="content" class="col-md-9 col-sm-8">
+<div id="content" class="<%= main_content_classes %>">
   <% unless has_search_parameters? %>
     <%# if there are no input/search related params, display the "home" partial -%>
     <%= render 'home' %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,7 +1,7 @@
-<div id="content" class="col-md-9 col-sm-8 show-document">
+<div id="content" class="<%= show_content_classes %>">
   <%= render_document_main_content_partial %>
 </div>
 
-<div id="sidebar" class="col-md-3 col-sm-4">
+<div id="sidebar" class="<%= show_sidebar_classes %>">
    <%= render_document_sidebar_partial %>
 </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,32 +1,5 @@
 <div id="content" class="col-md-9 col-sm-8 show-document">
-
-  <%= render 'previous_next_doc' %>
-
-   
-<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe -%>
-<% content_for(:head) { render_link_rel_alternates } -%>
-<%# this should be in a partial -%>
-
-<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
-  <div id="doc_<%= @document.id.to_s.parameterize %>">
-  
-    <% # bookmark/folder functions -%>
-    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
- 
-  </div>
-</div>
-
-
-
-  <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
-    <!-- 
-         // COinS, for Zotero among others. 
-         // This document_partial_name(@document) business is not quite right,
-         // but has been there for a while. 
-    -->
-    <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
-  <% end %>
-
+  <%= render_document_main_content_partial %>
 </div>
 
 <div id="sidebar" class="col-md-3 col-sm-4">

--- a/spec/helpers/layout_helper_spec.rb
+++ b/spec/helpers/layout_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe LayoutHelper do
+  describe '#show_content_classes' do
+    it 'returns a string of classes' do
+      expect(helper.show_content_classes).to be_an String
+      expect(helper.show_content_classes).to eq 'col-md-9 col-sm-8 show-document'
+    end
+  end
+
+  describe '#show_sidebar_classes' do
+    it 'returns a string of classes' do
+      expect(helper.show_sidebar_classes).to be_an String
+      expect(helper.show_sidebar_classes).to eq 'col-md-3 col-sm-4'
+    end
+  end
+
+  describe '#main_content_classes' do
+    it 'returns a string of classes' do
+      expect(helper.main_content_classes).to be_an String
+      expect(helper.main_content_classes).to eq 'col-md-9 col-sm-8'
+    end
+  end
+
+  describe '#sidebar_classes' do
+    it 'returns a string of classes' do
+      expect(helper.sidebar_classes).to be_an String
+      expect(helper.sidebar_classes).to eq 'col-md-3 col-sm-4'
+    end
+  end
+end


### PR DESCRIPTION
This pull request enables more configuration on a document's show page, without having to override a partial.

 1. 996a6ae moves most of the content within https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/show.html.erb#L3-29 into a new partial `_show_main_content.html.erb`
 1. 4461f5b makes the classes used for both the content and sidebar divs configurable via new helpers. These new helpers are part of a new `LayoutHelper` module
