### PR TITLE
SolrRepository#find should prefer the default_document_solr_params[:qt] over document_solr_request_handler

### DIFF
--- a/lib/blacklight/solr_repository.rb
+++ b/lib/blacklight/solr_repository.rb
@@ -12,8 +12,8 @@ module Blacklight
     # @param [String] document's unique key value
     # @param [Hash] additional solr query parameters
     def find id, params = {}
-      doc_params = params.reverse_merge(qt: blacklight_config.document_solr_request_handler)
-                         .reverse_merge(blacklight_config.default_document_solr_params)
+      doc_params = params.reverse_merge(blacklight_config.default_document_solr_params)
+                         .reverse_merge(qt: blacklight_config.document_solr_request_handler)
                          .merge(blacklight_config.document_unique_id_param => id)
 
       solr_response = send_and_receive blacklight_config.document_solr_path || blacklight_config.solr_path, doc_params

--- a/spec/lib/blacklight/solr_repository_spec.rb
+++ b/spec/lib/blacklight/solr_repository_spec.rb
@@ -42,6 +42,13 @@ describe Blacklight::SolrRepository do
       allow(subject.connection).to receive(:send_and_receive).with('select', hash_including(params: { id: '123', qt: 'abc'})).and_return(mock_response)
       expect(subject.find("123", {qt: 'abc'})).to be_a_kind_of Blacklight::SolrResponse
     end
+    
+    it "should use the :qt parameter from the default_document_solr_params" do
+      blacklight_config.default_document_solr_params[:qt] = 'abc'
+      blacklight_config.document_solr_request_handler = 'xyz'
+      allow(subject.connection).to receive(:send_and_receive).with('select', hash_including(params: { id: '123', qt: 'abc'})).and_return(mock_response)
+      expect(subject.find("123")).to be_a_kind_of Blacklight::SolrResponse
+    end
 
     it "should preserve the class of the incoming params" do
       doc_params = HashWithIndifferentAccess.new


### PR DESCRIPTION
Fixes #1186 