### PR TITLE
Add clearer error on missing secret key

### DIFF
--- a/lib/blacklight/rails/routes.rb
+++ b/lib/blacklight/rails/routes.rb
@@ -18,7 +18,7 @@ module ActionDispatch::Routing
     private
     def raise_no_blacklight_secret_key #:nodoc:
       raise <<-ERROR
-Blacklight.secret_key was not set. Please add the following to an initializer:
+Blacklight.secret_key was not set. If you are using Rails 4.1+, set your app's secret key base (config/secrets.yml) OR add the following to an initializer:
 
 Blacklight.secret_key = '#{SecureRandom.hex(64)}'
 


### PR DESCRIPTION
Helps when doing a quick test of a production environment that isn't yet set up to know we only need the secret key base.