### PR TITLE
Add a CacheKey module that is mixed into Blacklight::Document

### DIFF
--- a/lib/blacklight/document.rb
+++ b/lib/blacklight/document.rb
@@ -15,6 +15,7 @@
 module Blacklight::Document
   autoload :ActiveModelShim, 'blacklight/document/active_model_shim'
   autoload :SchemaOrg, 'blacklight/document/schema_org'
+  autoload :CacheKey, 'blacklight/document/cache_key'
   autoload :DublinCore, 'blacklight/document/dublin_core'
   autoload :Email, 'blacklight/document/email'
   autoload :SemanticFields, 'blacklight/document/semantic_fields'
@@ -25,6 +26,7 @@ module Blacklight::Document
   extend ActiveSupport::Concern
   include Blacklight::Document::SchemaOrg
   include Blacklight::Document::SemanticFields
+  include Blacklight::Document::CacheKey
   include Blacklight::Document::Export
 
   extend Deprecation

--- a/lib/blacklight/document/cache_key.rb
+++ b/lib/blacklight/document/cache_key.rb
@@ -1,0 +1,23 @@
+# -*- encoding : utf-8 -*-
+# This module provides the cache key which can be used by rails
+# caching to determine when to expire a particular object's cache
+# See http://apidock.com/rails/ActiveRecord/Integration/cache_key
+# This key should be used in conjunction with additional data to
+# determine when a document can be cached (e.g. for different view
+# types in search results like gallery and list)
+module Blacklight::Document::CacheKey
+  def cache_key
+    case
+    when new_record?
+      "#{self.class.model_name.cache_key}/new"
+    when cache_version_value = self[cache_version_key]
+      "#{self.class.model_name.cache_key}/#{id}-#{Array(cache_version_value).join}"
+    else
+      "#{self.class.model_name.cache_key}/#{id}"
+    end
+  end
+
+  def cache_version_key
+    :_version_
+  end
+end

--- a/spec/lib/blacklight/document/cache_key_spec.rb
+++ b/spec/lib/blacklight/document/cache_key_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Blacklight::Document::CacheKey do
+  let(:attributes) { {} }
+  let(:subject) { SolrDocument.new(attributes) }
+  it 'SolrDocument includes the module' do
+    expect(subject.class).to include(Blacklight::Document::CacheKey)
+  end
+
+  describe 'new record' do
+    before do
+      allow(subject).to receive_messages(new_record?: true)
+    end
+    it 'provides an acceptable cache key' do
+      expect(subject.cache_key).to eq 'solr_documents/new'
+    end
+  end
+
+  describe 'with version' do
+    let(:attributes) { { id: '12345', _version_: '1497353774427013120' } }
+    it 'provides a cache key with the id and version' do
+      expect(subject.cache_key).to eq 'solr_documents/12345-1497353774427013120'
+    end
+    describe 'as array' do
+      let(:attributes) { { id: '12345', _version_: ['1234', '4321'] } }
+      it 'provides a cache key with the id and joined version array' do
+        expect(subject.cache_key).to eq 'solr_documents/12345-12344321'
+      end
+    end
+  end
+
+  describe 'without version' do
+    let(:attributes) { { id: '12345' } }
+    it 'provides a cache key with just the id' do
+      expect(subject.cache_key).to eq 'solr_documents/12345'
+    end
+  end
+
+  describe '#cache_version_key' do
+    let(:attributes) { { id: '12345', another_version_field: '1497353774427013120' } }
+    before do
+      allow(subject).to receive_messages(cache_version_key: :another_version_field)
+    end
+    it 'provides a cache key with the defined field' do
+      expect(subject.cache_key).to eq 'solr_documents/12345-1497353774427013120'
+    end
+  end
+end


### PR DESCRIPTION
This returns a cache_key method for classes that mixin `Blacklight::Document` that uses the class name, item id, and a formatted updated at timestamp.