### PR TITLE
adds save search to results collection

### DIFF
--- a/app/assets/stylesheets/blacklight/_blacklight_base.scss
+++ b/app/assets/stylesheets/blacklight/_blacklight_base.scss
@@ -16,3 +16,4 @@
 @import "blacklight/facets";
 @import "blacklight/search_history";
 @import "blacklight/modal";
+@import 'blacklight/results';

--- a/app/assets/stylesheets/blacklight/_results.scss
+++ b/app/assets/stylesheets/blacklight/_results.scss
@@ -1,0 +1,10 @@
+.search-widgets {
+  .form-inline {
+    display: inline;
+    position: relative;
+
+    div {
+      display: inline;
+    }
+  }
+}

--- a/app/views/catalog/_save_search.html.erb
+++ b/app/views/catalog/_save_search.html.erb
@@ -1,0 +1,8 @@
+<% search ||= @current_search_session %>
+<% if search %>
+  <% if current_or_guest_user && search.saved? %>
+    <%= button_to t('blacklight.search_history.forget'), forget_search_path(search.id), class: 'btn btn-default', form_class: 'form-inline' %>
+  <% else %>
+    <%= button_to t('blacklight.search_history.save'), save_search_path(search.id), method: :put, :class => 'btn btn-default', form_class: 'form-inline' %>
+  <% end %>
+<% end %>

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -176,6 +176,9 @@ class <%= controller_name.classify %>Controller < ApplicationController
     # If there are more than this many search results, no spelling ("did you 
     # mean") suggestion is offered.
     config.spell_max = 5
+    
+    # Add the save search tool to a results collection
+    config.add_results_collection_tool :save_search
   end
 
 end 

--- a/spec/features/saved_searches_spec.rb
+++ b/spec/features/saved_searches_spec.rb
@@ -10,6 +10,18 @@ describe "Saved Searches" do
     click_link 'Saved Searches'
     expect(page).to have_content 'You have no saved searches'
   end
+  
+  it 'can be saved and forgotten from a search result' do
+    visit catalog_index_path(q: 'book')
+    within '.search-widgets' do
+      click_button 'save'
+    end
+    expect(page).to have_content 'Successfully saved your search.'
+    within '.search-widgets' do
+      click_button 'forget'
+    end
+    expect(page).to have_content 'Successfully removed that saved search.'
+  end
 
   describe "with a saved search 'book'" do
     before do
@@ -37,7 +49,7 @@ describe "Saved Searches" do
         click_button "save"
         click_link 'Saved Searches'
       end
-      it "should clear the searhes" do
+      it "should clear the searches" do
         click_link "Clear Saved Searches"
         expect(page).to have_content 'Cleared your saved searches.'
         expect(page).to have_content 'You have no saved searches'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,5 +55,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view
   config.infer_spec_type_from_file_location!
 end

--- a/spec/views/catalog/_save_search.html.erb_spec.rb
+++ b/spec/views/catalog/_save_search.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "/catalog/_save_search.html.erb" do
+  describe 'a current user' do
+    before do
+      sign_in 'user1'
+    end
+    describe ' and a saved search' do
+      it 'renders a forget button' do
+        assign(:current_search_session, double('saved?' => true, id: 1))
+        render
+        within 'form[action="/saved_searches/forget/1"]' do
+          expect(rendered).to have_css 'input[value="forget"]'
+        end
+      end
+    end
+    describe ' and a search that is not saved' do
+      it 'renders a save button' do
+        assign(:current_search_session, double('saved?' => false, id: 1))
+        render
+        within 'form[action="/saved_searches/save/1"]' do
+          expect(rendered).to have_css 'input[value="save"]'
+        end
+      end
+    end
+  end
+  describe 'no current user and search that is not saved' do
+    it 'renders a save button' do
+      assign(:current_search_session, double('saved?' => false, id: 1))
+      render
+      within 'form[action="/saved_searches/save/1"]' do
+        expect(rendered).to have_css 'input[value="save"]'
+      end
+    end
+  end
+  describe 'no current search' do
+    it 'renders nothing' do
+      assign(:current_search_session, false)
+      render
+      expect(rendered).to_not have_css 'form'
+    end
+  end
+end


### PR DESCRIPTION
Should close #520 @jcoyne ?

Adds a "save" and "forget" button to the results collection area on a results page. I opted to do this in `catalog_controller.rb` for easy commenting out by those who don't want to use this functionality.

![screen shot 2015-05-27 at 10 25 14 pm](https://cloud.githubusercontent.com/assets/1656824/7853201/db1ea948-04bf-11e5-87a4-f25fb6e45286.png)

![screen shot 2015-05-27 at 10 25 19 pm](https://cloud.githubusercontent.com/assets/1656824/7853200/db1eb212-04bf-11e5-827e-78cdba772828.png)
