### PR TITLE
Don't copy configuration model classes if nil.

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -342,7 +342,7 @@ module Blacklight
         deep_dup.tap do |copy|
           %w(repository_class response_model document_model document_presenter_class search_builder_class facet_paginator_class).each do |klass|
             # Don't copy if nil, so as not to prematurely autoload default classes
-            copy.send("#{klass}=", send(klass)) unless fetch(klass.to_sym).nil?
+            copy.send("#{klass}=", send(klass)) unless fetch(klass.to_sym, nil).nil?
           end
         end
       end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -340,12 +340,10 @@ module Blacklight
       # too. These model names should not be `#dup`'ed or we might break ActiveModel::Naming.
       def deep_copy
         deep_dup.tap do |copy|
-          copy.repository_class = self.repository_class
-          copy.response_model = self.response_model
-          copy.document_model = self.document_model
-          copy.document_presenter_class = self.document_presenter_class
-          copy.search_builder_class = self.search_builder_class
-          copy.facet_paginator_class = self.facet_paginator_class
+          %w(repository_class response_model document_model document_presenter_class search_builder_class facet_paginator_class).each do |klass|
+            # Don't copy if nil, so as not to prematurely autoload default classes
+            copy.send("#{klass}=", send(klass)) unless fetch(klass.to_sym).nil?
+          end
         end
       end
       alias_method :inheritable_copy, :deep_copy

--- a/spec/lib/blacklight/configuration_spec.rb
+++ b/spec/lib/blacklight/configuration_spec.rb
@@ -96,14 +96,32 @@ describe "Blacklight::Configuration" do
       expect(@config.facet_fields).to_not include(@mock_facet)
     end
 
-    it "should not dup response_model or document_model" do
-      @config.response_model = Blacklight::SolrResponse
-      @config.document_model = SolrDocument
+    context "when model classes are customised" do
+      it "should not dup response_model or document_model" do
+        @config.response_model = Hash
+        @config.document_model = Array
 
-      config_copy = @config.inheritable_copy
+        config_copy = @config.inheritable_copy
 
-      expect(config_copy.response_model).to eq Blacklight::SolrResponse
-      expect(config_copy.document_model).to eq SolrDocument
+        expect(config_copy.response_model).to eq Hash
+        expect(config_copy.document_model).to eq Array
+      end
+    end
+
+    context "when model classes are not set" do
+      it "should leave response_model and document_model empty" do
+        config_copy = @config.inheritable_copy
+
+        expect(config_copy.fetch(:response_model)).to be_nil
+        expect(config_copy.fetch(:document_model)).to be_nil
+      end
+
+      it "should return default classes" do
+        config_copy = @config.inheritable_copy
+
+        expect(config_copy.response_model).to eq Blacklight::SolrResponse
+        expect(config_copy.document_model).to eq SolrDocument
+      end
     end
 
     it "should provide cloned copies of mutable data structures" do

--- a/spec/lib/blacklight/configuration_spec.rb
+++ b/spec/lib/blacklight/configuration_spec.rb
@@ -112,8 +112,8 @@ describe "Blacklight::Configuration" do
       it "should leave response_model and document_model empty" do
         config_copy = @config.inheritable_copy
 
-        expect(config_copy.fetch(:response_model)).to be_nil
-        expect(config_copy.fetch(:document_model)).to be_nil
+        expect(config_copy.fetch(:response_model, nil)).to be_nil
+        expect(config_copy.fetch(:document_model, nil)).to be_nil
       end
 
       it "should return default classes" do


### PR DESCRIPTION
Fixing issue #1207 by leaving the class configuration settings alone if they are `nil`.