### PR TITLE
has_facet_values? should return false if facets have values but are not displayable

### DIFF
--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -9,7 +9,7 @@ module Blacklight::FacetsHelperBehavior
   # @param [Hash] options
   # @return [Boolean]
   def has_facet_values? fields = facet_field_names, options = {}
-    facets_from_request(fields).any? { |display_facet| !display_facet.items.empty? }
+    facets_from_request(fields).any? { |display_facet| !display_facet.items.empty? && should_render_facet?(display_facet) }
   end
 
   ##

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -12,9 +12,9 @@ describe FacetsHelper do
   describe "has_facet_values?" do
     it "should be true if there are any facets to display" do
 
-      a = double(:items => [1,2])
-      b = double(:items => ['b','c'])
-      empty = double(:items => [])
+      a = double(:items => [1,2], :name => 'a')
+      b = double(:items => ['b','c'], :name => 'b')
+      empty = double(:items => [], :name => 'empty')
 
       fields = [a,b,empty]
       expect(helper.has_facet_values?(fields)).to be true
@@ -25,6 +25,19 @@ describe FacetsHelper do
       empty = double(:items => [])
 
       fields = [empty]
+      expect(helper.has_facet_values?(fields)).to be false
+    end
+
+    it "should be false if no facets are displayable" do
+      @config = Blacklight::Configuration.new do |config|
+        config.add_facet_field 'basic_field', :if => false
+      end
+
+      allow(helper).to receive_messages(:blacklight_config => @config)
+
+      a = double(:items => [1,2], :name=>'basic_field')
+      fields = [a]
+
       expect(helper.has_facet_values?(fields)).to be false
     end
   end


### PR DESCRIPTION
I ran into this edge case where there are facets with values but they are not displayable.  This leaves the facets header ("Limit your search") on the page without any facets underneath it.