### PR TITLE
remove extra folder keys

### DIFF
--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -48,16 +48,6 @@ fr:
       list_title: 'Vos favoris'
       delete: 'Supprimer'
 
-    folder:
-      title: 'Panier'
-      add:
-        success: '%{title} a bien été sélectionné.'
-      remove:
-        success: '%{title} a bien été supprimé.'
-      clear:
-        success: 'Panier vide.'
-      no_folder: 'Votre panier est vide'
-
     saved_searches:
       add:
         success: 'Votre recherche a bien été sauvegardée.'


### PR DESCRIPTION
These popped up in a review with @cjcolvar 

Are these legacy keys that were never removed?

cc @biblimathieu

