### PR TITLE
removes qt as a default solr configuration

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -30,8 +30,6 @@ module Blacklight
           # HTTP method to use when making requests to solr; valid
           # values are :get and :post.
           http_method: :get,
-          # The solr request handler ('qt') to use for search requests
-          qt: 'search',
           # The path to send requests to solr.
           solr_path: 'select',
           # Default values of parameters to send with every search request

--- a/lib/blacklight/search_fields.rb
+++ b/lib/blacklight/search_fields.rb
@@ -11,7 +11,7 @@
 # [:label]
 #   "Title",  # user-displayable label, optional, if not supplied :key.titlecase will be used
 # [:qt]
-#   "search", # Solr qt param, request handler, usually can be left blank; defaults to blacklight_config[:default_solr_params][:qt] if not specified. 
+#   "search", # Solr qt param, request handler, usually can be left blank; defaults to nil if not explicitly specified
 # [:solr_parameters]
 #   {:qf => "something"} # optional hash of additional parameters to pass to solr for searches on this field.
 # [:solr_local_parameters]

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -6,7 +6,6 @@ class <%= controller_name.classify %>Controller < ApplicationController
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = { 
-      :qt => 'search',
       :rows => 10 
     }
     

--- a/spec/lib/blacklight/solr/search_builder_spec.rb
+++ b/spec/lib/blacklight/solr/search_builder_spec.rb
@@ -130,8 +130,8 @@ describe Blacklight::Solr::SearchBuilder do
         expect(subject[:"facet.field"].map { |x| x.gsub(/\{![^}]+\}/, '') }).to match_array ["format", "subject_topic_facet", "pub_date", "language_facet", "lc_1letter_facet", "subject_geo_facet", "subject_era_facet"]
       end
 
-      it "should have default qt"  do
-        expect(subject[:qt]).to eq "search"
+      it "should not have a default qt"  do
+        expect(subject[:qt]).to be_nil
       end
       it "should have no fq" do
         expect(subject[:phrase_filters]).to be_blank


### PR DESCRIPTION
This PR should close #930 

Removes `qt` from a configuration, but still allows `qt` to be explicitly passed in.