### PR TITLE
Add support for globalid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ rvm:
 matrix:
   include:
     - rvm: 2.2.2
-      env: "RAILS_VERSION=4.0.12"
-    - rvm: 2.2.2
       env: "RAILS_VERSION=4.1.9"
     - rvm: 2.1.6
       env: "RAILS_VERSION=4.2.1"

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails",     ">= 3.2.6", "< 5"
+  s.add_dependency "rails",     ">= 4.1", "< 5"
+  s.add_dependency "globalid"
   s.add_dependency "nokogiri",  "~>1.6"     # XML Parser
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results
   s.add_dependency "rsolr",     "~> 1.0.11"  # Library for interacting with rSolr.

--- a/lib/blacklight/document.rb
+++ b/lib/blacklight/document.rb
@@ -34,6 +34,7 @@ module Blacklight::Document
   included do
     extend ActiveModel::Naming
     include Blacklight::Document::Extensions
+    include GlobalID::Identification
   end    
 
   attr_reader :response, :_source

--- a/lib/blacklight/document/active_model_shim.rb
+++ b/lib/blacklight/document/active_model_shim.rb
@@ -14,6 +14,14 @@ module Blacklight::Document
       def base_class
         self
       end
+
+      def repository
+        Blacklight.default_index
+      end
+
+      def find id
+        repository.find(id).documents.first
+      end
     end
     
     ##

--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -16,10 +16,11 @@ module Blacklight
   This generator makes the following changes to your application:
    1. Generates blacklight:models
    2. Adds rsolr to the Gemfile
-   3. Creates a number of public assets, including images, stylesheets, and javascript
-   4. Injects behavior into your user application_controller.rb
-   5. Adds example configurations for dealing with MARC-like data
-   6. Adds Blacklight routes to your ./config/routes.rb
+   3. Adds globalid to the Gemfile
+   4. Creates a number of public assets, including images, stylesheets, and javascript
+   5. Injects behavior into your user application_controller.rb
+   6. Adds example configurations for dealing with MARC-like data
+   7. Adds Blacklight routes to your ./config/routes.rb
 
   Thank you for Installing Blacklight.
          """
@@ -37,6 +38,10 @@ module Blacklight
 
     def add_rsolr_gem
       gem "rsolr", "~> 1.0.6"
+    end
+
+    def add_globalid_gem
+      gem "globalid"
     end
 
     def bundle_install

--- a/spec/lib/blacklight/document/active_model_shim_spec.rb
+++ b/spec/lib/blacklight/document/active_model_shim_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'Blacklight::Document::ActiveModelShim' do
+
+  class MockDocument
+    include Blacklight::Document
+    include Blacklight::Document::ActiveModelShim
+  end
+
+  class MockResponse
+    attr_reader :response, :params
+
+    def initialize(response, params)
+      @response = response
+      @params = params
+    end
+
+    def documents
+      response.collect {|doc| MockDocument.new(doc, self)}
+    end
+  end
+
+  before do
+    allow(MockDocument.repository).to receive(:find).and_return(MockResponse.new([{id: 1}], {}))
+  end
+ 
+  describe "#find" do
+   it "should return a document from the repository" do
+      expect(MockDocument.find(1)).to be_a MockDocument
+      expect(MockDocument.find(1).id).to be 1
+    end
+  end
+end

--- a/spec/lib/blacklight/document_spec.rb
+++ b/spec/lib/blacklight/document_spec.rb
@@ -59,4 +59,32 @@ describe Blacklight::Document do
       end
     end
   end
+
+  describe "#to_global_id" do
+    class MockDocument
+      include Blacklight::Document
+      include Blacklight::Document::ActiveModelShim
+    end
+
+    class MockResponse
+      attr_reader :response, :params
+
+      def initialize(response, params)
+        @response = response
+        @params = params
+      end
+
+      def documents
+        response.collect {|doc| MockDocument.new(doc, self)}
+      end
+    end
+
+    before do
+      allow(MockDocument.repository).to receive(:find).and_return(MockResponse.new([{id: 1}], {}))
+    end
+
+    it "should have a globalid" do
+      expect(MockDocument.find(1).to_global_id).to be_a GlobalID
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1120

This allows for inclusion of ActiveModelShim to provide #id and #find if they aren't supplied by the class including Blacklight::Document.  These two methods are required for globalid to function properly.  It looks like the ActiveRecord and ElasticSearch Document implementations in #1156 supply these already.

@jkeck @cbeer
