### PR TITLE
Specify AirBnb javascript style guide

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,4 @@
 ruby:
   config_file: .rubocop.yml
+javascript:
+  config_file: .jshintrc

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,67 @@
+{
+  /*
+   * ENVIRONMENTS
+   * =================
+   */
+
+  // Define globals exposed by modern browsers.
+  "browser": true,
+
+  // Define globals exposed by jQuery.
+  "jquery": true,
+
+  // Define globals exposed by Node.js.
+  "node": true,
+
+  // Allow ES6.
+  "esnext": true,
+
+  /*
+   * ENFORCING OPTIONS
+   * =================
+   */
+
+  // Force all variable names to use either camelCase style or UPPER_CASE
+  // with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Enforce line length to 80 characters
+  "maxlen": 80,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  // Enforce placing 'use strict' at the top function scope
+  "strict": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  /*
+   * RELAXING OPTIONS
+   * =================
+   */
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true,
+
+  // Custom predefined javascript objects that should be defined
+  "predef": [
+    "Blacklight"
+  ]
+}


### PR DESCRIPTION
Asks Hound to use the `.jshintrc` file in project root directory. This should also work for local devs who are working on Blacklight JavaScript, as jshint will look for the [closest .jshintrc file](http://jshint.com/docs/).

The jshintrc is a copy of the [AirBnb JavaScript style guide](https://github.com/airbnb/javascript/blob/master/linters/jshintrc). It adds an additional key, `predef` which allows us to predefine variables. I'm predefining `Blacklight` so that Hound warning will go away.