### PR TITLE
When SearchBuilder has a NameError raise it.

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -223,7 +223,12 @@ module Blacklight
 
     def locate_search_builder_class
       ::SearchBuilder
-    rescue NameError
+    rescue NameError => e
+      # If the NameError is a result of the SearchBuilder having a
+      # NameError (e.g. NoMethodError) within it then raise the error.
+      raise e if Object.const_defined? "::SearchBuilder"
+
+      # Otherwise the NameError was a result of not being able to find SearchBuilder
       Deprecation.warn(Configuration, "Your application is missing the SearchBuilder. Have you run `rails generate blacklight:search_builder`? Falling back to Blacklight::Solr::SearchBuilder")
       Blacklight::Solr::SearchBuilder
     end


### PR DESCRIPTION
Previously the rescue block was hiding the error and saying that
SearchBuilder could not be found.