### PR TITLE
Allow spellcheck collation to support Solr 5 json response format

### DIFF
--- a/lib/blacklight/solr_response/spelling.rb
+++ b/lib/blacklight/solr_response/spelling.rb
@@ -81,6 +81,8 @@ module Blacklight::SolrResponse::Spelling
           unless suggestions.nil?
             if suggestions.index("collation")
               suggestions[suggestions.index("collation") + 1]
+            elsif spellcheck.key?("collations")
+              spellcheck['collations'].last
             end
           end
         end

--- a/spec/lib/blacklight/solr_response_spec.rb
+++ b/spec/lib/blacklight/solr_response_spec.rb
@@ -153,17 +153,34 @@ describe Blacklight::SolrResponse do
     expect(r.spelling.words).to eq []
   end
 
-  it 'should provide spelling suggestions for a regular spellcheck results with a collation' do
-    raw_response = eval(mock_response_with_spellcheck_collation)
-    r = Blacklight::SolrResponse.new(raw_response, {})
-    expect(r.spelling.words).to include("dell")
-    expect(r.spelling.words).to include("ultrasharp")
+  context "pre solr 5 spellcheck collation syntax" do
+    it 'should provide spelling suggestions for a regular spellcheck results with a collation' do
+      raw_response = eval(mock_response_with_spellcheck_collation)
+      r = Blacklight::SolrResponse.new(raw_response, {})
+      expect(r.spelling.words).to include("dell")
+      expect(r.spelling.words).to include("ultrasharp")
+    end
+
+    it 'should provide spelling suggestion collation' do
+      raw_response = eval(mock_response_with_spellcheck_collation)
+      r = Blacklight::SolrResponse.new(raw_response, {})
+      expect(r.spelling.collation).to eq 'dell ultrasharp'
+    end
   end
 
-  it 'should provide spelling suggestion collation' do
-    raw_response = eval(mock_response_with_spellcheck_collation)
-    r = Blacklight::SolrResponse.new(raw_response, {})
-    expect(r.spelling.collation).to eq 'dell ultrasharp'
+  context "solr 5 spellcheck collation syntax" do
+    it 'should provide spelling suggestions for a regular spellcheck results with a collation' do
+      raw_response = eval(mock_response_with_spellcheck_collation_solr5)
+      r = Blacklight::SolrResponse.new(raw_response, {})
+      expect(r.spelling.words).to include("dell")
+      expect(r.spelling.words).to include("ultrasharp")
+    end
+
+    it 'should provide spelling suggestion collation' do
+      raw_response = eval(mock_response_with_spellcheck_collation_solr5)
+      r = Blacklight::SolrResponse.new(raw_response, {})
+      expect(r.spelling.collation).to eq 'dell ultrasharp'
+    end
   end
 
   it "should provide MoreLikeThis suggestions" do
@@ -206,6 +223,10 @@ describe Blacklight::SolrResponse do
   # it can be the case that extended results are off and collation is on
   def mock_response_with_spellcheck_collation
     %|{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'spellspellcheck.build'=>'true','spellcheck'=>'true','q'=>'hell','spellcheck.q'=>'hell ultrashar','wt'=>'ruby','spellcheck.collate'=>'true'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'suggestion'=>['dell']},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'suggestion'=>['ultrasharp']},'collation','dell ultrasharp']}}|
+  end
+
+  def mock_response_with_spellcheck_collation_solr5
+    %|{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'spellspellcheck.build'=>'true','spellcheck'=>'true','q'=>'hell','spellcheck.q'=>'hell ultrashar','wt'=>'ruby','spellcheck.collate'=>'true'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'suggestion'=>['dell']},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'suggestion'=>['ultrasharp']}],'collations'=>['collation','dell ultrasharp']}}|
   end
   
   def mock_response_with_more_like_this


### PR DESCRIPTION
As of Solr 5.0, the format of the JSON response spellcheck hash has [changed](https://issues.apache.org/jira/browse/SOLR-3029) to have `spellcheck` and `collation` as separate keys in the spellcheck hash instead of being elements added after the spelling suggestions in the `spellcheck['suggestions]` array. The 3f1ca2b commit allows Blacklight to support word suggestions for both the new and older Solr response format.

This commit will allow Blacklight to accommodate both response formats for collation as well.