### PR TITLE
Add Rubocop 0.29.1 to bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ gemspec path: File.expand_path('..', __FILE__)
 gem 'simplecov', '~> 0.7.1', require: false
 gem 'coveralls', require: false
 
+group :development do
+  gem 'rubocop', '0.29.1', require: false
+end
+
 group :test do
   gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 end


### PR DESCRIPTION
Re #1204, this simply adds Rubocop 0.29.1 to the bundle so that developers can run the style checks before pushing their commits. Locked to version 0.29.1 as that is the version used by [Hound](https://github.com/thoughtbot/hound/blob/master/Gemfile).