### PR TITLE
Improved API for SearchBuilder processor chain manipulation

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -57,6 +57,27 @@ module Blacklight
     end
 
     ##
+    # Converse to append, remove processor chain directives,
+    # returning a new builder that's a copy of receiver with
+    # specified change. 
+    #
+    # Methods in argument that aren't currently in processor
+    # chain are ignored as no-ops, rather than raising. 
+    def except *except_processor_chain
+      builder = self.class.new(processor_chain - except_processor_chain, scope)
+          .with(blacklight_params)
+          .merge(@merged_params)
+          .reverse_merge(@reverse_merged_params)
+
+      builder.start(@start) if @start
+      builder.rows(@rows) if @rows
+      builder.page(@page) if @page
+      builder.facet(@facet) if @facet
+
+      builder
+    end
+
+    ##
     # Merge additional, repository-specific parameters
     def merge extra_params, &block
       if extra_params

--- a/lib/blacklight/search_helper.rb
+++ b/lib/blacklight/search_helper.rb
@@ -94,13 +94,17 @@ module Blacklight::SearchHelper
 
   # a solr query method
   # @param [Hash,HashWithIndifferentAccess] user_params ({}) the user provided parameters (e.g. query, facets, sort, etc)
-  # @param [Hash,HashWithIndifferentAccess] extra_controller_params ({}) extra parameters to add to the search
   # @param [List<Symbol] processor_chain a list of filter methods to run
+  # @yield [search_builder] optional block yields configured SearchBuilder, caller can modify or create new SearchBuilder to be used. Block should return SearchBuilder to be used. 
   # @return [Blacklight::SolrResponse] the solr response object
   def search_results(user_params, search_params_logic)
     builder = search_builder(search_params_logic).with(user_params)
     builder.page(user_params[:page]) if user_params[:page]
     builder.rows(user_params[:per_page] || user_params[:rows]) if user_params[:per_page] or user_params[:rows]
+
+    if block_given? 
+      builder = yield(builder)
+    end
 
     response = repository.search(builder)
 

--- a/spec/lib/blacklight/search_builder_spec.rb
+++ b/spec/lib/blacklight/search_builder_spec.rb
@@ -47,6 +47,17 @@ describe Blacklight::SearchBuilder do
     end
   end
 
+  describe "#except" do
+    let(:processor_chain) { [:a, :b, :c, :d, :e] }
+    it "should provide a new search builder excepting arguments" do
+      builder = subject.except(:b, :d, :does_not_exist)
+      expect(builder).not_to equal(subject)
+      expect(subject.processor_chain).to eq processor_chain
+      expect(builder.processor_chain).not_to eq subject.processor_chain
+      expect(builder.processor_chain).to match_array [:a, :c, :e]
+    end
+  end
+
   describe "#to_hash" do
     it "should append the extra parameters to the result" do
       Deprecation.silence(Blacklight::SearchBuilder) do

--- a/spec/lib/blacklight/search_helper_spec.rb
+++ b/spec/lib/blacklight/search_helper_spec.rb
@@ -118,6 +118,27 @@ describe Blacklight::SearchHelper do
       end
     end
 
+    describe "with SearchBuilder replacement block" do
+      it "should pass configured SearchBuilder and use returned SearchBuilder" do
+        replacement_search_builder = subject.search_builder([:new_chain])
+
+        # Sorry, have to use mocks to make sure method really passes the
+        # block return value to the repository search, couldn't figure
+        # out a better way to test. 
+        expect(subject.repository).to receive(:search) do |arg_search_builder|
+          expect(arg_search_builder).to equal(replacement_search_builder)
+        end.and_return(
+          blacklight_config.response_model.new({'response'=>{'docs'=>[]}}, {}, document_model: blacklight_config.document_model, blacklight_config: blacklight_config)
+        )
+
+        subject.search_results({q: @no_docs_query}, [:one, :two]) do |arg_search_builder|
+          expect(arg_search_builder.processor_chain).to eq([:one, :two])
+
+          replacement_search_builder
+        end
+      end
+    end
+
     describe "#get_search_results " do
       it "should be deprecated and return results" do
         expect(Deprecation).to receive(:warn)


### PR DESCRIPTION
I found myself several times needing to execute a search with "Same as usual processor chain, but with this filter method(s) removed and/or this extra method(s) added."

Doing this in a safe way, especially for the 'removed' case, and especially taking account of the non-legacy `search_params_logic = true` case required some annoying and confusing boilerplate, for instance [as here](https://github.com/projectblacklight/blacklight_range_limit/blob/bl514/lib/blacklight_range_limit/controller_override.rb#L41-L48), violating separation of concerns to boot I'd say. 

I thought there should be a built in API to do this with a simpler expression of intent. 

First step was adding an `#except` method to SearchBuilder, paralleling the existing `#append` method, but removing filters instead of adding them.  Since I noticed `append` was already there, I thought it best to follow that in parallel. Pretty straightforward:

     new_builder = existing_builder.except(:some_filter_method, :other)

But my code where I needed to do this was typically well-placed to use [Catalog#search_results](https://github.com/projectblacklight/blacklight/blob/5f6916b8f69ff77af87930def90f9c63e5cd92e5/lib/blacklight/search_helper.rb#L100). I didn't want to have to go down a level to use the SearchBuilder directly, because it would require me to copy [the boilerplate code in search_results for setting things up and dealing with results](https://github.com/projectblacklight/blacklight/blob/5f6916b8f69ff77af87930def90f9c63e5cd92e5/lib/blacklight/search_helper.rb#L102-L114), each time, in an un-DRY and fragile  way. 

I had trouble coming up with a good API here, until I hit upon the present one, an optional block argument to `search_results`, which is passed an already configured SearchBuilder (so you don't need to copy the logic from `search_results` for configuring), and can modify it and/or change it to an entirely different one. 

      results, doc_list = search_results(params, search_params_logic) do |search_builder|
         search_builder.append(:some_method).except(:other_method)
      end

Works fine if `search_params_logic` is `true` (new style) or if it's an array of symbols (legacy supporting style), doesn't matter, it's all good. 

Note since `append` and `except` return new copies instead of mutating, the API needs to take the result of the block as the SearchBuilder to use, which can get a bit confusing, but is the only way to make this do what's needed with existing `append` definition. 

I think this API turns out pretty well, and can also be used to do things that weren't in my original use case, anything you need to do to customize the SearchBuilder (while starting with the default setup from `search_results`), such as, say:

       results, doc_list = search_results(params, search_params_logic) do |search_builder|
         search_builder.reverse_merge( forced_explicit_solr_parameters )
      end

Which is also convenient I think. (Since reverse_merge returns `self`, this still works fine)