### PR TITLE
add index navigation for facet more links

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -148,6 +148,22 @@ ul.facet_extended_list, .facet_extended_list ul
   @extend .clearfix;
 }
 
+ 
+// Facet modal alphabetical filter
+.alpha-filter {
+  margin-bottom: 18px;
+  text-align: center;
+
+  a {
+    padding: 0 2px;
+    
+    &.active {
+      color: inherit;
+      font-weight: bold;
+    }
+  }
+}
+
 
 @media (max-width: $grid-float-breakpoint) {
 

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -13,6 +13,12 @@ module Blacklight::FacetsHelperBehavior
   end
 
   ##
+  # The querystring params without the facet filter, used for index navigation#
+  def params_no_facet_filter
+    params.except(:'facet.prefix')
+  end
+  
+  ##
   # Render a collection of facet fields.
   # @see #render_facet_limit 
   # 

--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,0 +1,11 @@
+  <% if @facet.index_pagination && @display_facet.sort == 'index' %>
+    <div id="facet-index-navigation" class="alpha-filter">
+      <span id="facet-index-label"><%= t('blacklight.search.facets.filter') %></span>
+      <span id="facet-index-letters">
+        <% unless params[:'facet.prefix'].blank? %><%= link_to(t('blacklight.search.facets.clear'), @pagination.params_for_resort_url('index', params.except(:'facet.prefix')), data: {ajax_modal: "preserve"}) %><% end %>
+        <% @facet.index_range.each do |letter| %>
+          <%= link_to(letter, @pagination.params_for_resort_url('index', params.merge(:'facet.prefix'=> letter)), data: {ajax_modal: "preserve"}, class: (params[:'facet.prefix']==letter ? 'active' : '')) %>
+        <% end %>
+      </span>
+    </div>
+  <% end %>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,21 +1,20 @@
-    <div class="prev_next_links btn-group pull-left">
-      <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), :params => params, :param_name => blacklight_config.facet_paginator_class.request_keys[:page], :class => 'btn btn-link', :data => {:ajax_modal => "preserve"} do %>
-       <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
-     <% end %>
-      <%= link_to_next_page @pagination, raw(t('views.pagination.next')), :params => params, :param_name => blacklight_config.facet_paginator_class.request_keys[:page], :class => 'btn btn-link',  :data => {:ajax_modal => "preserve"} do %>
-       
-       <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
-      <% end %>
-     
-    </div>
+  <%= render partial: 'facet_index_navigation' %>
+  
+  <div class="prev_next_links btn-group pull-left">
+    <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: {ajax_modal: "preserve"} do %>
+     <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
+   <% end %>
+    <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: {ajax_modal: "preserve"} do %>       
+     <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
+    <% end %>     
+  </div>
  
   <div class="sort_options btn-group pull-right">
     <% if @pagination.sort == 'index' -%>
       <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span><%= link_to_unless(@pagination.sort == 'count', t('blacklight.search.facets.sort.count'), 
-        @pagination.params_for_resort_url('count', params), :class => "sort_change numeric btn btn-default",  
-        :data => {:ajax_modal => "preserve"}) %>
+        @pagination.params_for_resort_url('count', params_no_facet_filter), class: "sort_change numeric btn btn-default", data: {ajax_modal: "preserve"}) %>
     <% elsif @pagination.sort == 'count' -%>
-      <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', params), 
-        :class => "sort_change az btn btn-default",  :data => {:ajax_modal => "preserve"}) %><span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+      <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', params_no_facet_filter), 
+        class: "sort_change az btn btn-default",  data: {ajax_modal: "preserve"}) %><span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
     <% end -%>    
   </div>

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -185,6 +185,8 @@ de:
         counter: '%{counter}. '
       facets:
         title: 'Beschränken dein Suche'
+        filter: 'Filter:'
+        clear: 'Löschen'
         sort:
           count: 'Numerisch ordnen'
           index: 'A-Z Ordnen'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -183,6 +183,8 @@ en:
         counter: '%{counter}. '
       facets:
         title: 'Limit your search'
+        filter: 'Filter:'
+        clear: 'Clear'
         sort:
           count: 'Numerical Sort'
           index: 'A-Z Sort'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -185,6 +185,8 @@ es:
         counter: '%{counter}.'
       facets:
         title: 'Limite su búsqueda'
+        filter: 'Límite:'
+        clear: 'Borrar'
         sort:
           count: 'Ordenación numérica'
           index: 'Ordenación A-Z'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -191,6 +191,8 @@ fr:
         unselect: 'Panier'
       facets:
         title: 'Limiter votre recherche'
+        filter: 'Filtre:'
+        clear: 'Effacer'
         sort:
           count: 'Du + au - fréquent'
           index: 'Tri de A à Z'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -185,6 +185,8 @@ it:
         counter: '%{counter}. '
       facets:
         title: 'Affina la ricerca'
+        filter: 'Limite:'
+        clear: 'Cancella'
         sort:
           count: 'Ordina per numero'
           index: 'Ordina A-Z'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -183,6 +183,8 @@ pt-BR:
         counter: '%{counter}. '
       facets:
         title: 'Filtre sua busca'
+        filter: 'Filtre:'
+        clear: 'Limpar'  
         sort:
           count: 'Ordenar por Número'
           index: 'Ordem Alfabética A-Z'

--- a/lib/blacklight/catalog.rb
+++ b/lib/blacklight/catalog.rb
@@ -79,6 +79,7 @@ module Blacklight::Catalog
 
     # displays values and pagination links for a single facet field
     def facet
+            
       @facet = blacklight_config.facet_fields[params[:id]]
       @response = get_facet_field_response(@facet.key, params)
       @display_facet = @response.aggregations[@facet.key]

--- a/lib/blacklight/search_helper.rb
+++ b/lib/blacklight/search_helper.rb
@@ -160,6 +160,7 @@ module Blacklight::SearchHelper
   # @return [Blacklight::SolrResponse] the solr response
   def get_facet_field_response(facet_field, user_params = params || {}, extra_controller_params = {})
     query = search_builder.with(user_params).facet(facet_field)
+    extra_controller_params.merge!({:"facet.prefix"=>user_params[:"facet.prefix"]}) unless user_params[:"facet.prefix"].blank?
     repository.search(query.merge(extra_controller_params))
   end
 

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -53,9 +53,14 @@ class <%= controller_name.classify %>Controller < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the 
     # facet bar
+    
+    # set :index_pagination to true if you want the pop-up window for large facets to have alphabetical index navigation
+    #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
+    # if you set :index_pagination to true, you MUST set :index_range to an array of characters that will be used to create the navigation (note: It is case sensitive when searching values)
+    
     config.add_facet_field 'format', :label => 'Format'
     config.add_facet_field 'pub_date', :label => 'Publication Year', :single => true
-    config.add_facet_field 'subject_topic_facet', :label => 'Topic', :limit => 20 
+    config.add_facet_field 'subject_topic_facet', :label => 'Topic', :limit => 20, :index_pagination=>true, :index_range=>('A' .. 'Z').to_a
     config.add_facet_field 'language_facet', :label => 'Language', :limit => true 
     config.add_facet_field 'lc_1letter_facet', :label => 'Call Number' 
     config.add_facet_field 'subject_geo_facet', :label => 'Region' 

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe "Facets" do
   it "should show a single facet's values" do
     visit catalog_facet_path("language_facet")
-    expect(page).to have_selector(".modal-title", :text => "Language")
-    expect(page).to have_selector(".facet_select", :text => "Tibetan")
+    expect(page).to have_selector ".modal-title", :text => "Language"
+    expect(page).to have_selector ".facet_select", :text => "Tibetan"
   end
   
   it "should paginate through a facet's values" do
@@ -29,9 +29,29 @@ describe "Facets" do
     expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
     expect(page).to have_link "Numerical Sort"
     expect(page).to have_selector '.sort_options .active', text: "A-Z Sort"
-    
-    
   end
+  
+  it "should be able to sort more facet window by letter" do
+    visit catalog_facet_path("subject_topic_facet")
+    within ".modal-footer" do
+      click_on "A-Z Sort"
+    end
+    expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
+    expect(page).to have_css '.facet-values li', count: 20
+    find(:css,".facet_pagination.bottom").click_on "B"  
+    expect(page).to have_selector '.facet-values li:first', text: "Buddhism"
+    expect(page).to have_css '.facet-values li', count: 1
+    find(:css,".facet_pagination.bottom").click_on "T"
+    expect(page).to have_selector '.facet-values li:first', text: "Teaching"
+    expect(page).to have_css '.facet-values li', count: 4
+    find(:css,".facet_pagination.bottom").click_on "Clear"
+    expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
+    expect(page).to have_css '.facet-values li', count: 20
+    find(:css,".facet_pagination.bottom").click_on "Numerical Sort"
+    expect(page).to have_selector '.facet-values li:first', text: "Japanese drama"
+    expect(page).to have_css '.facet-values li', count: 20
+  end
+  
   describe '"More" links' do
     it 'has default more link with sr-only text' do
       visit root_path


### PR DESCRIPTION
This is a feature we recently added to the Revs Digital Library website.  For facets that have many many values, users click on the "More" link to see them all then have to page through results 20 at a time.  If there are thousands of values, it is helpful when in "A-Z" mode to have index navigation (i.e. filter by letter).  There are still limitations (i.e. you will see all letters even if some have no values, and it is case sensitive due to solr restrictions) but it is a start.