### PR TITLE
use {!term} localparam instead of {!raw}

### DIFF
--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -299,7 +299,7 @@ module Blacklight::Solr
         when value.is_a?(Range)
           "#{prefix}#{solr_field}:[#{value.first} TO #{value.last}]"
         else
-          "{!raw f=#{solr_field}#{(" " + local_params.join(" ")) unless local_params.empty?}}#{value}"
+          "{!term f=#{solr_field}#{(" " + local_params.join(" ")) unless local_params.empty?}}#{value}"
       end
     end
 


### PR DESCRIPTION
Facet drill-downs weren't working for me as-is with Solr 5.3.0, and https://wiki.apache.org/solr/QueryParser says "Note: use 'term' for this in Solr 4.0 or above", which fixes it.

Sorry if I'm missing something here.