### PR TITLE
return an empty result set instead of throwing exception when the use…

### DIFF
--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -282,7 +282,12 @@ module Blacklight::Solr
 
       case
         when (facet_config and facet_config.query)
-          facet_config.query[value][:fq]
+          if facet_config.query[value]
+            facet_config.query[value][:fq]
+          else
+            # exclude all documents if the custom facet key specified was not found
+            '-*:*'
+          end
         when (facet_config and facet_config.date)
           # in solr 3.2+, this could be replaced by a !term query
           "#{prefix}#{solr_field}:#{RSolr.solr_escape(value)}"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -69,7 +69,19 @@ describe CatalogController do
           expect(facet.items).to be_empty
         end
       end
+      
+      it "should show 0 results when the user asks for an invalid value to a custom facet query", :integration => true do
+        get :index, f: {example_query_facet_field: 'bogus'} # bogus custom facet value
+        expect(assigns_response.docs).to be_empty
+      end
 
+      it "should return results (possibly 0) when the user asks for a valid value to a custom facet query", :integration => true do
+        get :index, f: {example_query_facet_field: 'years_10'} # valid custom facet value with some results
+        expect(assigns_response.docs).to_not be_empty
+        get :index, f: {example_query_facet_field: 'years_5'}  # valid custom facet value with NO results
+        expect(assigns_response.docs).to be_empty
+      end
+      
       it "should have a spelling suggestion for an appropriately poor query", :integration => true do
         get :index, :q => 'boo'
         expect(assigns_response.spelling.words).to_not be_nil


### PR DESCRIPTION
…r requests a custom facet query value that does not exist (fixes https://github.com/projectblacklight/blacklight/issues/1255)