### PR TITLE
Wrap the search form fielded search select in a input-group-addon

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -20,13 +20,27 @@
 #search-navbar {
   z-index: 1;
 
-  .search-query-form {
-    @extend .col-md-8;
-    padding-left: 0;
+  .input-group {
+    width: 100%;
+  }
+
+  .input-group-addon {
+    &.for-search-field {
+      background-color: $input-bg;
+      border-radius: $border-radius-base 0 0 $border-radius-base;
+      width: 15ch;
+    }
+  }
+
+  .search_field {
+    background: transparent;
+    border: none;
   }
 
   .search-query-form {
+    @extend .col-md-8;
     border: 0;
+    padding-left: 0;
   }
   .submit-search-text {
     // hide 'search' label at very small screens

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,20 +1,24 @@
-  <%= form_tag search_action_url, :method => :get, :class => 'search-query-form clearfix navbar-form' do %>
-    <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
+<%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search' do %>
+  <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
 
-    <% unless search_fields.empty? %>
-      <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
-      <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field form-control") %>
-      <span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
+  <div class="input-group">
+    <% if search_fields.length > 1 %>
+      <span class="input-group-addon for-search-field">
+        <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+        <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), title: t('blacklight.search.form.search_field.title'), id: "search_field", class: "search_field") %>
+      </span>
+    <% elsif search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, search_fields.first.last %>
     <% end %>
-    <div class="input-group search-input-group">
-        <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-         <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.search.placeholder'), :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box? %>
 
-      <span class="input-group-btn">
-        <button type="submit" class="btn btn-primary search-btn" id="search">
-          <span class="submit-search-text"><%=t('blacklight.search.form.submit')%></span>
-          <span class="glyphicon glyphicon-search"></span>
-        </button>
-        </span>
-      </div>
-  <% end %>
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?  %>
+
+    <span class="input-group-btn">
+      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+        <span class="glyphicon glyphicon-search"></span>
+      </button>
+    </span>
+  </div>
+<% end %>


### PR DESCRIPTION
I've ported (and improved?) the way we style the search form in [SearchWorks](http://searchworks.stanford.edu/) to connect the search field control with the text box a little better. Thoughts?

---

Webkit:
<img width="611" alt="screen shot 2015-10-16 at 8 13 29 am" src="https://cloud.githubusercontent.com/assets/111218/10545513/edf826e2-73dd-11e5-8842-7e9f5ddbb2e3.png">

Firefox:
<img width="329" alt="screen shot 2015-10-16 at 8 14 39 am" src="https://cloud.githubusercontent.com/assets/111218/10545527/fbf28bfc-73dd-11e5-9025-af33388cff31.png">