### PR TITLE
Add facet prefix filtering when paginating within a facet

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -152,6 +152,22 @@ ul.facet_extended_list, .facet_extended_list ul
   }
 }
 
+ 
+// Facet modal alphabetical filter
+.alpha-filter {
+  margin-bottom: 18px;
+  text-align: center;
+
+  a {
+    padding: 0 2px;
+    
+    &.active {
+      color: inherit;
+      font-weight: bold;
+    }
+  }
+}
+
 
 @media (max-width: $grid-float-breakpoint) {
 

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -146,6 +146,10 @@ ul.facet_extended_list, .facet_extended_list ul
 
 .facet_pagination {
   @extend .clearfix;
+
+  &.top {
+    padding: $modal-inner-padding;
+  }
 }
 
 

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -155,19 +155,14 @@ ul.facet_extended_list, .facet_extended_list ul
  
 // Facet modal alphabetical filter
 .alpha-filter {
-  margin-bottom: 18px;
-  text-align: center;
+  .btn {
+    vertical-align: top;
+  }
 
-  a {
-    padding: 0 2px;
-    
-    &.active {
-      color: inherit;
-      font-weight: bold;
-    }
+  .pagination {
+    margin: 0;
   }
 }
-
 
 @media (max-width: $grid-float-breakpoint) {
 

--- a/app/assets/stylesheets/blacklight/_pagination.scss
+++ b/app/assets/stylesheets/blacklight/_pagination.scss
@@ -9,3 +9,13 @@
   text-align: center ;
 }
 
+
+.pagination-xs {
+  li {
+    a,
+    span {
+      border: none;
+      padding: $padding-xs-vertical $padding-xs-horizontal;
+    }
+  }
+}

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -13,12 +13,6 @@ module Blacklight::FacetsHelperBehavior
   end
 
   ##
-  # The querystring params without the facet filter, used for index navigation#
-  def params_no_facet_filter
-    params.except(:'facet.prefix')
-  end
-  
-  ##
   # Render a collection of facet fields.
   # @see #render_facet_limit 
   # 

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -13,6 +13,12 @@ module Blacklight::FacetsHelperBehavior
   end
 
   ##
+  # The querystring params without the facet filter, used for index navigation#
+  def params_no_facet_filter
+    params.except(:'facet.prefix')
+  end
+  
+  ##
   # Render a collection of facet fields.
   # @see #render_facet_limit 
   # 

--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,11 +1,9 @@
-  <% if @facet.index_pagination && @display_facet.sort == 'index' %>
-    <div id="facet-index-navigation" class="alpha-filter">
-      <span id="facet-index-label"><%= t('blacklight.search.facets.filter') %></span>
-      <span id="facet-index-letters">
-        <% unless params[:'facet.prefix'].blank? %><%= link_to(t('blacklight.search.facets.clear'), @pagination.params_for_resort_url('index', params.except(:'facet.prefix')), data: {ajax_modal: "preserve"}) %><% end %>
-        <% @facet.index_range.each do |letter| %>
-          <%= link_to(letter, @pagination.params_for_resort_url('index', params.merge(:'facet.prefix'=> letter)), data: {ajax_modal: "preserve"}, class: (params[:'facet.prefix']==letter ? 'active' : '')) %>
-        <% end %>
-      </span>
-    </div>
-  <% end %>
+<nav class="alpha-filter">
+  <%= link_to t('blacklight.search.facets.clear'), @pagination.params_for_resort_url('index', params.except(@pagination.request_keys[:prefix])), data: { ajax_modal: "preserve" }, class: ['btn btn-default btn-xs', ('disabled' unless @pagination.prefix.present?)].join(' ') %>
+
+  <ol class="pagination pagination-xs">
+    <% @facet.index_range.each do |letter| %>
+      <li class="<%= 'active' if @pagination.prefix == letter %>"><%= link_to(letter, @pagination.params_for_resort_url('index', params.merge(@pagination.request_keys[:prefix] => letter)), data: { ajax_modal: "preserve" }) %></li>
+    <% end %>
+  </ol>
+</nav>

--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,0 +1,11 @@
+  <% if @facet.index_pagination && @display_facet.sort == 'index' %>
+    <div id="facet-index-navigation" class="alpha-filter">
+      <span id="facet-index-label"><%= t('blacklight.search.facets.filter') %></span>
+      <span id="facet-index-letters">
+        <% unless params[:'facet.prefix'].blank? %><%= link_to(t('blacklight.search.facets.clear'), @pagination.params_for_resort_url('index', params.except(:'facet.prefix')), data: {ajax_modal: "preserve"}) %><% end %>
+        <% @facet.index_range.each do |letter| %>
+          <%= link_to(letter, @pagination.params_for_resort_url('index', params.merge(:'facet.prefix'=> letter)), data: {ajax_modal: "preserve"}, class: (params[:'facet.prefix']==letter ? 'active' : '')) %>
+        <% end %>
+      </span>
+    </div>
+  <% end %>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,20 +1,19 @@
-  <%= render partial: 'facet_index_navigation' %>
-  
-  <div class="prev_next_links btn-group pull-left">
-    <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: {ajax_modal: "preserve"} do %>
-     <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
-   <% end %>
-    <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: {ajax_modal: "preserve"} do %>       
-     <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
-    <% end %>     
-  </div>
- 
-  <div class="sort_options btn-group pull-right">
-    <% if @pagination.sort == 'index' -%>
-      <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span><%= link_to_unless(@pagination.sort == 'count', t('blacklight.search.facets.sort.count'), 
-        @pagination.params_for_resort_url('count', params_no_facet_filter), class: "sort_change numeric btn btn-default", data: {ajax_modal: "preserve"}) %>
-    <% elsif @pagination.sort == 'count' -%>
-      <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', params_no_facet_filter), 
-        class: "sort_change az btn btn-default",  data: {ajax_modal: "preserve"}) %><span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
-    <% end -%>    
-  </div>
+<div class="prev_next_links btn-group pull-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { ajax_modal: "preserve" } do %>
+    <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
+  <% end %>
+
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { ajax_modal: "preserve" } do %>
+    <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
+  <% end %>
+</div>
+
+<div class="sort_options btn-group pull-right">
+  <% if @pagination.sort == 'index' -%>
+    <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= link_to_unless(@pagination.sort == 'count', t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', params), class: "sort_change numeric btn btn-default", data: {ajax_modal: "preserve"}) %>
+  <% elsif @pagination.sort == 'count' -%>
+    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', params), class: "sort_change az btn btn-default",  data: { ajax_modal: "preserve" }) %>
+    <span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+  <% end -%>
+</div>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,21 +1,20 @@
-    <div class="prev_next_links btn-group pull-left">
-      <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), :params => params, :param_name => blacklight_config.facet_paginator_class.request_keys[:page], :class => 'btn btn-link', :data => {:ajax_modal => "preserve"} do %>
-       <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
-     <% end %>
-      <%= link_to_next_page @pagination, raw(t('views.pagination.next')), :params => params, :param_name => blacklight_config.facet_paginator_class.request_keys[:page], :class => 'btn btn-link',  :data => {:ajax_modal => "preserve"} do %>
-       
-       <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
-      <% end %>
-     
-    </div>
+  <%= render partial: 'facet_index_navigation' %>
+  
+  <div class="prev_next_links btn-group pull-left">
+    <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: {ajax_modal: "preserve"} do %>
+     <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
+   <% end %>
+    <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: params, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: {ajax_modal: "preserve"} do %>       
+     <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
+    <% end %>     
+  </div>
  
   <div class="sort_options btn-group pull-right">
     <% if @pagination.sort == 'index' -%>
       <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span><%= link_to_unless(@pagination.sort == 'count', t('blacklight.search.facets.sort.count'), 
-        @pagination.params_for_resort_url('count', params), :class => "sort_change numeric btn btn-default",  
-        :data => {:ajax_modal => "preserve"}) %>
+        @pagination.params_for_resort_url('count', params_no_facet_filter), class: "sort_change numeric btn btn-default", data: {ajax_modal: "preserve"}) %>
     <% elsif @pagination.sort == 'count' -%>
-      <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', params), 
-        :class => "sort_change az btn btn-default",  :data => {:ajax_modal => "preserve"}) %><span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+      <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', params_no_facet_filter), 
+        class: "sort_change az btn btn-default",  data: {ajax_modal: "preserve"}) %><span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
     <% end -%>    
   </div>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -3,11 +3,11 @@
 </div>
 
 <div class="modal-header">
-  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
-
   <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
 
   <h3 class="modal-title"><%= facet_field_label(@facet.key) %></h3>
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
 </div>
 <div class="modal-body">
   <div class="facet_extended_list">

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -3,7 +3,10 @@
 </div>
 
 <div class="modal-header">
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
   <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
+
   <h3 class="modal-title"><%= facet_field_label(@facet.key) %></h3>
 </div>
 <div class="modal-body">

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -185,7 +185,6 @@ de:
         counter: '%{counter}. '
       facets:
         title: 'Beschränken dein Suche'
-        filter: 'Filter:'
         clear: 'Löschen'
         sort:
           count: 'Numerisch ordnen'

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -185,6 +185,8 @@ de:
         counter: '%{counter}. '
       facets:
         title: 'Beschränken dein Suche'
+        filter: 'Filter:'
+        clear: 'Löschen'
         sort:
           count: 'Numerisch ordnen'
           index: 'A-Z Ordnen'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -183,6 +183,8 @@ en:
         counter: '%{counter}. '
       facets:
         title: 'Limit your search'
+        filter: 'Filter:'
+        clear: 'Clear'
         sort:
           count: 'Numerical Sort'
           index: 'A-Z Sort'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -183,8 +183,7 @@ en:
         counter: '%{counter}. '
       facets:
         title: 'Limit your search'
-        filter: 'Filter:'
-        clear: 'Clear'
+        clear: 'Clear Filter'
         sort:
           count: 'Numerical Sort'
           index: 'A-Z Sort'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -185,7 +185,6 @@ es:
         counter: '%{counter}.'
       facets:
         title: 'Limite su búsqueda'
-        filter: 'Límite:'
         clear: 'Borrar'
         sort:
           count: 'Ordenación numérica'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -185,6 +185,8 @@ es:
         counter: '%{counter}.'
       facets:
         title: 'Limite su búsqueda'
+        filter: 'Límite:'
+        clear: 'Borrar'
         sort:
           count: 'Ordenación numérica'
           index: 'Ordenación A-Z'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -191,6 +191,8 @@ fr:
         unselect: 'Panier'
       facets:
         title: 'Limiter votre recherche'
+        filter: 'Filtre:'
+        clear: 'Effacer'
         sort:
           count: 'Du + au - fréquent'
           index: 'Tri de A à Z'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -191,7 +191,6 @@ fr:
         unselect: 'Panier'
       facets:
         title: 'Limiter votre recherche'
-        filter: 'Filtre:'
         clear: 'Effacer'
         sort:
           count: 'Du + au - fréquent'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -185,6 +185,8 @@ it:
         counter: '%{counter}. '
       facets:
         title: 'Affina la ricerca'
+        filter: 'Limite:'
+        clear: 'Cancella'
         sort:
           count: 'Ordina per numero'
           index: 'Ordina A-Z'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -185,7 +185,6 @@ it:
         counter: '%{counter}. '
       facets:
         title: 'Affina la ricerca'
-        filter: 'Limite:'
         clear: 'Cancella'
         sort:
           count: 'Ordina per numero'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -183,7 +183,6 @@ pt-BR:
         counter: '%{counter}. '
       facets:
         title: 'Filtre sua busca'
-        filter: 'Filtre:'
         clear: 'Limpar'  
         sort:
           count: 'Ordenar por Número'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -183,6 +183,8 @@ pt-BR:
         counter: '%{counter}. '
       facets:
         title: 'Filtre sua busca'
+        filter: 'Filtre:'
+        clear: 'Limpar'  
         sort:
           count: 'Ordenar por Número'
           index: 'Ordem Alfabética A-Z'

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -6,6 +6,7 @@ module Blacklight
       self.collapse = true if self.collapse.nil?
       self.show = true if self.show.nil?
       self.if = self.show if self.if.nil?
+      self.index_range = 'A'..'Z' if self.index_range == true
 
       super
       

--- a/lib/blacklight/facet.rb
+++ b/lib/blacklight/facet.rb
@@ -8,6 +8,7 @@ module Blacklight
         display_facet.items,
         sort: display_facet.sort,
         offset: display_facet.offset,
+        prefix: display_facet.prefix,
         limit: facet_limit_for(field_config.key)
       )
     end

--- a/lib/blacklight/facet_paginator.rb
+++ b/lib/blacklight/facet_paginator.rb
@@ -30,7 +30,7 @@ module Blacklight
     #            display all with no previous or next. 
     # :offset => current item offset, default 0
     # :sort => 'count' or 'index', solr tokens for facet value sorting, default 'count'. 
-    def initialize(all_facet_values, arguments)
+    def initialize(all_facet_values, arguments = {})
       # to_s.to_i will conveniently default to 0 if nil
       @offset = arguments[:offset].to_s.to_i 
       @limit = arguments[:limit]

--- a/lib/blacklight/facet_paginator.rb
+++ b/lib/blacklight/facet_paginator.rb
@@ -14,14 +14,14 @@ module Blacklight
     # and need to make them accessible in a list so we can easily
     # strip em out before redirecting to catalog/index.
     mattr_accessor :request_keys do
-      { sort: :'facet.sort', page: :'facet.page' }
+      { sort: :'facet.sort', page: :'facet.page', prefix: :'facet.prefix' }
     end
 
     if Rails.version < "4.1"
-      self.request_keys = { sort: :'facet.sort', page: :'facet.page' }
+      self.request_keys = { sort: :'facet.sort', page: :'facet.page', prefix: :'facet.prefix' }
     end
 
-    attr_reader :offset, :limit, :sort
+    attr_reader :offset, :limit, :sort, :prefix
     
     # all_facet_values is a list of facet value objects returned by solr,
     # asking solr for n+1 facet values.
@@ -35,6 +35,7 @@ module Blacklight
       @offset = arguments[:offset].to_s.to_i 
       @limit = arguments[:limit]
       @sort = arguments[:sort]
+      @prefix = arguments[:prefix]
 
       @all = all_facet_values
     end
@@ -84,10 +85,16 @@ module Blacklight
     # under facet.sort ), and your current request params.
     # Get back params suitable to passing to an ActionHelper method for
     # creating a url, to resort by that method.
-    def params_for_resort_url(sort_method, params)
+    def params_for_resort_url(sort_method, params = {})
       # When resorting, we've got to reset the offset to start at beginning,
       # no way to make it make sense otherwise.
-      params.merge(request_keys[:sort] => sort_method, request_keys[:page] => nil)
+      resort_params = params.merge(request_keys[:sort] => sort_method, request_keys[:page] => nil)
+
+      if sort_method == 'count'
+        resort_params.except!(request_keys[:prefix])
+      end
+
+      resort_params
     end
 
     def as_json(_ = nil)

--- a/lib/blacklight/search_helper.rb
+++ b/lib/blacklight/search_helper.rb
@@ -93,7 +93,6 @@ module Blacklight::SearchHelper
   # @return [Blacklight::SolrResponse] the solr response
   def get_facet_field_response(facet_field, user_params = params || {}, extra_controller_params = {})
     query = search_builder.with(user_params).facet(facet_field)
-    extra_controller_params.merge!({:"facet.prefix"=>user_params[:"facet.prefix"]}) unless user_params[:"facet.prefix"].blank?
     repository.search(query.merge(extra_controller_params))
   end
 

--- a/lib/blacklight/search_helper.rb
+++ b/lib/blacklight/search_helper.rb
@@ -93,6 +93,7 @@ module Blacklight::SearchHelper
   # @return [Blacklight::SolrResponse] the solr response
   def get_facet_field_response(facet_field, user_params = params || {}, extra_controller_params = {})
     query = search_builder.with(user_params).facet(facet_field)
+    extra_controller_params.merge!({:"facet.prefix"=>user_params[:"facet.prefix"]}) unless user_params[:"facet.prefix"].blank?
     repository.search(query.merge(extra_controller_params))
   end
 

--- a/lib/blacklight/solr/facet_paginator.rb
+++ b/lib/blacklight/solr/facet_paginator.rb
@@ -17,11 +17,15 @@ module Blacklight::Solr
     #            display all with no previous or next. 
     # :offset => current item offset, default 0
     # :sort => 'count' or 'index', solr tokens for facet value sorting, default 'count'. 
-    def initialize(all_facet_values, arguments)
+    def initialize(all_facet_values, arguments = {})
       super
 
       # count is solr's default
-      @sort ||= 'count'
+      @sort ||= if @limit.to_i > 0
+                  'count'
+                else
+                  'index'
+                end
     end
   end
 end

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -216,6 +216,7 @@ module Blacklight::Solr
       offset = (page - 1) * (limit)
 
       sort = blacklight_params[request_keys[:sort]]
+      prefix = blacklight_params[request_keys[:prefix]]
 
       # Need to set as f.facet_field.facet.* to make sure we
       # override any field-specific default in the solr request handler.
@@ -223,6 +224,9 @@ module Blacklight::Solr
       solr_params[:"f.#{facet}.facet.offset"] = offset
       if blacklight_params[request_keys[:sort]]
         solr_params[:"f.#{facet}.facet.sort"] = sort
+      end
+      if blacklight_params[request_keys[:prefix]]
+        solr_params[:"f.#{facet}.facet.prefix"] = prefix
       end
       solr_params[:rows] = 0
     end

--- a/lib/blacklight/solr_response/facets.rb
+++ b/lib/blacklight/solr_response/facets.rb
@@ -45,6 +45,18 @@ module Blacklight::SolrResponse::Facets
     def offset
       @options[:offset] || solr_default_offset
     end
+
+    def prefix
+      @options[:prefix] || solr_default_prefix
+    end
+
+    def index?
+      sort == 'index'
+    end
+
+    def count?
+      sort == 'count'
+    end
     
     private
     # Per https://wiki.apache.org/solr/SimpleFacetParameters#facet.limit
@@ -65,7 +77,10 @@ module Blacklight::SolrResponse::Facets
     def solr_default_offset
       0
     end
-    
+
+    def solr_default_prefix
+      nil
+    end
   end
 
   ##
@@ -148,6 +163,10 @@ module Blacklight::SolrResponse::Facets
 
       if params[:"f.#{facet_field_name}.facet.offset"] || params[:'facet.offset']
         options[:offset] = (params[:"f.#{facet_field_name}.facet.offset"] || params[:'facet.offset']).to_i
+      end
+
+      if params[:"f.#{facet_field_name}.facet.prefix"] || params[:'facet.prefix']
+        options[:prefix] = (params[:"f.#{facet_field_name}.facet.prefix"] || params[:'facet.prefix'])
       end
 
       hash[facet_field_name] = FacetField.new(facet_field_name, items, options)

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -53,9 +53,14 @@ class <%= controller_name.classify %>Controller < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the 
     # facet bar
+    
+    # set :index_pagination to true if you want the pop-up window for large facets to have alphabetical index navigation
+    #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
+    # if you set :index_pagination to true, you MUST set :index_range to an array of characters that will be used to create the navigation (note: It is case sensitive when searching values)
+    
     config.add_facet_field 'format', :label => 'Format'
     config.add_facet_field 'pub_date', :label => 'Publication Year', :single => true
-    config.add_facet_field 'subject_topic_facet', :label => 'Topic', :limit => 20 
+    config.add_facet_field 'subject_topic_facet', :label => 'Topic', :limit => 20, :index_pagination=>true, :index_range=>('A' .. 'Z').to_a
     config.add_facet_field 'language_facet', :label => 'Language', :limit => true 
     config.add_facet_field 'lc_1letter_facet', :label => 'Call Number' 
     config.add_facet_field 'subject_geo_facet', :label => 'Region' 

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -53,14 +53,14 @@ class <%= controller_name.classify %>Controller < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the 
     # facet bar
-    
-    # set :index_pagination to true if you want the pop-up window for large facets to have alphabetical index navigation
+    #
+    # set :index_range to true if you want the facet pagination view to have facet prefix-based navigation
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
-    # if you set :index_pagination to true, you MUST set :index_range to an array of characters that will be used to create the navigation (note: It is case sensitive when searching values)
+    # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
     
     config.add_facet_field 'format', :label => 'Format'
     config.add_facet_field 'pub_date', :label => 'Publication Year', :single => true
-    config.add_facet_field 'subject_topic_facet', :label => 'Topic', :limit => 20, :index_pagination=>true, :index_range=>('A' .. 'Z').to_a
+    config.add_facet_field 'subject_topic_facet', :label => 'Topic', :limit => 20, :index_range => 'A'..'Z'
     config.add_facet_field 'language_facet', :label => 'Language', :limit => true 
     config.add_facet_field 'lc_1letter_facet', :label => 'Call Number' 
     config.add_facet_field 'subject_geo_facet', :label => 'Region' 

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -38,13 +38,13 @@ describe "Facets" do
     end
     expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
     expect(page).to have_css '.facet-values li', count: 20
-    find(:css,".facet_pagination.bottom").click_on "B"  
+    click_on 'B'
     expect(page).to have_selector '.facet-values li:first', text: "Buddhism"
     expect(page).to have_css '.facet-values li', count: 1
-    find(:css,".facet_pagination.bottom").click_on "T"
+    click_on 'T'
     expect(page).to have_selector '.facet-values li:first', text: "Teaching"
     expect(page).to have_css '.facet-values li', count: 4
-    find(:css,".facet_pagination.bottom").click_on "Clear"
+    click_on 'Clear Filter'
     expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
     expect(page).to have_css '.facet-values li', count: 20
     find(:css,".facet_pagination.bottom").click_on "Numerical Sort"

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe "Facets" do
   it "should show a single facet's values" do
     visit catalog_facet_path("language_facet")
-    expect(page).to have_selector(".modal-title", :text => "Language")
-    expect(page).to have_selector(".facet_select", :text => "Tibetan")
+    expect(page).to have_selector ".modal-title", :text => "Language"
+    expect(page).to have_selector ".facet_select", :text => "Tibetan"
   end
   
   it "should paginate through a facet's values" do
@@ -29,9 +29,29 @@ describe "Facets" do
     expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
     expect(page).to have_link "Numerical Sort"
     expect(page).to have_selector '.sort_options .active', text: "A-Z Sort"
-    
-    
   end
+  
+  it "should be able to sort more facet window by letter" do
+    visit catalog_facet_path("subject_topic_facet")
+    within ".modal-footer" do
+      click_on "A-Z Sort"
+    end
+    expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
+    expect(page).to have_css '.facet-values li', count: 20
+    find(:css,".facet_pagination.bottom").click_on "B"  
+    expect(page).to have_selector '.facet-values li:first', text: "Buddhism"
+    expect(page).to have_css '.facet-values li', count: 1
+    find(:css,".facet_pagination.bottom").click_on "T"
+    expect(page).to have_selector '.facet-values li:first', text: "Teaching"
+    expect(page).to have_css '.facet-values li', count: 4
+    find(:css,".facet_pagination.bottom").click_on "Clear"
+    expect(page).to have_selector '.facet-values li:first', text: "Accident insurance"
+    expect(page).to have_css '.facet-values li', count: 20
+    find(:css,".facet_pagination.bottom").click_on "Numerical Sort"
+    expect(page).to have_selector '.facet-values li:first', text: "Japanese drama"
+    expect(page).to have_css '.facet-values li', count: 20
+  end
+  
   describe '"More" links' do
     it 'has default more link with sr-only text' do
       visit root_path

--- a/spec/lib/blacklight/facet_paginator_spec.rb
+++ b/spec/lib/blacklight/facet_paginator_spec.rb
@@ -68,6 +68,18 @@ describe Blacklight::FacetPaginator do
         expect(click_params[ sort_key ]).to eq 'count'
         expect(click_params[ page_key ]).to be_nil
     end
+
+    context 'when sorting by "count"' do
+      subject { described_class.new([]) }
+
+      it 'includes the prefix filter for "index" sorting' do
+        expect(subject.params_for_resort_url('index', :'facet.prefix' => 'A')).to include :'facet.prefix' => 'A'
+      end
+
+      it 'removes the prefix filter' do
+        expect(subject.params_for_resort_url('count', :'facet.prefix' => 'A')).not_to include :'facet.prefix' => 'A'
+      end
+    end
   end
 
   context "for a nil :limit" do

--- a/spec/lib/blacklight/solr/facet_paginator_spec.rb
+++ b/spec/lib/blacklight/solr/facet_paginator_spec.rb
@@ -6,7 +6,17 @@ describe Blacklight::Solr::FacetPaginator do
     subject { described_class.new([f1], offset: 0, limit: nil).as_json }
     it "should be well structured" do
       expect(subject).to eq("items" => [{"hits"=>"792", "value"=>"Book"}], "limit" => nil,
-       "offset" => 0, "sort" => "count")
+       "offset" => 0, "sort" => "index")
+    end
+  end
+
+  describe '#sort' do
+    it 'defaults to "count" if a limit is provided' do
+      expect(described_class.new([], limit: 10).sort).to eq 'count'
+    end
+
+    it 'defaults to "index" if no limit is given' do
+      expect(described_class.new([]).sort).to eq 'index'
     end
   end
 end

--- a/spec/lib/blacklight/solr/search_builder_spec.rb
+++ b/spec/lib/blacklight/solr/search_builder_spec.rb
@@ -554,6 +554,7 @@ describe Blacklight::Solr::SearchBuilder do
     let(:facet_field) { 'format' }
     let(:sort_key) { Blacklight::Solr::FacetPaginator.request_keys[:sort] }
     let(:page_key) { Blacklight::Solr::FacetPaginator.request_keys[:page] }
+    let(:prefix_key) { Blacklight::Solr::FacetPaginator.request_keys[:prefix] }
 
     let(:blacklight_config) do
       Blacklight::Configuration.new do |config|
@@ -610,6 +611,13 @@ describe Blacklight::Solr::SearchBuilder do
       let(:user_params) { { sort_key => 'index' } }
       it 'uses sort provided in the parameters' do
         expect(solr_parameters[:"f.#{facet_field}.facet.sort"]).to eq 'index'
+      end
+    end
+
+    context 'when a prefix is provided' do
+      let(:user_params) { { prefix_key => 'A' } }
+      it 'includes the prefix in the query' do
+        expect(solr_parameters[:"f.#{facet_field}.facet.prefix"]).to eq 'A'
       end
     end
   end

--- a/spec/lib/blacklight/solr_response/facets_spec.rb
+++ b/spec/lib/blacklight/solr_response/facets_spec.rb
@@ -76,11 +76,30 @@ describe Blacklight::SolrResponse::Facets do
 
       it "should default to count if no value is found and the default limit is used" do
         expect(subject.aggregations['my_field'].sort).to eq 'count'
+        expect(subject.aggregations['my_field'].count?).to eq true
       end
       
       it "should default to index if no value is found and the limit is unlimited" do
         request_params['facet.limit'] = -1
         expect(subject.aggregations['my_field'].sort).to eq 'index'
+        expect(subject.aggregations['my_field'].index?).to eq true
+      end
+    end
+
+    describe '#prefix' do
+      it 'extracts field-specific prefix values' do
+        request_params['f.my_field.facet.prefix'] = "a"
+        request_params['facet.prefix'] = "b"
+        expect(subject.aggregations['my_field'].prefix).to eq 'a'
+      end
+
+      it "extracts a global sort value" do
+        request_params['facet.prefix'] = "abc"
+        expect(subject.aggregations['my_field'].prefix).to eq 'abc'
+      end
+
+      it "defaults to no prefix value" do
+        expect(subject.aggregations['my_field'].prefix).to be_nil
       end
     end
   end

--- a/spec/views/catalog/_facet_index_navigation.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_index_navigation.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'catalog/_facet_index_navigation.html.erb', type: :view do
+  let(:pagination) { Blacklight::Solr::FacetPaginator.new([]) }
+  let(:facet) { Blacklight::Configuration::FacetField.new({ index_range: '0'..'9' })}
+
+  before do
+    assign(:pagination, pagination)
+    assign(:facet, facet)
+  end
+
+  it 'renders the facet index navigation range' do
+    render
+
+    expect(rendered).to have_selector '.pagination'
+    expect(rendered).to have_link '0', href: '/?facet.prefix=0&facet.sort=index'
+    expect(rendered).to have_link '1'
+    expect(rendered).to have_link '8'
+    expect(rendered).to have_link '9'
+  end
+
+  it 'renders a "clear filter" button' do
+    render
+    expect(rendered).to have_selector '.btn.disabled', text: 'Clear Filter'
+  end
+
+  context 'with a selected index' do
+    let(:pagination) { Blacklight::Solr::FacetPaginator.new([], prefix: '5') }
+
+    it 'highlights the selected index' do
+      render
+      expect(rendered).to have_selector '.active', text: '5'
+    end
+
+    it 'enables the clear facets button' do
+      render
+      expect(rendered).to have_link 'Clear Filter'
+    end
+  end
+end

--- a/spec/views/catalog/_facets.html.erb_spec.rb
+++ b/spec/views/catalog/_facets.html.erb_spec.rb
@@ -26,7 +26,7 @@ describe "catalog/_facets" do
     before do
       blacklight_config.facet_fields['facet_field_1'] = facet_field
 
-        @mock_display_facet_1 = double(:name => 'facet_field_1', sort: nil, offset: nil, :items => [Blacklight::SolrResponse::Facets::FacetItem.new(:value => 'Value', :hits => 1234)])
+        @mock_display_facet_1 = double(:name => 'facet_field_1', sort: nil, offset: nil, prefix: nil, :items => [Blacklight::SolrResponse::Facets::FacetItem.new(:value => 'Value', :hits => 1234)])
         allow(view).to receive_messages(:facet_field_names => [:facet_field_1],
                   :facet_limit_for => 10 )
 


### PR DESCRIPTION
Fixes #1251. I took @peetucket's commit and tried to push logic down into the models and use some more bootstrap-y styling:

<img width="603" alt="screen shot 2015-10-17 at 9 36 06 am" src="https://cloud.githubusercontent.com/assets/111218/10560031/0f13926e-74b3-11e5-85a8-f0a2344da9db.png">

There's significant work left to make it a general purpose tool (say, disabling the prefixes that have 0 hits), but this may be good enough for some targeted use or in a very large index.
