### PR TITLE
Fix facet wrapping/hyphenation in Firefox

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -10,6 +10,7 @@
 //= require blacklight/ajax_modal
 //= require blacklight/search_context
 //= require blacklight/collapsable
+//= require blacklight/facet_load
 //
 //Bootstrap JS for providing collapsable tablet/mobile menu/alert boxes
 //= require bootstrap/transition

--- a/app/assets/javascripts/blacklight/facet_load.js
+++ b/app/assets/javascripts/blacklight/facet_load.js
@@ -1,0 +1,23 @@
+/*global Blacklight */
+
+(function($) {
+  'use strict';
+  
+  Blacklight.doResizeFacetLabelsAndCounts = function() {
+    // adjust width of facet columns to fit their contents
+    function longer (a,b){ return b.textContent.length - a.textContent.length; }
+
+    $('ul.facet-values, ul.pivot-facet').each(function(){
+      var longest = $(this).find('span.facet-count').sort(longer).first();
+      var clone = longest.clone()
+        .css('visibility','hidden').css('width', 'auto');
+      $('body').append(clone);
+      $(this).find('.facet-count').first().width(clone.width());
+      clone.remove();
+    });
+  };
+
+  Blacklight.onLoad(function() {
+    Blacklight.doResizeFacetLabelsAndCounts();
+  });
+})(jQuery);

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -40,12 +40,12 @@
 
 .facet-values {
   display: table;
+  table-layout: fixed;
   width: 100%;
 
   li {
 
     display: table-row;
-
     .selected {
       @extend .text-success;
     }
@@ -69,10 +69,9 @@
 
   @mixin hyphens-auto {
     // breaks long words apart so they don't cause the containing div to
-    // be too big
-    // from http://kenneth.io/blog/2012/03/04/word-wrapping-hypernation-using-css/
-    -ms-word-break: break-all;
-    word-break: break-all;
+    // be too big, also fix hypenation
+    -ms-word-break: keep-all;
+    word-break: keep-all;
 
     // Non standard for webkit
     word-break: break-word;
@@ -80,17 +79,16 @@
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     -ms-hyphens: auto;
+    -o-hyphens: auto;
     hyphens: auto;
   }
 
   .facet-label {
     display: table-cell;
     padding-right: 1em;
-
     text-indent: -15px;
     padding-left: 15px;
     padding-bottom: $padding-base-vertical;
-
     @include hyphens-auto;
   }
 
@@ -98,6 +96,7 @@
     display: table-cell;
     vertical-align: top;
     text-align: right;
+    width: 5em;
   }
 }
 


### PR DESCRIPTION
Fixes #1224 

I've squashed @bkeese's commits and extracted the anonymous `onLoad()` function to a named one.

<img width="259" alt="screen shot 2015-10-17 at 10 16 10 am" src="https://cloud.githubusercontent.com/assets/111218/10560203/1e736a04-74b8-11e5-954c-b22ca20d9847.png">
