### PR TITLE
Use facet_field_label for rendering filters with I18n support on sear…

### DIFF
--- a/app/helpers/blacklight/search_history_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/search_history_constraints_helper_behavior.rb
@@ -32,7 +32,7 @@ module Blacklight::SearchHistoryConstraintsHelperBehavior
     return "".html_safe unless params[:f]
 
     safe_join(params[:f].collect do |facet_field, value_list|
-      render_search_to_s_element(facet_configuration_for_field(facet_field).label,
+      render_search_to_s_element(facet_field_label(facet_field),
         safe_join(value_list.collect do |value|
           render_filter_value(value, facet_field)
         end, content_tag(:span, " #{t('blacklight.and')} ", :class =>'filterSeparator'))

--- a/spec/helpers/search_history_constraints_helper_spec.rb
+++ b/spec/helpers/search_history_constraints_helper_spec.rb
@@ -8,6 +8,10 @@ describe SearchHistoryConstraintsHelper do
 
       config.add_facet_field 'some_facet', :label => 'Some'
       config.add_facet_field 'other_facet', :label => 'Other'
+      config.add_facet_field 'i18n_facet'
+
+      I18n.backend.store_translations(:en, blacklight: {search: {fields: {facet: {i18n_facet: 'English facet label'}}}})
+      I18n.backend.store_translations(:de, blacklight: {search: {fields: {facet: {i18n_facet: 'German facet label'}}}})
     end
   end
 
@@ -75,11 +79,27 @@ describe SearchHistoryConstraintsHelper do
 
       it "should render a constraint for a selected facet not in the config" do
         response = helper.render_search_to_s_filters(:f => {"undefined_facet" => ["value1", "value2"]})
-        expect(response).to eq("<span class=\"constraint\"><span class=\"filterName\">Undefined Facet:</span><span class=\"filterValues\"><span class=\"filterValue\">value1</span><span class=\"filterSeparator\"> and </span><span class=\"filterValue\">value2</span></span></span>")
+        expect(response).to eq("<span class=\"constraint\"><span class=\"filterName\">#{'undefined_facet'.humanize}:</span><span class=\"filterValues\"><span class=\"filterValue\">value1</span><span class=\"filterSeparator\"> and </span><span class=\"filterValue\">value2</span></span></span>")
+      end
+
+      context 'with I18n translations for selected facet' do
+        before do
+          @orig_locale = I18n.locale
+        end
+
+        after do
+          I18n.locale = @orig_locale
+        end
+
+        it 'should render the correct I18n label for a selected facet with I18n translations' do
+          {en: 'English facet label', de: 'German facet label'}.each do |locale, label|
+            I18n.locale = locale
+            response = helper.render_search_to_s_filters(f: {'i18n_facet' => ['value1', 'value2']})
+            expect(response).to include(label)
+          end
+        end
       end
     end
-
-  
   end
 
 end


### PR DESCRIPTION
…ch history.

- Add test coverage for I18n-labeled facets
- Update existing test for undefined facets to expect label
  to be humanized facet name instead of a specific string value