### PR TITLE
Allow show tool actions to skip defining an accessor method

### DIFF
--- a/app/controllers/concerns/blacklight/default_component_configuration.rb
+++ b/app/controllers/concerns/blacklight/default_component_configuration.rb
@@ -36,6 +36,9 @@ module Blacklight
       def add_show_tools_partial name, opts = {}
         blacklight_config.add_show_tools_partial(name, opts)
 
+        return if method_defined?(name) || opts[:define_method] == false
+
+        # Define a simple action handler for the tool
         define_method name do
           @response, @documents = action_documents
 
@@ -57,7 +60,7 @@ module Blacklight
               format.js { render :layout => false }
             end
           end
-        end unless method_defined? name
+        end
       end
 
       ##

--- a/spec/controllers/blacklight/catalog/component_configuration_spec.rb
+++ b/spec/controllers/blacklight/catalog/component_configuration_spec.rb
@@ -22,6 +22,11 @@ describe Blacklight::DefaultComponentConfiguration do
       subject.add_show_tools_partial :some_existing_action
       expect(subject.new.some_existing_action).to eq 1
     end
+
+    it "should allow the configuration to opt out of creating a method" do
+      subject.add_show_tools_partial :some_missing_action, define_method: false
+      expect(subject.new).not_to respond_to :some_missing_action
+    end
   end
 
   


### PR DESCRIPTION
I'm having trouble updating `blacklight-marc` when configuring the refworks, endnote, and librarian view actions. I suspect some kind of load or evaluation ordering problem, and being able to opt-out of the automatic method creation would be handy. 