### PR TITLE
Allow SearchBuilder to take 1 or 2 arguments

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -22,7 +22,7 @@ module Blacklight::Catalog
 
     # get search results from the solr index
     def index
-      (@response, @document_list) = search_results(params, search_params_logic)
+      (@response, @document_list) = search_results(params)
 
       respond_to do |format|
         format.html { store_preferred_view }

--- a/app/controllers/concerns/blacklight/request_builders.rb
+++ b/app/controllers/concerns/blacklight/request_builders.rb
@@ -1,39 +1,20 @@
 module Blacklight
-  ##
-  # This module contains methods that are specified by SearchHelper.search_params_logic
-  # They transform user parameters into parameters that are sent as a request to Solr when
-  # RequestBuilders#solr_search_params is called.
-  #
   module RequestBuilders
     extend ActiveSupport::Concern
 
     included do
-      # We want to install a class-level place to keep
-      # search_params_logic method names. Compare to before_filter,
-      # similar design. Since we're a module, we have to add it in here.
-      # There are too many different semantic choices in ruby 'class variables',
-      # we choose this one for now, supplied by Rails.
-      class_attribute :search_params_logic
-
-      # Set defaults. Each symbol identifies a _method_ that must be in
-      # this class, taking two parameters (solr_parameters, user_parameters)
-      # Can be changed in local apps or by plugins, eg:
-      # CatalogController.include ModuleDefiningNewMethod
-      # CatalogController.search_params_logic += [:new_method]
-      # CatalogController.search_params_logic.delete(:we_dont_want)
-      self.search_params_logic = true
-
       if self.respond_to?(:helper_method)
         helper_method(:facet_limit_for)
       end
     end
 
+    # Override this method to use a search builder other than the one in the config
     def search_builder_class
       blacklight_config.search_builder_class
     end
 
-    def search_builder processor_chain = search_params_logic
-      search_builder_class.new(processor_chain, self)
+    def search_builder
+      search_builder_class.new(self)
     end
 
     ##

--- a/app/controllers/concerns/blacklight/search_helper.rb
+++ b/app/controllers/concerns/blacklight/search_helper.rb
@@ -50,11 +50,10 @@ module Blacklight::SearchHelper
 
   # a solr query method
   # @param [Hash,HashWithIndifferentAccess] user_params ({}) the user provided parameters (e.g. query, facets, sort, etc)
-  # @param [List<Symbol] processor_chain a list of filter methods to run
   # @yield [search_builder] optional block yields configured SearchBuilder, caller can modify or create new SearchBuilder to be used. Block should return SearchBuilder to be used. 
   # @return [Blacklight::Solr::Response] the solr response object
-  def search_results(user_params, search_params_logic)
-    builder = search_builder(search_params_logic).with(user_params)
+  def search_results(user_params)
+    builder = search_builder.with(user_params)
     builder.page(user_params[:page]) if user_params[:page]
     builder.rows(user_params[:per_page] || user_params[:rows]) if user_params[:per_page] or user_params[:rows]
 

--- a/app/models/blacklight/search_builder.rb
+++ b/app/models/blacklight/search_builder.rb
@@ -1,20 +1,29 @@
 module Blacklight
   class SearchBuilder
+    extend Deprecation
     class_attribute :default_processor_chain
     self.default_processor_chain = []
 
     attr_reader :processor_chain, :blacklight_params
 
-    # @param [List<Symbol>,TrueClass] processor_chain a list of filter methods to run or true, to use the default methods
+    # @param [List<Symbol>,TrueClass] options a list of filter methods to run or true, to use the default methods
     # @param [Object] scope the scope where the filter methods reside in.
-    def initialize(processor_chain, scope)
-      @processor_chain = if processor_chain === true
-        default_processor_chain.dup
+    def initialize(*options)
+      @scope = case options.size
+      when 1
+        options.first
+      when 2
+        if options.first === true
+          Deprecation.warn Blacklight::SearchBuilder, "SearchBuilder#initialize now takes only one parameter, the scope. Passing `true' will be removed in Blacklight 7"
+        else
+          @processor_chain = options.first
+        end
+        options.last
       else
-        processor_chain
+        raise ArgumentError, "wrong number of arguments. (#{options.size} for 1..2)"
       end
 
-      @scope = scope
+      @processor_chain ||= default_processor_chain.dup
       @blacklight_params = {}
       @merged_params = {}
       @reverse_merged_params = {}

--- a/spec/models/blacklight/search_builder_spec.rb
+++ b/spec/models/blacklight/search_builder_spec.rb
@@ -7,9 +7,22 @@ describe Blacklight::SearchBuilder do
   subject { described_class.new processor_chain, scope }
 
   context "with default processor chain" do
-    subject { described_class.new true, scope }
-    it "should use the class-level default_processor_chain" do
-      expect(subject.processor_chain).to eq []
+    context "with two arguments" do
+      subject do
+        Deprecation.silence Blacklight::SearchBuilder do
+          described_class.new true, scope
+        end
+      end
+      it "uses the class-level default_processor_chain" do
+        expect(subject.processor_chain).to eq []
+      end
+    end
+
+    context "with one arguments" do
+      subject { described_class.new scope }
+      it "uses the class-level default_processor_chain" do
+        expect(subject.processor_chain).to eq []
+      end
     end
   end
 
@@ -49,7 +62,7 @@ describe Blacklight::SearchBuilder do
 
   describe "#except" do
     let(:processor_chain) { [:a, :b, :c, :d, :e] }
-    it "should provide a new search builder excepting arguments" do
+    it "provide a new search builder excepting arguments" do
       builder = subject.except(:b, :d, :does_not_exist)
       expect(builder).not_to equal(subject)
       expect(subject.processor_chain).to eq processor_chain

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -7,20 +7,32 @@ describe Blacklight::Solr::SearchBuilder do
   let(:subject_search_params) { { commit: "search", search_field: "subject", action: "index", controller: "catalog", rows: "10", q: "wome" } }
 
   let(:blacklight_config) { CatalogController.blacklight_config.deep_copy }
-  let(:method_chain) { CatalogController.search_params_logic }
   let(:user_params) { Hash.new }
   let(:context) { CatalogController.new }
 
   before { allow(context).to receive(:blacklight_config).and_return(blacklight_config) }
 
-  let(:search_builder) { described_class.new(method_chain, context) }
+  let(:search_builder) { described_class.new(context) }
 
   subject { search_builder.with(user_params) }
 
   context "with default processor chain" do
-    subject { described_class.new true, context }
-    it "should use the class-level default_processor_chain" do
-      expect(subject.processor_chain).to eq described_class.default_processor_chain
+    context "with two arguments" do
+      subject do
+        Deprecation.silence Blacklight::SearchBuilder do
+          described_class.new true, context
+        end
+      end
+      it "uses the class-level default_processor_chain" do
+        expect(subject.processor_chain).to eq described_class.default_processor_chain
+      end
+    end
+
+    context "with one arguments" do
+      subject { described_class.new context }
+      it "uses the class-level default_processor_chain" do
+        expect(subject.processor_chain).to eq described_class.default_processor_chain
+      end
     end
   end
 
@@ -78,6 +90,7 @@ describe Blacklight::Solr::SearchBuilder do
     end
 
     context "when search_params_logic is customized" do
+      let(:search_builder) { described_class.new(method_chain, context) }
       let(:method_chain) { [:add_foo_to_solr_params] }
 
       it "allows customization of search_params_logic" do

--- a/spec/views/catalog/_paginate_compact.html.erb_spec.rb
+++ b/spec/views/catalog/_paginate_compact.html.erb_spec.rb
@@ -18,7 +18,7 @@ describe "catalog/_paginate_compact.html.erb" do
     include Blacklight::SearchHelper
 
     it "should render solr responses" do
-      solr_response, document_list = search_results({ q: '' }, CatalogController.search_params_logic)
+      solr_response, document_list = search_results(q: '')
 
       render :partial => 'catalog/paginate_compact', :object => solr_response
       expect(rendered).to have_selector ".page_entries"


### PR DESCRIPTION
This means there is no need to pass 'true' to use the defaults.