### PR TITLE
rename blacklight_path to search_state

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -100,7 +100,7 @@ module Blacklight::Catalog
     end
 
     def action_success_redirect_path
-      blacklight_path.url_for_document(blacklight_config.document_model.new(id: params[:id]))
+      search_state.url_for_document(blacklight_config.document_model.new(id: params[:id]))
     end
 
     ##

--- a/app/controllers/concerns/blacklight/controller.rb
+++ b/app/controllers/concerns/blacklight/controller.rb
@@ -24,7 +24,7 @@ module Blacklight::Controller
     helper_method :has_user_authentication_provider?
     helper_method :blacklight_config, :blacklight_configuration_context
     helper_method :search_action_url, :search_action_path, :search_facet_url
-    helper_method :blacklight_path
+    helper_method :search_state
 
 
     # This callback runs when a user first logs in
@@ -64,9 +64,9 @@ module Blacklight::Controller
       has_user_authentication_provider? and current_user
     end
 
-    # @return [Blacklight::Path] a memoized instance of the parameter state.
-    def blacklight_path
-      @blacklight_path ||= Blacklight::Path.new(params, blacklight_config)
+    # @return [Blacklight::SearchState] a memoized instance of the parameter state.
+    def search_state
+      @search_state ||= Blacklight::SearchState.new(params, blacklight_config)
     end
 
     # Default route to the search action (used e.g. in global partials). Override this method

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -138,7 +138,7 @@ module Blacklight::FacetsHelperBehavior
     if facet_config.url_method
       send(facet_config.url_method, facet_field, item)
     else
-      search_action_path(blacklight_path.add_facet_params_and_redirect(facet_field, item))
+      search_action_path(search_state.add_facet_params_and_redirect(facet_field, item))
     end
   end
 
@@ -146,7 +146,7 @@ module Blacklight::FacetsHelperBehavior
   # Standard display of a SELECTED facet value (e.g. without a link and with a remove button)
   # @params (see #render_facet_value)
   def render_selected_facet_value(facet_field, item)
-    remove_href = search_action_path(blacklight_path.remove_facet_params(facet_field, item))
+    remove_href = search_action_path(search_state.remove_facet_params(facet_field, item))
     content_tag(:span, class: "facet-label") do
       content_tag(:span, facet_display_value(facet_field, item), class: "selected") +
       # remove link

--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -48,7 +48,7 @@ module Blacklight::RenderConstraintsHelperBehavior
   # @return [String]
   def render_constraints_filters(localized_params = params)
      return "".html_safe unless localized_params[:f]
-     path = Blacklight::Path.new(localized_params, blacklight_config)
+     path = Blacklight::SearchState.new(localized_params, blacklight_config)
      content = []
      localized_params[:f].each_pair do |facet,values|
        content << render_filter_element(facet, values, path)
@@ -61,7 +61,7 @@ module Blacklight::RenderConstraintsHelperBehavior
   # Render a single facet's constraint
   # @param [String] facet field
   # @param [Array<String>] values selected facet values
-  # @param [Blacklight::Path] path query parameters
+  # @param [Blacklight::SearchState] path query parameters
   # @return [String]
   def render_filter_element(facet, values, path)
     facet_config = facet_configuration_for_field(facet)

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -6,7 +6,7 @@ module Blacklight::UrlHelperBehavior
   # to provide more interesting routing to
   # documents
   def url_for_document(doc, options = {})
-    blacklight_path.url_for_document(doc, options)
+    search_state.url_for_document(doc, options)
   end
 
   # link_to_document(doc, 'VIEW', :counter => 3)
@@ -146,7 +146,7 @@ module Blacklight::UrlHelperBehavior
   # @param [Blacklight::SolrResponse::Group]
   # @return [Hash]
   def add_group_facet_params_and_redirect group
-    blacklight_path.add_facet_params_and_redirect(group.field, group.key, params)
+    search_state.add_facet_params_and_redirect(group.field, group.key, params)
   end
 
   # A URL to refworks export, with an embedded callback URL to this app. 

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -7,7 +7,7 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>
-      <li><%= link_to(label, url_for(blacklight_path.params_for_search(per_page: count))) %></li>
+      <li><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
     <%- end -%>
   </ul>
 </div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search' do %>
-  <%= render_hash_as_hidden_fields(blacklight_path.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group">
     <% if search_fields.length > 1 %>
       <span class="input-group-addon for-search-field">

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -6,7 +6,7 @@
 
   <ul class="dropdown-menu" role="menu">
       <%- active_sort_fields.each do |sort_key, field_config| %>
-        <li><%= link_to(field_config.label, url_for(blacklight_path.params_for_search(sort: sort_key))) %></li>
+        <li><%= link_to(field_config.label, url_for(search_state.params_for_search(sort: sort_key))) %></li>
       <%- end -%>
   </ul>
 </div>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -6,7 +6,7 @@
 
     <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) -%>
       <li><%= t 'blacklight.search.zero_results.search_fields', :search_fields => search_field_label(params) %> - 
-      <%= link_to t('blacklight.search.zero_results.search_everything', field: blacklight_config.default_search_field.label), url_for(blacklight_path.params_for_search(search_field: blacklight_config.default_search_field.key)) %>
+      <%= link_to t('blacklight.search.zero_results.search_everything', field: blacklight_config.default_search_field.label), url_for(search_state.params_for_search(search_field: blacklight_config.default_search_field.key)) %>
       </li>
     <%- end %>
 

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -4,10 +4,10 @@ require 'deprecation'
 require 'blacklight/utils'
 
 module Blacklight
-  autoload :Exceptions, 'blacklight/exceptions'
-  autoload :Path,       'blacklight/path'
-  autoload :Parameters, 'blacklight/parameters'
-  autoload :Routes, 'blacklight/routes'
+  autoload :Exceptions,  'blacklight/exceptions'
+  autoload :SearchState, 'blacklight/search_state'
+  autoload :Parameters,  'blacklight/parameters'
+  autoload :Routes,      'blacklight/routes'
 
   extend Deprecation
 

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -1,7 +1,7 @@
 module Blacklight
   # This class encapsulates the search state as represented by the query
   # parameters namely: :f, :q, :page, :per_page and, :sort
-  class Path
+  class SearchState
     include Blacklight::Facet
     attr_reader :blacklight_config # Must be called blacklight_config, because Blacklight::Facet calls blacklight_config.
     attr_reader :params

--- a/spec/controllers/blacklight/base_spec.rb
+++ b/spec/controllers/blacklight/base_spec.rb
@@ -4,13 +4,13 @@ describe Blacklight::Base do
   let(:controller) { (Class.new(ApplicationController) { include Blacklight::Base }).new }
   subject { controller}
 
-  describe "#blacklight_path" do
+  describe "#search_state" do
     let(:params) { double }
     before { allow(controller).to receive_messages(params: params) }
-    subject { controller.send(:blacklight_path) }
+    subject { controller.send(:search_state) }
 
     it "creates a path object" do
-      expect(subject).to be_kind_of Blacklight::Path
+      expect(subject).to be_kind_of Blacklight::SearchState
       expect(subject.params).to be params
     end
   end

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -301,11 +301,11 @@ describe FacetsHelper do
 
   describe "render_facet_value" do
     let(:item) { double(:value => 'A', :hits => 10) }
-    let(:blacklight_path) { double(add_facet_params_and_redirect: { controller: 'catalog' }) }
+    let(:search_state) { double(add_facet_params_and_redirect: { controller: 'catalog' }) }
     before do
       allow(helper).to receive(:facet_configuration_for_field).with('simple_field').and_return(double(:query => nil, :date => nil, :helper_method => nil, :single => false, :url_method => nil))
       allow(helper).to receive(:facet_display_value).and_return('Z')
-      allow(helper).to receive(:blacklight_path).and_return(blacklight_path)
+      allow(helper).to receive(:search_state).and_return(search_state)
       allow(helper).to receive(:search_action_path) do |*args|
         search_catalog_path *args
       end

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -34,7 +34,7 @@ describe RenderConstraintsHelper do
     end
     subject { helper.render_filter_element('type', ['journal'], path) }
 
-    let(:path) { Blacklight::Path.new({:q=>'biz'}, config) }
+    let(:path) { Blacklight::SearchState.new({:q=>'biz'}, config) }
 
     it "should have a link relative to the current url" do
       expect(subject).to have_link "Remove constraint Item Type: journal", href: "/catalog?q=biz"

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Blacklight::Path do
+describe Blacklight::SearchState do
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
       config.index.title_field = 'title_display'

--- a/spec/support/controller_level_helpers.rb
+++ b/spec/support/controller_level_helpers.rb
@@ -2,8 +2,8 @@ module ControllerLevelHelpers
   module ControllerViewHelpers
     include Blacklight::Facet
 
-    def blacklight_path
-      @blacklight_path ||= Blacklight::Path.new(params, blacklight_config)
+    def search_state
+      @search_state ||= Blacklight::SearchState.new(params, blacklight_config)
     end
 
     def blacklight_configuration_context


### PR DESCRIPTION
blacklight_path is already used by a built in Rails routing helper, and
the routing helper was getting precidence over our method.