### PR TITLE
Remove Blacklight::Catalog::SearchHistoryWindow reference from the default Blacklight configuration

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -141,7 +141,7 @@ module Blacklight
           default_per_page: nil,
           # how many searches to save in session history
           # (TODO: move the value into the configuration?)
-          search_history_window: Blacklight::Catalog::SearchHistoryWindow,
+          search_history_window: 100,
           default_facet_limit: 10
           }
         end


### PR DESCRIPTION
I guess this is a backwards compatibility concern, but it seems pretty slight. The alternative is doing lots of explicit class loading.