### PR TITLE
Add deprecated helper methods that use Blacklight::SearchState

### DIFF
--- a/app/helpers/blacklight/deprecated_url_helper_behavior.rb
+++ b/app/helpers/blacklight/deprecated_url_helper_behavior.rb
@@ -1,0 +1,58 @@
+module Blacklight
+  module DeprecatedUrlHelperBehavior
+    extend Deprecation
+    self.deprecation_horizon = 'blacklight 7.x'
+
+    def params_for_search(*args, &block)
+      source_params, params_to_merge = case args.length
+      when 0
+        search_state.params_for_search
+      when 1
+        search_state.params_for_search(args.first)
+      when 2
+        Deprecation.warn(Blacklight::DeprecatedUrlHelperBehavior, 'Use Blacklight::SearchState.new(source_params).params_for_search instead')
+        Blacklight::SearchState.new(args.first, blacklight_config).params_for_search(args.last)
+      else
+        raise ArgumentError.new "wrong number of arguments (#{args.length} for 0..2)"
+      end
+    end
+    deprecation_deprecate :params_for_search
+
+    def sanitize_search_params(source_params)
+      Blacklight::Parameters.sanitize(source_params)
+    end
+    deprecation_deprecate :sanitize_search_params
+
+    def reset_search_params(source_params)
+      Blacklight::SearchState.new(source_params, blacklight_config).send(:reset_search_params)
+    end
+    deprecation_deprecate :reset_search_params
+
+    def add_facet_params(field, item, source_params = nil)
+      if source_params
+        Deprecation.warn(Blacklight::DeprecatedUrlHelperBehavior, 'Use Blacklight::SearchState.new(source_params).add_facet_params instead')
+
+        Blacklight::SearchState.new(source_params, blacklight_config).add_facet_params(field, item)
+      else
+        search_state.add_facet_params(field, item)
+      end
+    end
+    deprecation_deprecate :add_facet_params
+
+    def remove_facet_params(field, item, source_params = nil)
+      if source_params
+        Deprecation.warn(Blacklight::DeprecatedUrlHelperBehavior, 'Use Blacklight::SearchState.new(source_params).remove_facet_params instead')
+
+        Blacklight::SearchState.new(source_params, blacklight_config).remove_facet_params(field, item)
+      else
+        search_state.remove_facet_params(field, item)
+      end
+    end
+    deprecation_deprecate :remove_facet_params
+
+    def add_facet_params_and_redirect(field, item)
+      search_state.add_facet_params_and_redirect(field, item)
+    end
+    deprecation_deprecate :add_facet_params_and_redirect
+  end
+end

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -146,7 +146,7 @@ module Blacklight::UrlHelperBehavior
   # @param [Blacklight::SolrResponse::Group]
   # @return [Hash]
   def add_group_facet_params_and_redirect group
-    search_state.add_facet_params_and_redirect(group.field, group.key, params)
+    search_state.add_facet_params_and_redirect(group.field, group.key)
   end
 
   # A URL to refworks export, with an embedded callback URL to this app. 

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -1,6 +1,8 @@
 ##
 # URL helper methods
 module Blacklight::UrlHelperBehavior
+  include Blacklight::DeprecatedUrlHelperBehavior
+
   ##
   # Extension point for downstream applications
   # to provide more interesting routing to

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -220,7 +220,7 @@ module Blacklight
           end
 
           Array(value).map do |v|
-            @controller.link_to render_field_value(v, field_config), @controller.search_action_path(@controller.add_facet_params(link_field, v, {}))
+            @controller.link_to render_field_value(v, field_config), @controller.search_action_path(@controller.search_state.reset.add_facet_params(link_field, v))
           end if field
         else
           value

--- a/spec/helpers/deprecated_url_helper_behavior_spec.rb
+++ b/spec/helpers/deprecated_url_helper_behavior_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Blacklight::DeprecatedUrlHelperBehavior do
+  around do |test|
+    Deprecation.silence(described_class) do
+      test.call
+    end
+  end
+  
+  let(:search_state) { Blacklight::SearchState.new(params, blacklight_config) }
+  let(:params) { {} }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+
+  before do
+    allow(helper).to receive(:search_state).and_return(search_state)
+    allow(helper).to receive(:params).and_return(params)
+    allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+  end
+
+  describe '#params_for_search' do
+    it 'passes through to the search state' do
+      expect(helper.params_for_search).to eq search_state.params_for_search
+    end
+
+    it 'passes arguments through to the search state' do
+      expect(helper.params_for_search(merge: 1)).to eq search_state.params_for_search(merge: 1)
+    end
+
+    it 'generates a search state for the source parameters' do
+      expect(helper.params_for_search({ source: 1 }, { merge: 1 })).to include merge: 1, source: 1
+    end
+  end
+
+  describe '#sanitize_search_params' do
+    it 'passes through to the parameter sanitizer' do
+      expect(helper.sanitize_search_params(a: 1)).to eq Blacklight::Parameters.sanitize(a: 1)
+    end
+  end
+
+  describe '#reset_search_params' do
+    it 'resets the current page and counter' do
+      expect(helper.reset_search_params(page: 1, counter: 10)).to be_blank
+    end
+  end
+
+  describe '#add_facet_params' do
+    before do
+      blacklight_config.add_facet_field 'x'
+    end
+
+    let(:field) { blacklight_config.facet_fields['x'] }
+    let(:item) { true }
+
+    it 'passes through to the search state' do
+      expect(helper.add_facet_params(field, item)).to eq search_state.add_facet_params(field, item)
+    end
+
+    it 'generates a search state for the source parameters' do
+      expect(helper.add_facet_params(field, item, source: 1)).to include source: 1
+    end
+  end
+
+  describe '#add_facet_params_and_redirect' do
+    before do
+      blacklight_config.add_facet_field 'x'
+    end
+
+    let(:field) { blacklight_config.facet_fields['x'] }
+    let(:item) { true }
+
+    it 'passes through to the search state' do
+      expect(helper.add_facet_params_and_redirect(field, item)).to eq search_state.add_facet_params_and_redirect(field, item)
+    end
+  end
+
+  describe '#remove_facet_params' do
+    before do
+      blacklight_config.add_facet_field 'x'
+    end
+
+    let(:field) { blacklight_config.facet_fields['x'] }
+    let(:item) { true }
+
+    it 'passes through to the search state' do
+      expect(helper.remove_facet_params(field, item)).to eq search_state.remove_facet_params(field, item)
+    end
+
+    it 'generates a search state for the source parameters' do
+      expect(helper.remove_facet_params(field, item, source: 1)).to include source: 1
+    end
+  end
+end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Blacklight::DocumentPresenter do
   include Capybara::RSpecMatchers
-  let(:request_context) { double(:add_facet_params => '') }
+  let(:request_context) { double }
   let(:config) { Blacklight::Configuration.new }
 
   subject { presenter }
@@ -14,6 +14,10 @@ describe Blacklight::DocumentPresenter do
                      'link_to_search_named' => 'x',
                      'qwer' => 'document qwer value',
                      'mnbv' => 'document mnbv value')
+  end
+
+  before do
+    allow(request_context).to receive(:search_state).and_return(Blacklight::SearchState.new({}, config))
   end
 
   describe "link_rel_alternates" do
@@ -116,7 +120,6 @@ describe Blacklight::DocumentPresenter do
     end
 
     it "should check for a link_to_search" do
-      allow(request_context).to receive(:add_facet_params).and_return(:f => { :link_to_search_true => ['x'] })
       allow(request_context).to receive(:search_action_path).with(:f => { :link_to_search_true => ['x'] }).and_return('/foo')
       allow(request_context).to receive(:link_to).with("x", '/foo').and_return('bar')
       value = subject.render_index_field_value 'link_to_search_true'
@@ -124,7 +127,6 @@ describe Blacklight::DocumentPresenter do
     end
 
     it "should check for a link_to_search with a field name" do
-      allow(request_context).to receive(:add_facet_params).and_return(:f => { :some_field => ['x'] })
       allow(request_context).to receive(:search_action_path).with(:f => { :some_field => ['x'] }).and_return('/foo')
       allow(request_context).to receive(:link_to).with("x", '/foo').and_return('bar')
       value = subject.render_index_field_value 'link_to_search_named'
@@ -211,14 +213,14 @@ describe Blacklight::DocumentPresenter do
     end
 
     it "should check for a link_to_search" do
-      allow(request_context).to receive(:search_action_path).with('').and_return('/foo')
+      allow(request_context).to receive(:search_action_path).and_return('/foo')
       allow(request_context).to receive(:link_to).with("x", '/foo').and_return('bar')
       value = subject.render_document_show_field_value 'link_to_search_true'
       expect(value).to eq 'bar'
     end
 
     it "should check for a link_to_search with a field name" do
-      allow(request_context).to receive(:search_action_path).with('').and_return('/foo')
+      allow(request_context).to receive(:search_action_path).and_return('/foo')
       allow(request_context).to receive(:link_to).with("x", '/foo').and_return('bar')
       value = subject.render_document_show_field_value 'link_to_search_named'
       expect(value).to eq 'bar'


### PR DESCRIPTION
Upgrading spotlight was unnecessarily painful without these deprecations. I've targeted this at `master`, but could be persuaded to backport `SearchState` to Blacklight 5.x instead. 