### PR TITLE
Update catalog#track to fall back on the model's route, and fallback …

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -56,12 +56,12 @@ module Blacklight::Catalog
       search_session['id'] = params[:search_id]
       search_session['per_page'] = params[:per_page]
 
-      path = if params[:redirect] and (params[:redirect].starts_with?("/") or params[:redirect] =~ URI::regexp)
-        URI.parse(params[:redirect]).path
+      if params[:redirect] and (params[:redirect].starts_with?('/') or params[:redirect] =~ URI::regexp)
+        path = URI.parse(params[:redirect]).path
+        redirect_to path, status: 303
       else
-        { action: 'show' }
+        redirect_to blacklight_config.document_model.new(id: params[:id]), status: 303
       end
-      redirect_to path, :status => 303
     end
 
     # displays values and pagination links for a single facet field

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Blacklight::Engine.routes.draw do
   put "saved_searches/save/:id",    :to => "saved_searches#save",    :as => "save_search"
   delete "saved_searches/forget/:id",  :to => "saved_searches#forget",  :as => "forget_search"
   post "saved_searches/forget/:id",  :to => "saved_searches#forget"
+  post "/catalog/:id/track", to: 'catalog#track', as: 'track_search_context'
+
   resources :suggest, only: :index, defaults: { format: 'json' }
 end

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -222,12 +222,29 @@ describe BlacklightUrlHelper do
       expect(helper.link_to_document(@document, :title_display, counter: 5)).to include 'data-context-href="tracking url"'
     end
 
-    it "should merge the data- attributes from the options with the counter params" do
+    it "includes the data- attributes from the options" do
       data = {'id'=>'123456','title_display'=>['654321']}
       @document = SolrDocument.new(data)
       link = helper.link_to_document @document, { data: { x: 1 }  }
       expect(link).to have_selector '[data-x]'
-      expect(link).to have_selector '[data-context-href]'
+    end
+
+    it 'adds a controller-specific tracking attribute' do
+      data = { 'id'=>'123456', 'title_display'=>['654321'] }
+      @document = SolrDocument.new(data)
+
+      expect(helper).to receive(:track_test_path).and_return('/asdf')
+      link = helper.link_to_document @document, { data: { x: 1 }  }
+
+      expect(link).to have_selector '[data-context-href="/asdf"]'
+    end
+
+    it 'adds a global tracking attribute' do
+      data = { 'id'=>'123456', 'title_display'=>['654321'] }
+      @document = SolrDocument.new(data)
+
+      link = helper.link_to_document @document, { data: { x: 1 }  }
+      expect(link).to have_selector '[data-context-href="/catalog/123456/track"]'
     end
 
     it "passes on the title attribute to the link_to_with_data method" do


### PR DESCRIPTION
…to a blacklight internal tracking route if a controller-specific one is unavailable.

This fixes a problem with plain polymorphic fallback, which may not be defined or routed to. 