### PR TITLE
Add 'null: default' to migration timestamps for compatibility with Rails 5

### DIFF
--- a/db/migrate/20140202020201_create_searches.rb
+++ b/db/migrate/20140202020201_create_searches.rb
@@ -5,7 +5,7 @@ class CreateSearches < ActiveRecord::Migration
       t.integer :user_id
       t.string :user_type
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :searches, :user_id

--- a/db/migrate/20140202020202_create_bookmarks.rb
+++ b/db/migrate/20140202020202_create_bookmarks.rb
@@ -5,7 +5,7 @@ class CreateBookmarks < ActiveRecord::Migration
       t.string :user_type
       t.string :document_id
       t.string :title
-      t.timestamps
+      t.timestamps null: false
     end
   end
 


### PR DESCRIPTION
Fixes #1319