### PR TITLE
DeprecatedConstantProxy doesn't work with classes; do manual deprecations instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,12 @@ source 'https://rubygems.org'
 gemspec path: File.expand_path('..', __FILE__)
 
 gem 'simplecov', '~> 0.10', require: false
-gem 'coveralls', require: false
+
+# Locking coverall dependency tins to 1.6.x because 1.7.0 requires ruby >= 2.0
+group :test do
+  gem 'coveralls', require: false
+  gem 'tins', "~> 1.6.0", require: false
+end
 
 group :test do
   gem "blacklight-marc", "~> 5.0", github: "projectblacklight/blacklight_marc"

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -23,18 +23,20 @@ module Blacklight
     attr_accessor :solr, :solr_config
   end
 
-  # For deprecating SolrRepository and SolrResponse
-  def self.const_missing(const_name)
-    case const_name
-    when :SolrRepository
-      Deprecation.warn(:SolrRepository, 'Blacklight::SolrRepository is deprecated; use Blacklight::Solr::Repository instead')
-      Solr::Repository
-    when :SolrResponse
-      Deprecation.warn(:SolrResponse, 'Blacklight::SolrResponse is deprecated; use Blacklight::Solr::Response instead')
-      Solr::Response
-    else
+  class SolrRepository < Solr::Repository
+    extend Deprecation
+    def initialize blacklight_config
+      Deprecation.warn(self, 'Blacklight::SolrRepository is deprecated; use Blacklight::Solr::Repository instead')
       super
-    end
+    end 
+  end
+
+  class SolrResponse < Solr::Response
+    extend Deprecation
+    def initialize(data, request_params, options = {})
+      Deprecation.warn(self, 'Blacklight::SolrResponse is deprecated; use Blacklight::Solr::Response instead')
+      super
+    end 
   end
 
   # Secret key used to share session information with

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -8,8 +8,6 @@ module Blacklight
   autoload :Routes, 'blacklight/routes'
   autoload :Solr, 'blacklight/solr'
 
-  SolrRepository = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('Blacklight::SolrRepository', 'Blacklight::Solr::Repository')
-  SolrResponse = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('Blacklight::SolrResponse', 'Blacklight::Solr::Response')
   autoload :SolrHelper, 'blacklight/solr_helper'
 
   autoload :AbstractRepository, 'blacklight/abstract_repository'
@@ -23,6 +21,20 @@ module Blacklight
 
   class << self
     attr_accessor :solr, :solr_config
+  end
+
+  # For deprecating SolrRepository and SolrResponse
+  def self.const_missing(const_name)
+    case const_name
+    when :SolrRepository
+      Deprecation.warn(:SolrRepository, 'Blacklight::SolrRepository is deprecated; use Blacklight::Solr::Repository instead')
+      Solr::Repository
+    when :SolrResponse
+      Deprecation.warn(:SolrResponse, 'Blacklight::SolrResponse is deprecated; use Blacklight::Solr::Response instead')
+      Solr::Response
+    else
+      super
+    end
   end
 
   # Secret key used to share session information with


### PR DESCRIPTION
This was causing blacklight_folders to break.