### PR TITLE
allow for configurable layout container classes

### DIFF
--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -30,5 +30,13 @@ module Blacklight
     def sidebar_classes
       'col-md-3 col-sm-4'
     end
+
+    ##
+    # Class used for specifying main layout container classes. Can be
+    # overwritten to return 'container-fluid' for Bootstrap full-width layout
+    # @return [String] 
+    def container_classes
+      'container'
+    end
   end
 end

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -35,7 +35,7 @@
 
   <%= render partial: 'shared/ajax_modal' %>
 
-  <div id="main-container" class="container">
+  <div id="main-container" class="<%= container_classes %>">
     <%= content_tag :h1, application_name, class: 'sr-only application-heading' %>
 
     <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,5 +1,5 @@
 <div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
-  <div class="container">
+  <div class="<%= container_classes %>">
     <div class="navbar-header">
     <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
       <span class="sr-only">Toggle navigation</span>
@@ -17,7 +17,7 @@
 </div>
 
 <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
-  <div class="container">
+  <div class="<%= container_classes %>">
     <%= render_search_bar  %>
   </div>
 </div>

--- a/spec/helpers/layout_helper_spec.rb
+++ b/spec/helpers/layout_helper_spec.rb
@@ -28,4 +28,11 @@ describe LayoutHelper do
       expect(helper.sidebar_classes).to eq 'col-md-3 col-sm-4'
     end
   end
+
+  describe '#container_classes' do
+    it 'returns a string of classe(s)' do
+      expect(helper.container_classes).to be_an String
+      expect(helper.container_classes).to eq 'container'
+    end
+  end
 end


### PR DESCRIPTION
Makes life simpler for switching to `container-fluid` and adding additional classes to main containers.