### PR TITLE
Add a CSS class and data attribute for the position of the document in the search results

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,4 @@
 <% # container for a single doc -%>
-<div class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
+<div class="document <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
   <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, :document_counter => document_counter %>
 </div>

--- a/spec/views/catalog/_document.html.erb_spec.rb
+++ b/spec/views/catalog/_document.html.erb_spec.rb
@@ -9,9 +9,12 @@ describe "catalog/_document" do
     Blacklight::Configuration.new
   end
 
-  it "should render the header, thumbnail and index by default" do
+  before do
     allow(view).to receive(:render_grouped_response?).and_return(false)
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
+  end
+
+  it "should render the header, thumbnail and index by default" do
     stub_template "catalog/_index_header_default.html.erb" => "document_header"
     stub_template "catalog/_thumbnail_default.html.erb" => "thumbnail_default"
     stub_template "catalog/_index_default.html.erb" => "index_default"
@@ -25,8 +28,6 @@ describe "catalog/_document" do
 
 
   it "should use the index.partials parameter to determine the partials to render" do
-    allow(view).to receive(:render_grouped_response?).and_return(false)
-    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     blacklight_config.index.partials = ['a', 'b', 'c']
     stub_template "catalog/_a_default.html.erb" => "a_partial"
     stub_template "catalog/_b_default.html.erb" => "b_partial"
@@ -35,5 +36,21 @@ describe "catalog/_document" do
     expect(rendered).to match /a_partial/
     expect(rendered).to match /b_partial/
     expect(rendered).to match /c_partial/
+  end
+
+  it 'has a css class with the document position' do
+    allow(view).to receive(:render_document_partials)
+
+    render partial: 'catalog/document', locals: { document: document, document_counter: 5 }
+
+    expect(rendered).to have_selector 'div.document-position-5'
+  end
+
+  it 'has a data attribute with the document position' do
+    allow(view).to receive(:render_document_partials)
+
+    render partial: 'catalog/document', locals: { document: document, document_counter: 5 }
+
+    expect(rendered).to have_selector 'div.document[@data-document-counter="5"]'
   end
 end


### PR DESCRIPTION
This should be useful in a couple contexts:

- styling the top result differently
- relevancy analytics 