### PR TITLE
Non image objects in search results

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -37,7 +37,7 @@ module Blacklight::CatalogHelperBehavior
     else
       collection.total_count
     end
-      
+
     case collection.total_count
       when 0; t('blacklight.search.pagination_info.no_items_found', :entry_name => entry_name ).html_safe
       when 1; t('blacklight.search.pagination_info.single_item_found', :entry_name => entry_name).html_safe
@@ -54,7 +54,7 @@ module Blacklight::CatalogHelperBehavior
     offset ||= @response.start if @response
     offset ||= 0
 
-    unless render_grouped_response? 
+    unless render_grouped_response?
       idx + 1 + offset
     end
   end
@@ -62,7 +62,7 @@ module Blacklight::CatalogHelperBehavior
   ##
   # Like #page_entries_info above, but for an individual
   # item show page. Displays "showing X of Y items" message.
-  # 
+  #
   # @see #page_entries_info
   # @return [String]
   def item_page_entry_info
@@ -86,7 +86,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Look up the current per page value, or the default if none if set
-  # 
+  #
   # @return [Integer]
   def current_per_page
     (@response.rows if @response and @response.rows > 0) || params.fetch(:per_page, default_per_page).to_i
@@ -94,7 +94,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Get the classes to add to a document's div
-  # 
+  #
   # @return [String]
   def render_document_class(document = @document)
     types = document[blacklight_config.view_config(document_index_view_type).display_type_field]
@@ -130,7 +130,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Should we display the sort and per page widget?
-  # 
+  #
   # @param [Blacklight::Solr::Response]
   # @return [Boolean]
   def show_sort_and_per_page? response = nil
@@ -151,7 +151,7 @@ module Blacklight::CatalogHelperBehavior
   ##
   # If no search parameters have been given, we should
   # auto-focus the user's cursor into the searchbox
-  # 
+  #
   # @return [Boolean]
   def should_autofocus_on_search_box?
     controller.is_a? Blacklight::Catalog and
@@ -161,7 +161,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Does the document have a thumbnail to render?
-  # 
+  #
   # @param [SolrDocument]
   # @return [Boolean]
   def has_thumbnail? document
@@ -172,12 +172,13 @@ module Blacklight::CatalogHelperBehavior
   ##
   # Render the thumbnail, if available, for a document and
   # link it to the document record.
-  # 
+  #
   # @param [SolrDocument]
   # @param [Hash] options to pass to the image tag
   # @param [Hash] url options to pass to #link_to_document
   # @return [String]
   def render_thumbnail_tag document, image_options = {}, url_options = {}
+    return "" unless has_thumbnail?(document) # do not render any html if there is no thumbnail
     value = if blacklight_config.view_config(document_index_view_type).thumbnail_method
       send(blacklight_config.view_config(document_index_view_type).thumbnail_method, document, image_options)
     elsif blacklight_config.view_config(document_index_view_type).thumbnail_field
@@ -195,7 +196,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Get the URL to a document's thumbnail image
-  # 
+  #
   # @param [SolrDocument]
   # @return [String]
   def thumbnail_url document
@@ -206,7 +207,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Get url parameters to a search within a grouped result set
-  # 
+  #
   # @param [Blacklight::Solr::Response::Group]
   # @return [Hash]
   def add_group_facet_params_and_redirect group
@@ -215,7 +216,7 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Render the view type icon for the results view picker
-  # 
+  #
   # @param [String]
   # @return [String]
   def render_view_type_group_icon view
@@ -230,7 +231,7 @@ module Blacklight::CatalogHelperBehavior
   def default_view_type_group_icon_classes view
     "glyphicon-#{view.to_s.parameterize } view-icon-#{view.to_s.parameterize}"
   end
-  
+
   def current_bookmarks response = nil
     response ||= @response
     @current_bookmarks ||= current_or_guest_user.bookmarks_for_documents(response.documents).to_a
@@ -244,10 +245,10 @@ module Blacklight::CatalogHelperBehavior
 
   alias_method :is_bookmarked?, :bookmarked?
   deprecation_deprecate :is_bookmarked?
-  
+
   def render_marc_tools
     return unless defined? Blacklight::Marc
-    
+
     begin
       # blacklight-marc 5.4+
       render 'marc_tools'
@@ -278,7 +279,7 @@ module Blacklight::CatalogHelperBehavior
     filter_label = facet_field_label(facet_config.key)
     filter_value = if values.size < 3
       values.map {|value| facet_display_value(facet, value)}.to_sentence
-    else 
+    else
       t('blacklight.search.page_title.many_constraint_values', values: values.size)
     end
     t('blacklight.search.page_title.constraint', label: filter_label, value: filter_value)

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -165,7 +165,7 @@ describe CatalogHelper do
       document = double(:has? => true)
       expect(helper.has_thumbnail? document).to be true
     end
-    
+
     it "should not have a thumbnail if the thumbnail_field is missing from the document" do
       allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
       document = double(:has? => false)
@@ -217,14 +217,14 @@ describe CatalogHelper do
 
     it "should return nil if no thumbnail is available" do
       allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new() ))
-      expect(helper.render_thumbnail_tag document).to be_nil
+      expect(helper.render_thumbnail_tag document).to be_blank
     end
 
     it "should return nil if no thumbnail is returned from the thumbnail method" do
       allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz) ))
       allow(helper).to receive_messages(:xyz => nil)
 
-      expect(helper.render_thumbnail_tag document).to be_nil
+      expect(helper.render_thumbnail_tag document).to be_blank
     end
   end
 


### PR DESCRIPTION
Instead of rendering a blank HTML image tag when there is no thumbnail for an object, just don't render anything.