### PR TITLE
When a document does not have a thumbnail avaialble, don't render an image tag

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -178,7 +178,9 @@ module Blacklight::CatalogHelperBehavior
     value = if blacklight_config.view_config(document_index_view_type).thumbnail_method
       send(blacklight_config.view_config(document_index_view_type).thumbnail_method, document, image_options)
     elsif blacklight_config.view_config(document_index_view_type).thumbnail_field
-      image_tag thumbnail_url(document), image_options
+      url = thumbnail_url(document)
+
+      image_tag url, image_options if url.present?
     end
 
     if value

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -226,6 +226,14 @@ describe CatalogHelper do
 
       expect(helper.render_thumbnail_tag document).to be_nil
     end
+
+    it "should return nil if no thumbnail is in the document" do
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
+
+      allow(document).to receive(:has?).with(:xyz).and_return(false)
+
+      expect(helper.render_thumbnail_tag document).to be_nil
+    end
   end
 
   describe "thumbnail_url" do


### PR DESCRIPTION
Fixes #1332