### PR TITLE
invalid_document_id_error: re-raise if public/404.html doesn't exist

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -249,6 +249,8 @@ module Blacklight::Catalog
     # CatalogController to do something else -- older BL displayed a Catalog#inde
     # page with a flash message and a 404 status.
     def invalid_document_id_error(exception)
+      raise exception unless Pathname.new("#{Rails.root}/public/404.html").exist?
+
       error_info = {
         "status" => "404",
         "error"  => "#{exception.class}: #{exception.message}"


### PR DESCRIPTION
The current error rendering doesn't work in applications using dynamic
error pages where `public/404.html` doesn't exist.  It's probably better
to just let the error pass through and have the application handle it
than ask each developer to redefine `Blacklight::Catalog.invalid_document_id_error`.

It'll make debugging easier, too; a stacktrace would have been much more
helpful than the `ActiveView::MissingTemplate` error that was caught by
the 500 error handler.
