### PR TITLE
Make SearchHistoryController have an AS::Concern

### DIFF
--- a/app/controllers/concerns/blacklight/search_history.rb
+++ b/app/controllers/concerns/blacklight/search_history.rb
@@ -1,0 +1,31 @@
+module Blacklight
+  module SearchHistory
+    extend ActiveSupport::Concern
+    include Blacklight::Configurable
+
+    included do
+      copy_blacklight_config_from(CatalogController)
+    end
+
+    def index
+      @searches = searches_from_history
+    end
+
+    # TODO: we may want to remove unsaved (those without user_id) items from
+    # the database when removed from history
+    def clear
+      if session[:history].clear
+        flash[:notice] = I18n.t('blacklight.search_history.clear.success')
+      else
+        flash[:error] = I18n.t('blacklight.search_history.clear.failure')
+      end
+
+      if respond_to? :redirect_back
+        redirect_back fallback_location: blacklight.search_history_path
+      else
+        # Deprecated in Rails 5.0
+        redirect_to :back
+      end
+    end
+  end
+end

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,26 +1,3 @@
 class SearchHistoryController < ApplicationController
-  include Blacklight::Configurable
-
-  copy_blacklight_config_from(CatalogController)
-
-  def index
-    @searches = searches_from_history
-  end
-
-  # TODO: we may want to remove unsaved (those without user_id) items from
-  # the database when removed from history
-  def clear
-    if session[:history].clear
-      flash[:notice] = I18n.t('blacklight.search_history.clear.success')
-    else
-      flash[:error] = I18n.t('blacklight.search_history.clear.failure')
-    end
-
-    if respond_to? :redirect_back
-      redirect_back fallback_location: blacklight.search_history_path
-    else
-      # Deprecated in Rails 5.0
-      redirect_to :back
-    end
-  end
+  include Blacklight::SearchHistory
 end


### PR DESCRIPTION
This will allow plugins to generate modifications to the
SearchHistoryController, instead of relying on patches during
initialization as is currently done in blacklight-range_limit

This will enable fixing https://github.com/projectblacklight/blacklight_range_limit/issues/41