### PR TITLE
update blacklight-marc dependency for use in BL 6.0

### DIFF
--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -98,7 +98,8 @@ EOF
 
     def generate_blacklight_marc_demo
       if options[:marc]
-        gem "blacklight-marc", "~> 5.0"
+        blacklight_marc = String.new('blacklight-marc')
+        gem blacklight_marc, '~> 6.0'
 
         Bundler.with_clean_env do
           run "bundle install"

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -23,7 +23,7 @@ class TestAppGenerator < Rails::Generators::Base
       run "bundle install"
     end
 
-    generate 'blacklight:install', '--devise --jettywrapper'
+    generate 'blacklight:install', '--devise --marc --jettywrapper'
   end
 
   def run_test_support_generator


### PR DESCRIPTION
blacklight-marc version 5.x is incompatible with blacklight 6.x. Updated install generator and test app generator to make sure user is able to add on MARC-related functionality in Blacklight 6.0.