### PR TITLE
make pagination span full width

### DIFF
--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,6 +1,6 @@
 <% if show_pagination? and @response.total_pages > 1 %>
  <div class="row record-padding">
-  <div class="col-md-9"> 
+  <div class="col-md-12">
     <div class="pagination">
       <%= paginate @response, :outer_window => 2, :theme => 'blacklight' %>
     </div>


### PR DESCRIPTION
Allows the pagination to take up the full width of the main content container. Changes this:
![pagination](https://cloud.githubusercontent.com/assets/4650153/12587483/985044f0-c422-11e5-8938-b2ff0a4b33e2.png)
To this:
![updated_pagination](https://cloud.githubusercontent.com/assets/4650153/12587488/9f31512e-c422-11e5-931d-930bc5a0fccc.png)
