### PR TITLE
Don't set facet.limit in the exemplar solrconfig

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -214,7 +214,6 @@
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
-       <str name="facet.limit">10</str>
        <str name="facet.field">format</str>
        <str name="facet.field">lc_1letter_facet</str>
        <str name="facet.field">lc_alpha_facet</str>


### PR DESCRIPTION
When this happens, facets only show the first 10 values and don't give
any indication that there is more than 10 (the more >>) link. This will
allow users to customize a sensible limit in their Blacklight
Configuration