### PR TITLE
Remove generation of globalid gem

### DIFF
--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -18,11 +18,10 @@ module Blacklight
       This generator makes the following changes to your application:
        1. Generates blacklight:models
        2. Generates utilities for working with solr 
-       3. Adds globalid to the Gemfile
-       4. Creates a number of public assets, including images, stylesheets, and javascript
-       5. Injects behavior into your user application_controller.rb
-       6. Adds example configurations for dealing with MARC-like data
-       7. Adds Blacklight routes to your ./config/routes.rb
+       3. Creates a number of public assets, including images, stylesheets, and javascript
+       4. Injects behavior into your user application_controller.rb
+       5. Adds example configurations for dealing with MARC-like data
+       6. Adds Blacklight routes to your ./config/routes.rb
 
       Thank you for Installing Blacklight.
     EOS
@@ -35,10 +34,6 @@ module Blacklight
       else
         generate "blacklight:solr#{solr_version}"
       end
-    end
-
-    def add_globalid_gem
-      gem "globalid"
     end
 
     def bundle_install


### PR DESCRIPTION
globalid is declared as a dependency in the gemspec, so there's no need
to generate the dependency too.