### PR TITLE
Address bug in default template install process (Solr4Generator).

### DIFF
--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -27,13 +27,16 @@ module Blacklight
     EOS
 
     def add_solr_wrapper
-      if options[:jettywrapper]
-        generate 'blacklight:solr4'
-      elsif solr_version == 'latest'
-        generate 'blacklight:solr5'
-      else
-        generate "blacklight:solr#{solr_version}"
-      end
+      generator_options = '--jettywrapper' if options[:jettywrapper]
+      solr_generator = case
+                       when options[:jettywrapper]
+                         'blacklight:solr4'
+                       when solr_version == 'latest'
+                         'blacklight:solr5'
+                       else
+                         "blacklight:solr#{solr_version}"
+                       end
+      generate solr_generator, generator_options
     end
 
     def bundle_install

--- a/lib/generators/blacklight/solr4_generator.rb
+++ b/lib/generators/blacklight/solr4_generator.rb
@@ -3,6 +3,11 @@ require 'rails/generators'
 
 module Blacklight
   class Solr4Generator < Rails::Generators::Base
+
+    source_root File.expand_path('../templates', __FILE__)
+
+    class_option :jettywrapper, type: :boolean, default: false, desc: "Use jettywrapper to download and control Jetty"
+
     desc <<-EOS
       This generator makes the following changes to your application:
        1. Installs jettywrapper into your application
@@ -11,9 +16,9 @@ module Blacklight
 
     def install_jettywrapper
       return unless options[:jettywrapper]
-      gem "jettywrapper".dup, ">= 2.0"
 
-      copy_file "config/jetty.yml"
+      gem "jettywrapper".dup, ">= 2.0"
+      copy_file "config/jetty.yml", "config/jetty.yml"
 
       append_to_file "Rakefile",
         "\nZIP_URL = \"https://github.com/projectblacklight/blacklight-jetty/archive/v4.10.4.zip\"\n" \


### PR DESCRIPTION
Don't require the jettywrapper option to be passed to the generator to install jettywrapper (it is already checked before running that generator).

Add the templates directory as a source_root so the generator can access to jetty.yml