### PR TITLE
Fix Next and Previous Links still clickable when disabled.

### DIFF
--- a/app/views/kaminari/blacklight/_next_page.html.erb
+++ b/app/views/kaminari/blacklight/_next_page.html.erb
@@ -6,6 +6,12 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<li class="<%= 'disabled' if current_page.last? %>">
-  <%= link_to raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
-</li>
+<% if current_page.last? %>
+    <li class="disabled">
+      <%= link_to raw(t 'views.pagination.next'), '#', :rel => 'next', :onclick=>'return false;' %>
+    </li>
+<% else %>
+    <li>
+      <%= link_to raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+    </li>
+<% end %>

--- a/app/views/kaminari/blacklight/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight/_prev_page.html.erb
@@ -6,6 +6,13 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<li class="<%= 'disabled' if current_page.first? %>">
-  <%= link_to raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
-</li>
+<% if current_page.first? %>
+    <li class="disabled">
+      <%= link_to raw(t 'views.pagination.previous'), '#', :rel => 'prev', :onclick=>'return false;' %>
+    </li>
+<% else %>
+    <li>
+      <%= link_to raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+    </li>
+<% end %>
+


### PR DESCRIPTION
While they are greyed out and show a disabled icon, the next and
previous pagination navigation is still clickable and will lead to
a weird state in the case of "next". This fixes it in a very easy
to read manner. There may be a more compact way of making this
change.

To duplicate the symptoms this fixes (tested in Chrome):

* Go to http://demo.projectblacklight.org/ and do a blank search.

* Click "<< Previous" at the very bottom of the page for error #1.
This is minor as it simply refreshes the page.

* Click "988" at the bottom of the page (the last page).

* Click the greyed-out "Next >>" at the bottom. This will lead to a
minor but more undesired state.