### PR TITLE
Add deprecated methods (deprecated by DocumentPresenter) into the new presenters

### DIFF
--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -127,9 +127,15 @@ module Blacklight
 
     # @deprecated
     def render_field_value(values, field_config = Configuration::NullField.new)
-      FieldPresenter.new(@controller, @document, field_config, value: values).render
+      field_values(field_config, value: Array(values))
     end
     deprecation_deprecate render_field_value: 'Use FieldPresenter instead'
+
+    # @deprecated
+    def render_values(values, field_config = Configuration::NullField.new)
+      field_values(field_config, value: Array(values))
+    end
+    deprecation_deprecate render_values: 'Use FieldPresenter instead'
 
     private
 

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 module Blacklight
   class IndexPresenter
+    extend Deprecation
+    self.deprecation_horizon = 'Blacklight version 7.0.0'
+
     attr_reader :document, :configuration, :view_context
 
     # @param [SolrDocument] document
@@ -34,6 +37,12 @@ module Blacklight
       field_values(config, value: value)
     end
 
+    # @deprecated
+    def render_document_index_label(*args)
+      label(*args)
+    end
+    deprecation_deprecate render_document_index_label: 'Use #label instead'
+
     ##
     # Render the index field label for a document
     #
@@ -46,6 +55,30 @@ module Blacklight
       field_config = field_config(field)
       field_values(field_config, options)
     end
+
+    # @deprecated
+    def render_index_field_value(*args)
+      field_value(*args)
+    end
+    deprecation_deprecate render_index_field_value: 'replaced by #field_value'
+
+    # @deprecated
+    def get_field_values(field_config, options={})
+      field_values(field_config, options)
+    end
+    deprecation_deprecate get_field_values: "replaced by #field_value"
+
+    # @deprecated
+    def render_field_values(values, field_config = Configuration::NullField.new)
+      field_values(field_config, value: Array(values))
+    end
+    deprecation_deprecate render_field_values: "replaced by #field_value"
+
+    # @deprecated
+    def render_values(values, field_config = Configuration::NullField.new)
+      field_values(field_config, value: Array(values))
+    end
+    deprecation_deprecate render_values: "replaced by #field_value"
 
     private
 

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -45,6 +45,12 @@ module Blacklight
       end
     end
 
+    # @deprecated
+    def document_show_html_title
+      html_title
+    end
+    deprecation_deprecate document_show_html_title: "use #html_title"
+
     ##
     # Get the value of the document's "title" field, or a placeholder
     # value (if empty)
@@ -75,6 +81,30 @@ module Blacklight
     def field_value field, options={}
       field_values(field_config(field), options)
     end
+
+    # @deprecated
+    def render_document_show_field_value(*args)
+      field_value(*args)
+    end
+    deprecation_deprecate render_document_show_field_value: 'replaced by #field_value'
+
+    # @deprecated
+    def get_field_values(field_config, options={})
+      field_values(field_config, options)
+    end
+    deprecation_deprecate get_field_values: "replaced by #field_value"
+
+    # @deprecated
+    def render_field_values(values, field_config = Configuration::NullField.new)
+      field_values(field_config, value: Array(values))
+    end
+    deprecation_deprecate render_field_values: "replaced by #field_value"
+
+    # @deprecated
+    def render_values(values, field_config = Configuration::NullField.new)
+      field_values(field_config, value: Array(values))
+    end
+    deprecation_deprecate render_values: "replaced by #field_value"
 
     private
 

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -428,4 +428,12 @@ describe Blacklight::DocumentPresenter do
       end
     end
   end
+
+  describe '#render_values' do
+    it 'renders field values as a string' do
+      expect(subject.render_values('x')).to eq 'x'
+      expect(subject.render_values(['x', 'y'])).to eq 'x and y'
+      expect(subject.render_values(['x', 'y', 'z'])).to eq 'x, y, and z'
+    end
+  end
 end

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -143,5 +143,31 @@ describe Blacklight::IndexPresenter do
       end
     end
   end
+
+  describe 'deprecated methods' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
+    let(:field_config) { config.add_index_field 'qwerty' }
+
+    describe '#get_field_values' do
+      it 'renders values for the given field' do
+        expect(subject.get_field_values(field_config, value: ['x', 'y'])).to eq 'x and y'
+      end
+    end
+
+    describe '#render_field_values' do
+      it 'renders values for the given field' do
+        expect(subject.render_field_values('x')).to eq 'x'
+      end
+    end
+
+    describe '#render_values' do
+      it 'renders values for the given field' do
+        expect(subject.render_values(['x', 'y', 'z'])).to eq 'x, y, and z'
+      end
+    end
+  end
 end
 

--- a/spec/presenters/show_presenter_spec.rb
+++ b/spec/presenters/show_presenter_spec.rb
@@ -283,5 +283,31 @@ describe Blacklight::ShowPresenter do
       end
     end
   end
+
+  describe 'deprecated methods' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
+    let(:field_config) { config.add_index_field 'qwerty' }
+
+    describe '#get_field_values' do
+      it 'renders values for the given field' do
+        expect(subject.get_field_values(field_config, value: ['x', 'y'])).to eq 'x and y'
+      end
+    end
+
+    describe '#render_field_values' do
+      it 'renders values for the given field' do
+        expect(subject.render_field_values('x')).to eq 'x'
+      end
+    end
+
+    describe '#render_values' do
+      it 'renders values for the given field' do
+        expect(subject.render_values(['x', 'y', 'z'])).to eq 'x, y, and z'
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
This should fix more backwards compatibility breaks introduced in 6.3.