### PR TITLE
Check that Turbolinks is not undefined before checking support

### DIFF
--- a/app/assets/javascripts/blacklight/core.js
+++ b/app/assets/javascripts/blacklight/core.js
@@ -13,7 +13,7 @@ Blacklight = function() {
 
     listeners: function () {
       var listeners = [];
-      if (Turbolinks && Turbolinks.supported) {
+      if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
         // Turbolinks 5
         if (Turbolinks.BrowserAdapter) {
           listeners.push('turbolinks:load');


### PR DESCRIPTION
When Turbolinks is not being used, the variable will be undefined and you will get a `ReferenceError: Turbolinks is not defined`.

The fix is check that `Turbolinks` is not undefined, rather than checking its truthiness.