### PR TITLE
Deprecate render_(index|show)_field_value and use the presenter

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -160,11 +160,13 @@ module Blacklight::BlacklightHelperBehavior
   #   @param [String] field
   #   @param [Hash] opts
   #   @options opts [String] :value
-  # TODO: deprecate and use render_field_value
+  # @deprecated use IndexPresenter#field_value
   def render_index_field_value *args
     render_field_value(*args)
   end
+  deprecation_deprecate render_index_field_value: 'replaced by IndexPresenter#field_value'
 
+  # @deprecated use IndexPresenter#field_value
   def render_field_value(*args)
     options = args.extract_options!
     document = args.shift || options[:document]
@@ -172,6 +174,7 @@ module Blacklight::BlacklightHelperBehavior
     field = args.shift || options[:field]
     presenter(document).field_value field, options.except(:document, :field)
   end
+  deprecation_deprecate render_field_value: 'replaced by IndexPresenter#field_value'
 
   ##
   # Render the show field label for a document
@@ -218,10 +221,12 @@ module Blacklight::BlacklightHelperBehavior
   #   @param [String] field
   #   @param [Hash] opts
   #   @options opts [String] :value
-  # TODO: deprecate and use render_field_value
+  # @deprecated use ShowPresenter#field_value
   def render_document_show_field_value *args
     render_field_value(*args)
   end
+  deprecation_deprecate render_document_show_field_value: 'replaced by ShowPresenter#field_value'
+
 
   ##
   # Get the value of the document's "title" field, or a placeholder

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,10 +1,11 @@
+<% doc_presenter = index_presenter(document) %> 
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="document-metadata dl-horizontal dl-invert">
   
   <% index_fields(document).each do |field_name, field| -%>
     <% if should_render_index_field? document, field %>
 	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
-	    <dd class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_value document, field: field_name %></dd>
+	    <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
     <% end -%>
   <% end -%>
 

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,9 +1,10 @@
+<% doc_presenter = show_presenter(document) %>
 <%# default partial to display solr document fields in catalog show view -%>
 <dl class="dl-horizontal  dl-invert">
   <% document_show_fields(document).each do |field_name, field| -%>
     <% if should_render_show_field? document, field %>
 	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
-	    <dd class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_value document, field: field_name %></dd>
+	    <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
     <% end -%>
   <% end -%>
 </dl>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -165,6 +165,7 @@ describe BlacklightHelper do
   describe "#render_index_field_value" do
     let(:presenter) { double }
     before do
+      allow(Deprecation).to receive(:warn)
       allow(helper).to receive(:presenter).with(doc).and_return(presenter)
     end
 
@@ -191,6 +192,7 @@ describe BlacklightHelper do
     let(:presenter) { double }
     before do
       allow(helper).to receive(:presenter).with(doc).and_return(presenter)
+      allow(Deprecation).to receive(:warn)
     end
 
     let(:doc) { double }


### PR DESCRIPTION
I know this introduces a bunch of deprecation warnings in the tests which I intend to take care of.