### PR TITLE
Update solr5 generator solr_wrapper require.

### DIFF
--- a/lib/generators/blacklight/solr5_generator.rb
+++ b/lib/generators/blacklight/solr5_generator.rb
@@ -13,7 +13,7 @@ module Blacklight
         gem 'solr_wrapper', '>= 0.3'
       end
 
-      append_to_file "Rakefile", "\nrequire 'solr_wrapper/rake_task'\n"
+      append_to_file "Rakefile", "\nrequire 'solr_wrapper/rake_task unless Rails.env.production?'\n"
     end
 
     def add_rsolr_gem


### PR DESCRIPTION
Avoid requiring solr_wrapper in production environment as the gem will not be installed.