### PR TITLE
provide more specific class selectors for width of typeahead inputs

### DIFF
--- a/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
+++ b/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
@@ -2,12 +2,12 @@
   float: left;
   width: 100%;
   z-index: 10000;
-  
-  .tt-input.form-control {
+
+  input.tt-input.form-control {
     width: 100%;
   }
-  
-  .tt-hint.form-control {
+
+  input.tt-hint.form-control {
     width: 100%;
   }
 


### PR DESCRIPTION
In some cases, `.tt-input.form-control` is not a specific enough selector, as `.navbar-form .input-group .form-control` will be more specific and override the width setting. This happens in GeoBlacklight as reported in https://github.com/geoblacklight/geoblacklight/issues/437 . 

This PR provides a [more specific selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) that solves the problem.

While normally I would not advocate for qualifying class selectors with an element, I would argue in this case it is ok since the element will always be `input`.
![screen shot 2016-07-27 at 3 48 15 pm](https://cloud.githubusercontent.com/assets/1656824/17195342/efb5c542-5411-11e6-94e7-64ca1623c67c.png)
![screen shot 2016-07-27 at 3 48 37 pm](https://cloud.githubusercontent.com/assets/1656824/17195339/efb2f038-5411-11e6-9c15-f48d1039dea3.png)
![screen shot 2016-07-27 at 3 48 46 pm](https://cloud.githubusercontent.com/assets/1656824/17195340/efb414ae-5411-11e6-87fc-1d9b1f66fee3.png)
