### PR TITLE
Remove HTML5 shim for older IE versions; hosted file is now missing

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -23,12 +23,6 @@
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
-
-    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-
   </head>
   <body class="<%= render_body_class %>">
   <%= render :partial => 'shared/header_navbar' %>


### PR DESCRIPTION
With the googlecode shutdown many months ago, this file is now missing. There are alternative sources for it, but we can leave that to downstream applications to add.