### PR TITLE
Makes the .twitter-typeahead index smaller

### DIFF
--- a/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
+++ b/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
@@ -1,7 +1,7 @@
 .twitter-typeahead {
   float: left;
   width: 100%;
-  z-index: 10000;
+  z-index: 500;
 
   input.tt-input.form-control {
     width: 100%;


### PR DESCRIPTION
In some cases this can conflict with the Bootstrap
modal z-index (1050). Drop it under 1050 to alleviate
these interactions.