### PR TITLE
Feed link tag helpers should accept a route_set

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 module Blacklight::CatalogHelperBehavior
 
-  def rss_feed_link_tag
-    auto_discovery_link_tag(:rss, feed_link_url('rss'), title: t('blacklight.search.rss_feed'))
+  # @param [Hash] options 
+  # @option options :route_set the route scope to use when constructing the link
+  def rss_feed_link_tag(options = {})
+    auto_discovery_link_tag(:rss, feed_link_url('rss', options), title: t('blacklight.search.rss_feed'))
   end
 
-  def atom_feed_link_tag
-    auto_discovery_link_tag(:atom, feed_link_url('atom'), title: t('blacklight.search.atom_feed'))
+  # @param [Hash] options 
+  # @option options :route_set the route scope to use when constructing the link
+  def atom_feed_link_tag(options = {})
+    auto_discovery_link_tag(:atom, feed_link_url('atom', options), title: t('blacklight.search.atom_feed'))
   end
 
   ##
@@ -285,7 +289,11 @@ module Blacklight::CatalogHelperBehavior
 
   private
 
-    def feed_link_url(format)
-      url_for search_state.to_h.merge(format: format)
+    # @param [String] format 
+    # @param [Hash] options 
+    # @option options :route_set the route scope to use when constructing the link
+    def feed_link_url(format, options = {})
+      scope = options.delete(:route_set) || self
+      scope.url_for search_state.to_h.merge(format: format)
     end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -129,6 +129,42 @@ describe CatalogHelper do
     end
   end
 
+  describe "rss_feed_link_tag" do
+    context "when an alternate scope is passed in" do
+      let(:my_engine) { double("Engine") }
+      let(:query_params) { { controller: 'catalog', action: 'index' } }
+      let(:config) { Blacklight::Configuration.new }
+      let(:search_state) { Blacklight::SearchState.new(query_params, config) }
+
+      it "calls url_for on the engine scope" do
+        allow(helper).to receive(:search_state).and_return search_state
+        expect(my_engine).to receive(:url_for).and_return(url_for(query_params))
+        tag = helper.rss_feed_link_tag(route_set: my_engine)
+        expect(tag).to match /title="RSS for results"/
+        expect(tag).to match /rel="alternate"/
+        expect(tag).to match %r{type="application/rss\+xml"}
+      end
+    end
+  end
+
+  describe "atom_feed_link_tag" do
+    context "when an alternate scope is passed in" do
+      let(:my_engine) { double("Engine") }
+      let(:query_params) { { controller: 'catalog', action: 'index' } }
+      let(:config) { Blacklight::Configuration.new }
+      let(:search_state) { Blacklight::SearchState.new(query_params, config) }
+
+      it "calls url_for on the engine scope" do
+        allow(helper).to receive(:search_state).and_return search_state
+        expect(my_engine).to receive(:url_for).and_return(url_for(query_params))
+        tag = helper.atom_feed_link_tag(route_set: my_engine)
+        expect(tag).to match /title="Atom for results"/
+        expect(tag).to match /rel="alternate"/
+        expect(tag).to match %r{type="application/atom\+xml"}
+      end
+    end
+  end
+
   describe "should_autofocus_on_search_box?" do
     it "is focused if we're on a catalog-like index page without query or facet parameters" do
       allow(helper).to receive_messages(controller: CatalogController.new, action_name: "index", has_search_parameters?: false)


### PR DESCRIPTION
For use in Rails engine gems.