### PR TITLE
Don't freeze string literals

### DIFF
--- a/template.demo.rb
+++ b/template.demo.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 gem "blacklight", ">= 6.1"
 gem "jettywrapper", ">= 2.0"
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]


### PR DESCRIPTION
Work around for https://github.com/rails/rails/issues/23137 which occurs on Ruby 2.3. and Rails 4.2. Fixes #1459