### PR TITLE
Use zindex-dropdown from bootstrap for typeahead widget

### DIFF
--- a/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
+++ b/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
@@ -1,7 +1,7 @@
 .twitter-typeahead {
   float: left;
   width: 100%;
-  z-index: 500;
+  z-index: $zindex-typeahead;
 
   input.tt-input.form-control {
     width: 100%;

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -4,3 +4,4 @@ $logo_image: 'blacklight/logo.png' !default;
 
 /* label (field names) */
 $field_name_color: $text-muted !default;
+$zindex-typeahead: $zindex-dropdown;


### PR DESCRIPTION
`500` doesn't play well with the cropping library we're using in spotlight. Using bootstrap's `zindex-dropdown` (1000, as of bootstrap 3.x) and adding our own intermediate variable should make this easier to configure as needed.