### PR TITLE
Better getter setter

### DIFF
--- a/spec/models/blacklight/search_builder_spec.rb
+++ b/spec/models/blacklight/search_builder_spec.rb
@@ -239,19 +239,21 @@ describe Blacklight::SearchBuilder do
     end
 
     it "is marked as changed when pagination changes" do
+      expect(subject).to receive(:page=).with(1).and_call_original
       subject.page(1)
       expect(subject.send(:params_changed?)).to eq true
     end
 
     it "is marked as changed when rows changes" do
+      expect(subject).to receive(:rows=).with(1).and_call_original
       subject.rows(1)
       expect(subject.send(:params_changed?)).to eq true
     end
 
     it "is marked as changed when start offset changes" do
+      expect(subject).to receive(:start=).with(1).and_call_original
       subject.start(1)
       expect(subject.send(:params_changed?)).to eq true
     end
-
   end
 end


### PR DESCRIPTION
Fixes #1462

If we wanted to drop/limit the builder pattern we would insert
deprecation warnings in those methods to be converted to pure getters.
If we want to keep the builder pattern, then we let it ride with the new explicit setters.

Updated calls where the returned `self` wasn't being used and the basic setter pattern is more idiomatic.

Added tests to make sure builder-style w/ arg calls underlying setter method.