### PR TITLE
Rake task for solr_wrapper commands exposed to bl-based apps

### DIFF
--- a/lib/railties/blacklight.rake
+++ b/lib/railties/blacklight.rake
@@ -118,4 +118,15 @@ namespace :blacklight do
       exit 1 if errors > 0
     end
   end
+
+  namespace :solr do
+    desc "Start solr with default configurations"
+    task :start, [:persist?] => [:environment]  do |_, args|
+      args[:persist?] ||= false
+      shell_cmd = "solr_wrapper -d #{File.join(Blacklight.root, 'solr', 'conf')} --collection_name blacklight-core"
+      shell_cmd << ' --persist' if args[:persist?]
+      sh shell_cmd
+    end
+  end
 end
+


### PR DESCRIPTION
Allows a blacklight specific solr instance to be spun up with `rake blacklight:solr:start` to make it easier to get started developing a blacklight based app.

Runs the `solr_wrapper` shell command  but passes in options to use the default blacklight solr conf and a collection named blacklight-core.

Provides an option to persist the data.

If merged, I'll update the [Quickstart](https://github.com/projectblacklight/blacklight/wiki/Quickstart) to use this command.
