### PR TITLE
remove dependency in SearchState

### DIFF
--- a/app/controllers/concerns/blacklight/facet.rb
+++ b/app/controllers/concerns/blacklight/facet.rb
@@ -4,6 +4,9 @@ module Blacklight
   # They are only dependent on `blacklight_config` and `@response`
   #
   module Facet
+
+    delegate :facet_configuration_for_field, to: :blacklight_config
+
     def facet_paginator(field_config, display_facet)
       blacklight_config.facet_paginator_class.new(
         display_facet.items,
@@ -20,17 +23,6 @@ module Blacklight
 
     def facet_field_names
       blacklight_config.facet_fields.values.map(&:field)
-    end
-
-    # @param [String] field Solr facet name
-    # @return [Blacklight::Configuration::FacetField] Blacklight facet configuration for the solr field
-    def facet_configuration_for_field(field)
-      # short-circuit on the common case, where the solr field name and the blacklight field name are the same.
-      return blacklight_config.facet_fields[field] if blacklight_config.facet_fields[field] && blacklight_config.facet_fields[field].field == field
-
-      # Find the facet field configuration for the solr field, or provide a default.
-      blacklight_config.facet_fields.values.find { |v| v.field.to_s == field.to_s } ||
-        Blacklight::Configuration::FacetField.new(field: field).normalize!
     end
 
     # Get a FacetField object from the @response

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -261,6 +261,17 @@ module Blacklight
       document_model.unique_key || 'id'
     end
 
+    # @param [String] field Solr facet name
+    # @return [Blacklight::Configuration::FacetField] Blacklight facet configuration for the solr field
+    def facet_configuration_for_field(field)
+      # short-circuit on the common case, where the solr field name and the blacklight field name are the same.
+      return facet_fields[field] if facet_fields[field] && facet_fields[field].field == field
+
+      # Find the facet field configuration for the solr field, or provide a default.
+      facet_fields.values.find { |v| v.field.to_s == field.to_s } ||
+        FacetField.new(field: field).normalize!
+    end
+
     # Add any configured facet fields to the default solr parameters hash
     # @overload add_facet_fields_to_solr_request!
     #    add all facet fields to the solr request

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -3,9 +3,11 @@ module Blacklight
   # This class encapsulates the search state as represented by the query
   # parameters namely: :f, :q, :page, :per_page and, :sort
   class SearchState
-    include Blacklight::Facet
+
     attr_reader :blacklight_config # Must be called blacklight_config, because Blacklight::Facet calls blacklight_config.
     attr_reader :params
+
+    delegate :facet_configuration_for_field, to: :blacklight_config
 
     # @param [ActionController::Parameters] params
     # @param [Blacklight::Config] blacklight_config


### PR DESCRIPTION
`Blacklight::Controller` conveniently allows you to override `#search_state` to provide your own subclass of `Blacklight::SearchState`. But when I try to create such a subclass, I get an 'uninitialized constant Blacklight::Facet' error, because that's a controller concern that hasn't been loaded yet.

This PR removes that dependency, making it possible to subclass SearchState.
