### PR TITLE
Remove unneeded #respond_to_missing? override

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,7 @@ Style/IndentationConsistency:
 
 Rails/OutputSafety:
   Enabled: false
+
+Style/MethodMissing:
+  Exclude:
+  - 'lib/blacklight/utils.rb'

--- a/lib/blacklight/utils.rb
+++ b/lib/blacklight/utils.rb
@@ -167,10 +167,6 @@ module Blacklight
         super
       end
     end
-    
-    def respond_to_missing?(*_)
-      true
-    end
 
     private
 


### PR DESCRIPTION
Also should be backported to a 6.x release.