### PR TITLE
Fix (and deprecate) regression from removing SolrDocument#to_hash casting

### DIFF
--- a/app/models/concerns/blacklight/document.rb
+++ b/app/models/concerns/blacklight/document.rb
@@ -44,7 +44,12 @@ module Blacklight::Document
   delegate :[], :key?, :keys, :to_h, to: :_source
 
   def initialize(source_doc={}, response=nil)
-    @_source = ActiveSupport::HashWithIndifferentAccess.new(source_doc)
+    @_source = if source_doc.respond_to?(:to_hash)
+                 ActiveSupport::HashWithIndifferentAccess.new(source_doc)
+               else
+                 Deprecation.warn(Blacklight::Document, "Blacklight::Document#initialize expects a hash-like object, received #{source_doc.class}.")
+                 ActiveSupport::HashWithIndifferentAccess.new(source_doc.to_h)
+               end
     @response = response
     apply_extensions
   end

--- a/spec/models/blacklight/document_spec.rb
+++ b/spec/models/blacklight/document_spec.rb
@@ -2,10 +2,23 @@
 
 describe Blacklight::Document do
   let(:data) { {} }
-  subject do
+  let(:test_class) do
     Class.new do
       include Blacklight::Document
-    end.new(data)
+    end
+  end
+
+  subject { test_class.new(data) }
+
+  describe '.new' do
+    it 'accepts a hash' do
+      expect(test_class.new(id: 1)[:id]).to eq 1
+    end
+
+    it 'accepts a SolrDocument' do
+      expect(Deprecation).to receive(:warn)
+      expect(test_class.new(test_class.new(id: 1))[:id]).to eq 1
+    end
   end
 
   describe "#has?" do


### PR DESCRIPTION
Fixes #1534