### PR TITLE
Right-align the per-page menu

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -4,7 +4,7 @@
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
     <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu" role="menu">
+  <ul class="dropdown-menu dropdown-menu-right" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>
       <li class="dropdown-item"><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
     <%- end -%>


### PR DESCRIPTION
Before:

<img width="415" alt="screen shot 2016-10-10 at 11 13 49" src="https://cloud.githubusercontent.com/assets/111218/19246324/a455b7c0-8eda-11e6-9720-4bc49893af08.png">

After:

<img width="378" alt="screen shot 2016-10-10 at 11 13 12" src="https://cloud.githubusercontent.com/assets/111218/19246328/a9789ccc-8eda-11e6-9bae-baa0d53a9914.png">
