### PR TITLE
Require dependency

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,7 +46,7 @@ Metrics/BlockNesting:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 184
+  Max: 200
 
 # Offense count: 20
 Metrics/CyclomaticComplexity:

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -4,20 +4,19 @@ module Blacklight
   # Blacklight::Configuration holds the configuration for a Blacklight::Controller, including
   # fields to display, facets to show, sort options, and search fields.
   class Configuration < OpenStructWithHashAccess
-    # Using required_dependency to work around Rails autoloading
-    # problems when developing blacklight. Without this, any change
-    # to this class breaks other classes in this namespace
+    extend ActiveSupport::Autoload
+    eager_autoload do
+      autoload :Context
+      autoload :ViewConfig
+      autoload :ToolConfig
+      autoload :Fields
+      autoload :Field
+      autoload :NullField
+      autoload :SearchField
+      autoload :FacetField
+      autoload :SortField
+    end
 
-    require_dependency 'blacklight/configuration/context'
-    require_dependency 'blacklight/configuration/view_config'
-    require_dependency 'blacklight/configuration/tool_config'
-    # XXX this isn't very pretty, but it works.
-    require_dependency 'blacklight/configuration/fields'
-    require_dependency 'blacklight/configuration/field'
-    require_dependency 'blacklight/configuration/null_field'
-    require_dependency 'blacklight/configuration/search_field'
-    require_dependency 'blacklight/configuration/facet_field'
-    require_dependency 'blacklight/configuration/sort_field'
     include Fields
 
     # Set up Blacklight::Configuration.default_values to contain

--- a/lib/blacklight/solr/response.rb
+++ b/lib/blacklight/solr/response.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
-  # Using required_dependency to work around Rails autoloading
-  # problems when developing blacklight. Without this, any change
-  # to this class breaks other classes in this namespace
-  require_dependency 'blacklight/solr/response/pagination_methods'
-  require_dependency 'blacklight/solr/response/response'
-  require_dependency 'blacklight/solr/response/spelling'
-  require_dependency 'blacklight/solr/response/facets'
-  require_dependency 'blacklight/solr/response/more_like_this'
-  require_dependency 'blacklight/solr/response/group_response'
-  require_dependency 'blacklight/solr/response/group'
+  extend ActiveSupport::Autoload
+  eager_autoload do
+    autoload :PaginationMethods
+    autoload :Response
+    autoload :Spelling
+    autoload :Facets
+    autoload :MoreLikeThis
+    autoload :GroupResponse
+    autoload :Group
+  end
 
   include PaginationMethods
   include Spelling


### PR DESCRIPTION
Effectively reverts #e804769eea4c4e297ad10ccbff18762311b64d66

Since that revision, Configuration moved out of `app` and into `lib`.
It didn’t autoload all the `Blacklight::Configuration::*` classes that existed at the time
(added **Context** here), but using conventional  `autoload` I can add methods, logger
lines, etc. to Configuration, and add methods, optional params in
Context… then reload pages/navigate without seeing anything break.  Logger lines go active, and
Rails magically reloads changes as expected.