### PR TITLE
Specify Blacklight logger for logging

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -298,11 +298,11 @@ module Blacklight::Catalog
       # If there are errors coming from the index page, we want to trap those sensibly
 
       if flash[:notice] == flash_notice
-        logger.error "Cowardly aborting rsolr_request_error exception handling, because we redirected to a page that raises another exception"
+        Blacklight.logger.error "Cowardly aborting rsolr_request_error exception handling, because we redirected to a page that raises another exception"
         raise exception
       end
 
-      logger.error exception
+      Blacklight.logger.error exception
 
       flash[:notice] = flash_notice
       redirect_to search_action_url

--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -104,6 +104,6 @@ module Blacklight::SearchContext
       @next_document = documents.last
     end
   rescue Blacklight::Exceptions::InvalidRequest => e
-    logger.warn "Unable to setup next and previous documents: #{e}"
+    Blacklight.logger.warn "Unable to setup next and previous documents: #{e}"
   end
 end

--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -175,7 +175,7 @@ module Blacklight::RenderPartialsHelperBehavior
     def find_document_show_template_with_view view_type, base_name, format, locals
       document_partial_path_templates.each do |str|
         partial = str % { action_name: base_name, format: format, index_view_type: view_type }
-        logger.debug "Looking for document partial #{partial}"
+        Blacklight.logger.debug "Looking for document partial #{partial}"
         template = lookup_context.find_all(partial, lookup_context.prefixes + [""], true, locals.keys + [:document], {}).first
         return template if template
       end
@@ -185,7 +185,7 @@ module Blacklight::RenderPartialsHelperBehavior
     def find_document_index_template_with_view view, locals
       document_index_path_templates.each do |str|
         partial = str % { index_view_type: view }
-        logger.debug "Looking for document index partial #{partial}"
+        Blacklight.logger.debug "Looking for document index partial #{partial}"
         template = lookup_context.find_all(partial, lookup_context.prefixes + [""], true, locals.keys + [:documents], {}).first
         return template if template
       end

--- a/lib/blacklight/solr/response.rb
+++ b/lib/blacklight/solr/response.rb
@@ -91,7 +91,7 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
         value.each { |v| force_to_utf8(v) }
       when String
         if value.encoding != Encoding::UTF_8
-          Rails.logger.warn "Found a non utf-8 value in Blacklight::Solr::Response. \"#{value}\" Encoding is #{value.encoding}"
+          Blacklight.logger.warn "Found a non utf-8 value in Blacklight::Solr::Response. \"#{value}\" Encoding is #{value.encoding}"
           value.dup.force_encoding('UTF-8')
         else
           value


### PR DESCRIPTION
When the action_view logger is disabled, Blacklight throws an error because the logger is set to nil.
(Anyone else try to suppress the dozens of "Rendered /blacklight-6.7.2/app/views/catalog/_bookmark_control.html.erb (0.6ms)" statements in the logs per request?)
