### PR TITLE
Pin rubocop-rspec to 1.8

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coveralls"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "rubocop"
-  s.add_development_dependency "rubocop-rspec"
+  s.add_development_dependency "rubocop-rspec", '~> 1.8.0'
 end


### PR DESCRIPTION
Because newer cops break our test suite