### PR TITLE
LinkAlternatePresenter uses url_for_document to construct links

### DIFF
--- a/app/presenters/blacklight/link_alternate_presenter.rb
+++ b/app/presenters/blacklight/link_alternate_presenter.rb
@@ -4,13 +4,13 @@ module Blacklight
     include ActionView::Helpers::OutputSafetyHelper
     include ActionView::Helpers::TagHelper
 
-    def initialize(controller, document, options)
-      @controller = controller
+    def initialize(view_context, document, options)
+      @view_context = view_context
       @document = document
       @options = { unique: false, exclude: [] }.merge(options)
     end
 
-    attr_reader :controller, :document, :options
+    attr_reader :view_context, :document, :options
 
     # Renders links to alternate representations
     # provided by export formats. Returns empty string if no links available.
@@ -22,8 +22,12 @@ module Blacklight
 
         seen.add(spec[:content_type])
 
-        tag(:link, rel: "alternate", title: format, type: spec[:content_type], href: controller.polymorphic_url(document, format: format))
+        tag(:link, rel: "alternate", title: format, type: spec[:content_type], href: href(format))
       end.compact, "\n")
+    end
+
+    def href(format)
+      view_context.polymorphic_url(view_context.search_state.url_for_document(document), format: format)
     end
   end
 end

--- a/spec/helpers/blacklight/facets_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/facets_helper_behavior_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'equivalent-xml'
-
 describe Blacklight::FacetsHelperBehavior do
   let(:blacklight_config) { Blacklight::Configuration.new }
 

--- a/spec/presenters/blacklight/link_alternate_presenter_spec.rb
+++ b/spec/presenters/blacklight/link_alternate_presenter_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Blacklight::LinkAlternatePresenter do
+  let(:view_context) { double }
+  let(:document) { SolrDocument.new(id: 9999) }
+  let(:options) { {} }
+  let(:config) { Blacklight::Configuration.new }
+  let(:parameter_class) { ActionController::Parameters }
+  let(:params) { parameter_class.new }
+  let(:search_state) { Blacklight::SearchState.new(params, config) }
+
+  let(:presenter) { described_class.new(view_context, document, options) }
+  before do
+    allow(view_context).to receive(:search_state).and_return(search_state)
+    allow(view_context).to receive(:polymorphic_url) do |doc, opts|
+      "http://test.host/catalog/#{doc.to_param}.#{opts[:format]}"
+    end
+  end
+
+  describe "#render" do
+    subject { presenter.render }
+    let(:expected_html) do
+      '<link rel="alternate" title="xml" type="application/xml" href="http://test.host/catalog/9999.xml" />' \
+      '<link rel="alternate" title="dc_xml" type="text/xml" href="http://test.host/catalog/9999.dc_xml" />' \
+      '<link rel="alternate" title="oai_dc_xml" type="text/xml" href="http://test.host/catalog/9999.oai_dc_xml" />'
+    end
+    it { is_expected.to be_equivalent_to expected_html }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require 'rspec/its'
 require 'rspec/collection_matchers'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
+require 'equivalent-xml'
 
 Capybara.javascript_driver = :poltergeist
 


### PR DESCRIPTION
Fixes #1603