### PR TITLE
Consistently differentiate between the user-facet facet key and the solr field name

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -71,7 +71,7 @@ module Blacklight::Catalog
     def facet
       @facet = blacklight_config.facet_fields[params[:id]]
       @response = search_service.facet_field_response(@facet.key)
-      @display_facet = @response.aggregations[@facet.key]
+      @display_facet = @response.aggregations[@facet.field]
       @pagination = facet_paginator(@facet, @display_facet)
       respond_to do |format|
         # Draw the facet selector for users who have javascript disabled:
@@ -117,7 +117,7 @@ module Blacklight::Catalog
 
     # Look up facet limit for given facet_field. Will look at config, and
     # if config is 'true' will look up from Solr @response if available. If
-    # no limit is avaialble, returns nil. Used from #add_facetting_to_solr
+    # no limit is available, returns nil. Used from #add_facetting_to_solr
     # to supply f.fieldname.facet.limit values in solr request (no @response
     # available), and used in display (with @response available) to create
     # a facet paginator with the right limit.
@@ -125,8 +125,8 @@ module Blacklight::Catalog
       facet = blacklight_config.facet_fields[facet_field]
       return if facet.blank?
 
-      if facet.limit && @response && @response.aggregations[facet_field]
-        limit = @response.aggregations[facet_field].limit
+      if facet.limit && @response && @response.aggregations[facet.field]
+        limit = @response.aggregations[facet.field].limit
 
         if limit.nil? # we didn't get or a set a limit, so infer one.
           facet.limit if facet.limit != true

--- a/app/controllers/concerns/blacklight/facet.rb
+++ b/app/controllers/concerns/blacklight/facet.rb
@@ -6,12 +6,12 @@ module Blacklight
   module Facet
     delegate :facet_configuration_for_field, to: :blacklight_config
 
-    def facet_paginator(field_config, display_facet)
+    def facet_paginator(field_config, response_data)
       blacklight_config.facet_paginator_class.new(
-        display_facet.items,
-        sort: display_facet.sort,
-        offset: display_facet.offset,
-        prefix: display_facet.prefix,
+        response_data.items,
+        sort: response_data.sort,
+        offset: response_data.offset,
+        prefix: response_data.prefix,
         limit: facet_limit_for(field_config.key)
       )
     end

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -89,7 +89,7 @@ module Blacklight::FacetsHelperBehavior
   # @param [Blacklight::Configuration::FacetField] facet_field
   # @return [Boolean]
   def should_collapse_facet? facet_field
-    !facet_field_in_params?(facet_field.field) && facet_field.collapse
+    !facet_field_in_params?(facet_field.key) && facet_field.collapse
   end
 
   ##

--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,11 +1,11 @@
 <ul class="facet-values list-unstyled">
   <% paginator = facet_paginator(facet_field, display_facet) %>
-  <%= render_facet_limit_list paginator, field_name %>
+  <%= render_facet_limit_list paginator, facet_field.key %>
 
   <% unless paginator.last_page? || params[:action] == "facet" %>
     <li class="more_facets">
       <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field.label), 
-        search_facet_path(id: field_name),
+        search_facet_path(id: facet_field.key),
         data: { blacklight_modal: 'trigger' } %>
     </li>
   <% end %>

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -182,7 +182,7 @@ module Blacklight::Solr
 
       # Now override with our specific things for fetching facet values
       facet_ex = facet_config.respond_to?(:ex) ? facet_config.ex : nil
-      solr_params[:"facet.field"] = with_ex_local_param(facet_ex, facet)
+      solr_params[:"facet.field"] = with_ex_local_param(facet_ex, facet_config.field)
 
       limit = if scope.respond_to?(:facet_list_limit)
                 scope.facet_list_limit.to_s.to_i
@@ -200,13 +200,13 @@ module Blacklight::Solr
 
       # Need to set as f.facet_field.facet.* to make sure we
       # override any field-specific default in the solr request handler.
-      solr_params[:"f.#{facet}.facet.limit"] = limit + 1
-      solr_params[:"f.#{facet}.facet.offset"] = offset
+      solr_params[:"f.#{facet_config.field}.facet.limit"] = limit + 1
+      solr_params[:"f.#{facet_config.field}.facet.offset"] = offset
       if blacklight_params[request_keys[:sort]]
-        solr_params[:"f.#{facet}.facet.sort"] = sort
+        solr_params[:"f.#{facet_config.field}.facet.sort"] = sort
       end
       if blacklight_params[request_keys[:prefix]]
-        solr_params[:"f.#{facet}.facet.prefix"] = prefix
+        solr_params[:"f.#{facet_config.field}.facet.prefix"] = prefix
       end
       solr_params[:rows] = 0
     end

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -133,6 +133,21 @@ describe Blacklight::Solr::SearchBuilderBehavior do
       end
     end
 
+    context "facet parameters" do
+      let(:blacklight_config) do
+        Blacklight::Configuration.new.tap do |config|
+          config.add_facet_field key: 'param_key', field: 'solr_field', limit: 50, ex: 'other'
+
+          config.add_facet_fields_to_solr_request!
+        end
+      end
+
+      it "should use the configured solr field name in queries" do
+        expect(subject).to include 'f.solr_field.facet.limit': 51,
+                                   'facet.field': ['{!ex=other}solr_field']
+      end
+    end
+
     describe 'for an entirely empty search' do
 
       it 'should not have a q param' do
@@ -584,6 +599,28 @@ describe Blacklight::Solr::SearchBuilderBehavior do
         expect(solr_parameters[:"f.#{facet_field}.facet.limit"]).to eq 51
       end
     end
+
+    context 'for a field with a param key different from the field name' do
+      let(:user_params) { { page_key => 2, 'facet.sort': 'index', 'facet.prefix': 'x' } }
+      let(:facet_field) { 'param_key' }
+
+      let(:blacklight_config) do
+        Blacklight::Configuration.new.tap do |config|
+          config.add_facet_field key: 'param_key', field: 'solr_field', more_limit: 50, ex: 'other'
+
+          config.add_facet_fields_to_solr_request!
+        end
+      end
+
+      it "should use the configured solr field name in queries" do
+        expect(solr_parameters).to include 'f.solr_field.facet.limit': 51,
+                                           'f.solr_field.facet.offset': 50,
+                                           'f.solr_field.facet.sort': 'index',
+                                           'f.solr_field.facet.prefix': 'x',
+                                           'facet.field': '{!ex=other}solr_field'
+      end
+    end
+
 
     it 'defaults limit to 20' do
       expect(solr_parameters[:"f.#{facet_field}.facet.limit"]).to eq 21


### PR DESCRIPTION
Fixes https://github.com/projectblacklight/spotlight/pull/1762