### PR TITLE
Add nav-link class to saved searchs link in shared navbar.

### DIFF
--- a/app/views/blacklight/nav/_saved_searches.html.erb
+++ b/app/views/blacklight/nav/_saved_searches.html.erb
@@ -1,1 +1,1 @@
-<%= link_to t('blacklight.header_links.saved_searches'), blacklight.saved_searches_path %>
+<%= link_to t('blacklight.header_links.saved_searches'), blacklight.saved_searches_path, class: 'nav-link' %>


### PR DESCRIPTION
Fixing this issue for logged in users:
![saved-searches-link](https://cloud.githubusercontent.com/assets/96776/25255664/a771b506-25e0-11e7-9059-d50448957027.png)
