### PR TITLE
Remove unused separator configuration option in pipeline spec.

### DIFF
--- a/spec/presenters/pipeline_spec.rb
+++ b/spec/presenters/pipeline_spec.rb
@@ -10,18 +10,18 @@ describe Blacklight::Rendering::Pipeline do
   describe "render" do
     subject { presenter.render }
     let(:values) { ['a', 'b'] }
-    let(:field_config) { Blacklight::Configuration::NullField.new } 
+    let(:field_config) { Blacklight::Configuration::NullField.new }
     it { is_expected.to eq "a and b" }
 
     context "when separator_options are in the config" do
       let(:values) { ['c', 'd'] }
-      let(:field_config) { Blacklight::Configuration::NullField.new(separator: nil, itemprop: nil, separator_options: { two_words_connector: '; '}) } 
+      let(:field_config) { Blacklight::Configuration::NullField.new(itemprop: nil, separator_options: { two_words_connector: '; '}) }
       it { is_expected.to eq "c; d" }
     end
 
     context "when itemprop is in the config" do
       let(:values) { ['a'] }
-      let(:field_config) { Blacklight::Configuration::NullField.new(separator: nil, itemprop: 'some-prop', separator_options: nil) } 
+      let(:field_config) { Blacklight::Configuration::NullField.new(itemprop: 'some-prop', separator_options: nil) }
       it { is_expected.to have_selector("span[@itemprop='some-prop']", :text => "a") }
     end
   end


### PR DESCRIPTION
 #to_sentence is now used which takes a separator_options key.
