### PR TITLE
Unpin the version of capybara

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.5"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
-  s.add_development_dependency "capybara", '~> 2.6.0'
+  s.add_development_dependency "capybara", '~> 2.6'
   s.add_development_dependency "poltergeist"
   s.add_development_dependency 'engine_cart', '~> 1.0'
   s.add_development_dependency "equivalent-xml"

--- a/spec/helpers/blacklight/hash_as_hidden_fields_behavior_spec.rb
+++ b/spec/helpers/blacklight/hash_as_hidden_fields_behavior_spec.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
 describe Blacklight::HashAsHiddenFieldsHelperBehavior do
-  before(:each) do
-    @hash = {:q => "query", :search_field => "search_field", :per_page=>10, :page=>5, :extra_arbitrary_key=>"arbitrary_value", :f=> {:field1 => ["a", "b"], :field2=> ["z"]}}
+  let(:params) do
+    { q: "query",
+      search_field: "search_field",
+      per_page: 10,
+      page: 5,
+      extra_arbitrary_key: "arbitrary_value",
+      f: { field1: %w(a b), field2: ["z"] } }
   end
+  let(:generated) { helper.render_hash_as_hidden_fields(params) }
 
   it "converts a hash with nested complex data to Rails-style hidden form fields" do
-
-    generated = helper.render_hash_as_hidden_fields(@hash)
-
-    expect(generated).to have_selector("input[type='hidden'][name='q'][value='query']")
-    expect(generated).to have_selector("input[type='hidden'][name='per_page'][value='10']")
-    expect(generated).to have_selector("input[type='hidden'][name='page'][value='5']")
-    expect(generated).to have_selector("input[type='hidden'][name='extra_arbitrary_key'][value='arbitrary_value']")
-    expect(generated).to have_selector("input[type='hidden'][name='f[field2][]'][value='z']")
-    expect(generated).to have_selector("input[type='hidden'][name='f[field1][]'][value='a']")
-    expect(generated).to have_selector("input[type='hidden'][name='f[field1][]'][value='b']")
-    
+    expect(generated).to have_selector("input[type='hidden'][name='q'][value='query']", visible: false)
+    expect(generated).to have_selector("input[type='hidden'][name='per_page'][value='10']", visible: false)
+    expect(generated).to have_selector("input[type='hidden'][name='page'][value='5']", visible: false)
+    expect(generated).to have_selector("input[type='hidden'][name='extra_arbitrary_key'][value='arbitrary_value']", visible: false)
+    expect(generated).to have_selector("input[type='hidden'][name='f[field2][]'][value='z']", visible: false)
+    expect(generated).to have_selector("input[type='hidden'][name='f[field1][]'][value='a']", visible: false)
+    expect(generated).to have_selector("input[type='hidden'][name='f[field1][]'][value='b']", visible: false)
   end
-
 end


### PR DESCRIPTION
This was originally set in
https://github.com/projectblacklight/blacklight/commit/0ddf30a0b01d6b850431d908ec9be07f6d91844e

but this blocks us from using Rails 5.1