### PR TITLE
Remove .card + .card bootstrap override that is no longer relevant.

### DIFF
--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -20,7 +20,3 @@
     }
   }
 }
-
-.card + .card {
-  margin-top: $card-spacer-y;
-}


### PR DESCRIPTION
There are no visible changes when removing this bootstrap override.