### PR TITLE
Move thumbnail generation to a presenter

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -197,9 +197,9 @@ module Blacklight::CatalogHelperBehavior
   # @param [SolrDocument] document
   # @return [Boolean]
   def has_thumbnail? document
-    blacklight_config.view_config(document_index_view_type).thumbnail_method.present? ||
-      blacklight_config.view_config(document_index_view_type).thumbnail_field && document.has?(blacklight_config.view_config(document_index_view_type).thumbnail_field)
+    index_presenter(document).thumbnail.exists?
   end
+  deprecation_deprecate has_thumbnail?: "use IndexPresenter#thumbnail.exists?"
 
   ##
   # Render the thumbnail, if available, for a document and
@@ -210,23 +210,9 @@ module Blacklight::CatalogHelperBehavior
   # @param [Hash] url_options to pass to #link_to_document
   # @return [String]
   def render_thumbnail_tag document, image_options = {}, url_options = {}
-    value = if blacklight_config.view_config(document_index_view_type).thumbnail_method
-              method_name = blacklight_config.view_config(document_index_view_type).thumbnail_method
-              send(method_name, document, image_options)
-            elsif blacklight_config.view_config(document_index_view_type).thumbnail_field
-              url = thumbnail_url(document)
-
-              image_tag url, image_options if url.present?
-            end
-
-    if value
-      if url_options == false || url_options[:suppress_link]
-        value
-      else
-        link_to_document document, value, url_options
-      end
-    end
+    index_presenter(document).thumbnail.thumbnail_tag(image_options, url_options)
   end
+  deprecation_deprecate render_thumbnail_tag: "Use IndexPresenter#thumbnail.thumbnail_tag"
 
   ##
   # Get the URL to a document's thumbnail image
@@ -238,6 +224,7 @@ module Blacklight::CatalogHelperBehavior
       document.first(blacklight_config.view_config(document_index_view_type).thumbnail_field)
     end
   end
+  deprecation_deprecate thumbnail_url: "this method will be removed without replacement"
 
   ##
   # Render the view type icon for the results view picker

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 module Blacklight
   class IndexPresenter
-    attr_reader :document, :configuration, :view_context
+    class_attribute :thumbnail_presenter
+    self.thumbnail_presenter = ThumbnailPresenter
+
+    attr_reader :document, :configuration, :view_context, :view_config
 
     # @param [SolrDocument] document
     # @param [ActionView::Base] view_context scope for linking and generating urls
@@ -10,6 +13,7 @@ module Blacklight
       @document = document
       @view_context = view_context
       @configuration = configuration
+      @view_config = configuration.view_config(view_context.document_index_view_type)
     end
 
     ##
@@ -45,6 +49,10 @@ module Blacklight
     def field_value field, options = {}
       field_config = field_config(field)
       field_values(field_config, options)
+    end
+
+    def thumbnail
+      @thumbnail ||= thumbnail_presenter.new(document, view_context, view_config)
     end
 
     private

--- a/app/presenters/blacklight/thumbnail_presenter.rb
+++ b/app/presenters/blacklight/thumbnail_presenter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class ThumbnailPresenter
+    attr_reader :document, :view_context, :view_config
+
+    # @param [SolrDocument] document
+    # @param [ActionView::Base] view_context scope for linking and generating urls
+    # @param [Blacklight::Configuration::ViewConfig] view_config
+    def initialize(document, view_context, view_config)
+      @document = document
+      @view_context = view_context
+      @view_config = view_config
+    end
+
+    ##
+    # Does the document have a thumbnail to render?
+    #
+    # @return [Boolean]
+    def exists?
+      thumbnail_method.present? || thumbnail_field && document.has?(thumbnail_field)
+    end
+
+    ##
+    # Render the thumbnail, if available, for a document and
+    # link it to the document record.
+    #
+    # @param [Hash] image_options to pass to the image tag
+    # @param [Hash] url_options to pass to #link_to_document
+    # @return [String]
+    # rubocop:disable Lint/AssignmentInCondition
+    def thumbnail_tag image_options = {}, url_options = {}
+      return unless value = thumbnail_value(image_options)
+      if url_options == false || url_options[:suppress_link]
+        value
+      else
+        view_context.link_to_document document, value, url_options
+      end
+    end
+    # rubocop:enable Lint/AssignmentInCondition
+
+    private
+
+    delegate :thumbnail_field, :thumbnail_method, to: :view_config
+
+    # @param [Hash] image_options to pass to the image tag
+    def thumbnail_value(image_options)
+      if thumbnail_method
+        view_context.send(thumbnail_method, document, image_options)
+      elsif thumbnail_field
+        url = document.first(thumbnail_field)
+        view_context.image_tag url, image_options if url.present?
+      end
+    end
+  end
+end

--- a/app/views/catalog/_thumbnail.html.erb
+++ b/app/views/catalog/_thumbnail.html.erb
@@ -1,5 +1,5 @@
-<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+<% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
 <div class="document-thumbnail">
   <%= tn %>
-</div>  
-<%- end %>
+</div>
+<% end %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -274,6 +274,7 @@ module Blacklight
     # Get a view configuration for the given view type
     # including default values from the index configuration
     # @param [Symbol,#to_sym] view_type
+    # @return [Blacklight::Configuration::ViewConfig]
     def view_config(view_type)
       view_type = view_type.to_sym unless view_type.is_a? Symbol
       index.merge(view_type == :show ? show : view.fetch(view_type, {}))

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe BlacklightHelper do
   describe "render_link_rel_alternates" do
     let(:document) { instance_double(SolrDocument) }
     let(:result) { double }
-    let(:presenter) { Blacklight::IndexPresenter.new(document, self) }
+    let(:view_context) { double(blacklight_config: blacklight_config, document_index_view_type: 'index') }
+    let(:presenter) { Blacklight::IndexPresenter.new(document, view_context) }
     let(:blacklight_config) do
       Blacklight::Configuration.new.configure do |config|
         config.index.title_field = 'title_display'

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -188,34 +188,44 @@ RSpec.describe CatalogHelper do
   end
 
   describe "has_thumbnail?" do
+    before do
+      expect(Deprecation).to receive(:warn)
+    end
+
     let(:document) { instance_double(SolrDocument) }
+
     it "has a thumbnail if a thumbnail_method is configured" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       expect(helper.has_thumbnail? document).to be true
     end
 
     it "has a thumbnail if a thumbnail_field is configured and it exists in the document" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       allow(document).to receive_messages(has?: true)
       expect(helper.has_thumbnail? document).to be true
     end
-    
+
     it "does not have a thumbnail if the thumbnail_field is missing from the document" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       allow(document).to receive_messages(has?: false)
       expect(helper.has_thumbnail? document).to be false
     end
 
     it "does not have a thumbnail if none of the fields are configured" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new() ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(document_presenter_class: Blacklight::IndexPresenter) ))
       expect(helper.has_thumbnail? document).to be_falsey
     end
   end
 
   describe "render_thumbnail_tag" do
+    before do
+      expect(Deprecation).to receive(:warn)
+    end
+
     let(:document) { instance_double(SolrDocument) }
+
     it "calls the provided thumbnail method" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       expect(helper).to receive_messages(:xyz => "some-thumbnail")
 
       allow(helper).to receive(:link_to_document).with(document, "some-thumbnail", {})
@@ -223,7 +233,7 @@ RSpec.describe CatalogHelper do
     end
 
     it "creates an image tag from the given field" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
 
       allow(document).to receive(:has?).with(:xyz).and_return(true)
       allow(document).to receive(:first).with(:xyz).and_return("http://example.com/some.jpg")
@@ -233,7 +243,7 @@ RSpec.describe CatalogHelper do
     end
 
     it "does not link to the document if the url options are false" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       allow(helper).to receive_messages(:xyz => "some-thumbnail")
 
       result = helper.render_thumbnail_tag document, {}, false
@@ -241,7 +251,7 @@ RSpec.describe CatalogHelper do
     end
 
     it "does not link to the document if the url options have :suppress_link" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       allow(helper).to receive_messages(:xyz => "some-thumbnail")
 
       result = helper.render_thumbnail_tag document, {}, suppress_link: true
@@ -250,27 +260,31 @@ RSpec.describe CatalogHelper do
 
 
     it "returns nil if no thumbnail is available" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new() ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(document_presenter_class: Blacklight::IndexPresenter) ))
       expect(helper.render_thumbnail_tag document).to be_nil
     end
 
     it "returns nil if no thumbnail is returned from the thumbnail method" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_method => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
       allow(helper).to receive_messages(:xyz => nil)
 
       expect(helper.render_thumbnail_tag document).to be_nil
     end
 
     it "returns nil if no thumbnail is in the document" do
-      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
+      allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz, document_presenter_class: Blacklight::IndexPresenter) ))
 
-      allow(document).to receive(:has?).with(:xyz).and_return(false)
+      allow(document).to receive(:first).with(:xyz).and_return(nil)
 
       expect(helper.render_thumbnail_tag document).to be_nil
     end
   end
 
   describe "thumbnail_url" do
+    before do
+      expect(Deprecation).to receive(:warn)
+    end
+    
     it "pulls the configured thumbnail field out of the document" do
       allow(helper).to receive_messages(:blacklight_config => Blacklight::Configuration.new(:index => Blacklight::OpenStructWithHashAccess.new(:thumbnail_field => :xyz) ))
       document = instance_double(SolrDocument)

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Blacklight::IndexPresenter do
   include Capybara::RSpecMatchers
-  let(:request_context) { double }
+  let(:request_context) { double(document_index_view_type: 'list') }
   let(:config) { Blacklight::Configuration.new }
 
   subject { presenter }
@@ -141,5 +141,9 @@ RSpec.describe Blacklight::IndexPresenter do
       end
     end
   end
-end
 
+  describe "#thumbnail" do
+    subject { presenter.thumbnail }
+    it { is_expected.to be_instance_of Blacklight::ThumbnailPresenter }
+  end
+end

--- a/spec/presenters/thumbnail_presenter_spec.rb
+++ b/spec/presenters/thumbnail_presenter_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::ThumbnailPresenter do
+  include Capybara::RSpecMatchers
+  let(:view_context) { double "View context" }
+  let(:config) { Blacklight::Configuration.new.view_config(:index) }
+  let(:presenter) { described_class.new(document, view_context, config) }
+  let(:document) { SolrDocument.new }
+
+  describe "#exists?" do
+    subject { presenter.exists? }
+
+    context "when thumbnail_method is configured" do
+      let(:config) do
+        Blacklight::OpenStructWithHashAccess.new(thumbnail_method: :xyz)
+      end
+      it { is_expected.to be true }
+    end
+
+    context "when thumbnail_field is configured" do
+      let(:config) do
+        Blacklight::OpenStructWithHashAccess.new(thumbnail_field: :xyz)
+      end
+
+      context "and the field exists in the document" do
+        let(:document) { SolrDocument.new('xyz' => 'image.png') }
+
+        it { is_expected.to be true }
+      end
+
+      context "and the field is missing from the document" do
+        it { is_expected.to be false }
+      end
+    end
+
+    context "without any configured options" do
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#thumbnail_tag" do
+    subject { presenter.thumbnail_tag }
+    context "when thumbnail_method is configured" do
+      let(:config) do
+        Blacklight::OpenStructWithHashAccess.new(thumbnail_method: :xyz)
+      end
+
+      context "and the method returns a value" do
+        before do
+          allow(view_context).to receive_messages(xyz: "some-thumbnail")
+        end
+
+        it "calls the provided thumbnail method" do
+          expect(view_context).to receive_messages(xyz: "some-thumbnail")
+          allow(view_context).to receive(:link_to_document).with(document, "some-thumbnail", {})
+            .and_return("link")
+          expect(subject).to eq "link"
+        end
+
+        context "and url options are false" do
+          subject { presenter.thumbnail_tag({}, false) }
+
+          it "does not link to the document" do
+            expect(subject).to eq "some-thumbnail"
+          end
+        end
+
+        context "and url options have :suppress_link" do
+          subject { presenter.thumbnail_tag({}, suppress_link: true) }
+
+          it "does not link to the document" do
+            expect(subject).to eq "some-thumbnail"
+          end
+        end
+      end
+
+      context "and no value is returned from the thumbnail method" do
+        before do
+          allow(view_context).to receive_messages(xyz: nil)
+        end
+        it { is_expected.to be nil }
+      end
+    end
+
+    context "when thumbnail_field is configured" do
+      let(:config) do
+        Blacklight::OpenStructWithHashAccess.new(thumbnail_field: :xyz)
+      end
+
+      it "creates an image tag from the given field" do
+        #allow(document).to receive(:has?).with(:xyz).and_return(true)
+        allow(document).to receive(:first).with(:xyz).and_return("http://example.com/some.jpg")
+        allow(view_context).to receive(:image_tag).with("http://example.com/some.jpg", {}).and_return('<img src="image.jpg">')
+        expect(view_context).to receive(:link_to_document).with(document, '<img src="image.jpg">', {})
+        subject
+      end
+
+      it "returns nil if no thumbnail is in the document" do
+        allow(document).to receive(:first).with(:xyz).and_return(nil)
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when no thumbnail is configured" do
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
 Presenters are an object oriented approach to organizing view helpers.
 Having objects allows us to encapsulate similar functionality which
 makes it easier to reason about how the methods interact with each
 other. Read more http://nithinbekal.com/posts/rails-presenters/