### PR TITLE
Add 'display_control' option to view configs to allow them to toggle …

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -134,6 +134,13 @@ module Blacklight::ConfigurationHelperBehavior
     end
   end
 
+  # filter #document_index_views to just views that should display in the view type control
+  def document_index_view_controls
+    document_index_views.select do |_k, config|
+      config.display_control.nil? || blacklight_configuration_context.evaluate_configuration_conditional(config.display_control)
+    end
+  end
+
   ##
   # Get the default index view type
   def default_document_index_view_type

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -2,7 +2,7 @@
 <div class="view-type">
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
-    <%  document_index_views.each do |view, config| %>
+    <% document_index_view_controls.each do |view, config| %>
       <%= link_to url_for(search_state.to_h.merge(view: view)), title: view_label(view), class: "btn btn-secondary view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
         <%= render_view_type_group_icon view %>
         <span class="caption"><%= view_label(view) %></span>

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
     end
   end
 
+  describe '#document_index_view_controls' do
+    before do
+      blacklight_config.view.a
+      blacklight_config.view.b.display_control = false
+    end
+
+    it "filters index views to those set to display controls" do
+      expect(helper.document_index_view_controls).to have_key :a
+      expect(helper.document_index_view_controls).not_to have_key :b
+    end
+  end
+
   describe "#has_alternative_views?" do
     before do
       blacklight_config.view.clear


### PR DESCRIPTION
…on/off visibility in the view type widget

(Turns out `display` is a reserved word for ruby objects? I'm still not exactly sure where that comes from.)