### PR TITLE
Improve the catalog JSON API by adopting JSON-API practices 

### DIFF
--- a/app/controllers/concerns/blacklight/controller.rb
+++ b/app/controllers/concerns/blacklight/controller.rb
@@ -80,7 +80,7 @@ module Blacklight::Controller
 
   def search_action_path *args
     if args.first.is_a? Hash
-      args.first[:only_path] = true
+      args.first[:only_path] = true if args.first[:only_path].nil?
     end
 
     search_action_url(*args)
@@ -94,7 +94,7 @@ module Blacklight::Controller
 
   def search_facet_path(options = {})
     Deprecation.silence(Blacklight::Controller) do
-      search_facet_url(options.merge(only_path: true))
+      search_facet_url(options.reverse_merge(only_path: true))
     end
   end
 

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -131,12 +131,12 @@ module Blacklight::FacetsHelperBehavior
   # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
   # @param [String] item
   # @return [String]
-  def path_for_facet(facet_field, item)
+  def path_for_facet(facet_field, item, path_options = {})
     facet_config = facet_configuration_for_field(facet_field)
     if facet_config.url_method
       send(facet_config.url_method, facet_field, item)
     else
-      search_action_path(search_state.add_facet_params_and_redirect(facet_field, item))
+      search_action_path(search_state.add_facet_params_and_redirect(facet_field, item).merge(path_options))
     end
   end
 

--- a/app/presenters/blacklight/json_presenter.rb
+++ b/app/presenters/blacklight/json_presenter.rb
@@ -19,6 +19,7 @@ module Blacklight
 
     def search_facets_as_json
       @facets.as_json.each do |f|
+        f.stringify_keys!
         f.delete "options"
         f["label"] = facet_configuration_for_field(f["name"]).label
         f["items"] = f["items"].as_json.each do |i|

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -33,13 +33,13 @@ json.included do
             json.hits item['hits']
           end
           json.links do
-            json.self path_for_facet(facet['name'], item['value'])
+            json.self path_for_facet(facet['name'], item['value'], only_path: false)
           end
         end
       end
     end
     json.links do
-      json.self search_facet_url(id: facet['name'])
+      json.self search_facet_path(id: facet['name'], only_path: false)
     end
   end
 

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -42,4 +42,26 @@ json.included do
       json.self search_facet_url(id: facet['name'])
     end
   end
+
+  json.array! search_fields do |(label, key)|
+    json.type 'search_field'
+    json.id key
+    json.attributes do
+      json.label label
+    end
+    json.links do
+      json.self url_for(search_state.to_h.merge(search_field: key, only_path: false))
+    end
+  end
+
+  json.array! active_sort_fields do |key, field|
+    json.type 'sort'
+    json.id key
+    json.attributes do
+      json.label field.label
+    end
+    json.links do
+      json.self url_for(search_state.to_h.merge(sort: key, only_path: false))
+    end
+  end
 end

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -1,5 +1,45 @@
-json.response do
-  json.docs @presenter.documents
-  json.facets @presenter.search_facets_as_json
+json.links do
+  json.self url_for(search_state.to_h.merge(only_path: false))
+  json.prev url_for(search_state.to_h.merge(only_path: false, page: @response.prev_page.to_s)) if @response.prev_page
+  json.next url_for(search_state.to_h.merge(only_path: false, page: @response.next_page.to_s)) if @response.next_page
+  json.last url_for(search_state.to_h.merge(only_path: false, page: @response.total_pages.to_s))
+end
+
+json.meta do
   json.pages @presenter.pagination_info
+end
+
+json.data do
+  json.array! @presenter.documents do |document|
+    json.id document.id
+    json.attributes document
+    json.links do
+      json.self polymorphic_url(url_for_document(document))
+    end
+  end
+end
+
+json.included do
+  json.array! @presenter.search_facets_as_json do |facet|
+    json.type 'facet'
+    json.id facet['name']
+    json.attributes do
+      json.items do
+        json.array! facet['items'] do |item|
+          json.id
+          json.attributes do
+            json.label item['label']
+            json.value item['value']
+            json.hits item['hits']
+          end
+          json.links do
+            json.self path_for_facet(facet['name'], item['value'])
+          end
+        end
+      end
+    end
+    json.links do
+      json.self search_facet_url(id: facet['name'])
+    end
+  end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -116,4 +116,3 @@ RSpec.describe "Search Page" do
     expect(page).to have_content "No results found for your search"
   end
 end
-

--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -6,32 +6,41 @@ RSpec.describe "catalog/index.json" do
   let(:config) { Blacklight::Configuration.new }
   let(:presenter) { Blacklight::JsonPresenter.new(response, facets, config) }
 
-  it "renders index json" do
+  let(:hash) do
+    render template: "catalog/index.json", format: :json
+    JSON.parse(rendered).with_indifferent_access
+  end
+
+  before do
     allow(view).to receive(:blacklight_config).and_return(config)
+    allow(view).to receive(:search_action_path).and_return('http://test.host/some/search/url')
+    allow(view).to receive(:search_facet_path).and_return('http://test.host/some/facet/url')
     allow(presenter).to receive(:pagination_info).and_return({ current_page: 1, next_page: 2,
                                                                prev_page: nil })
     allow(presenter).to receive(:search_facets_as_json).and_return(
-          [{ name: "format", label: "Format",
-             items: [{ value: 'Book', hits: 30, label: 'Book' }] }])
+          [{ 'name' => "format", 'label' => "Format",
+             'items' => [{ 'value' => 'Book', 'hits' => 30, 'label' => 'Book' }] }])
     assign :presenter, presenter
     assign :response, response
-    render template: "catalog/index.json", format: :json
-    hash = JSON.parse(rendered).with_indifferent_access
-    expect(hash).to include(links: hash_including(self: 'http://test.host/', next: 'http://test.host/?page=2', last: 'http://test.host/?page=3'))
-    expect(hash).to include(response: hash_including(facets: [
-      { 
-        'name' => "format", 'label' => "Format",
-        'items' => [
-          { 'value' => 'Book',
-            'hits' => 30,
-            'label' => 'Book' }] 
-      }]))
-    expect(hash).to include(response: hash_including(pages: 
+  end
+
+  it "has pagination links" do
+    expect(hash).to include(links: hash_including(
+      self: 'http://test.host/',
+      next: 'http://test.host/?page=2',
+      last: 'http://test.host/?page=3'))
+  end
+
+  it "has pagination information" do
+    expect(hash).to include(meta: hash_including(pages:
       { 
         'current_page' =>  1,
         'next_page' => 2,
         'prev_page' => nil 
       }))
+  end
+
+  it "includes documents, links, and their attributes" do
     expect(hash).to include(data: [
       {
         id: '123',
@@ -44,5 +53,23 @@ RSpec.describe "catalog/index.json" do
         links: { self: 'http://test.host/catalog/456' }
       },
     ])
+  end
+
+  it "has facet information and links" do
+    expect(hash).to include(:included)
+
+    facets = hash[:included].select { |x| x['type'] == 'facet' }
+    expect(facets).to be_present
+
+    expect(facets.map { |x| x['id'] }).to include 'format'
+
+    format = facets.find { |x| x['id'] == 'format' }
+
+    expect(format['links']).to include self: 'http://test.host/some/facet/url'
+    expect(format['attributes']).to include :items
+
+    format_items = format['attributes']['items'].map { |x| x['attributes'] }
+
+    expect(format_items).to match_array [{value: 'Book', hits: 30, label: 'Book'}]
   end
 end

--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -1,30 +1,48 @@
 # frozen_string_literal: true
 RSpec.describe "catalog/index.json" do
-  let(:response) { instance_double(Blacklight::Solr::Response, documents: docs) }
-  let(:docs) { [{ id: '123', title_t: 'Book1' }, { id: '456', title_t: 'Book2' }] }
+  let(:response) { instance_double(Blacklight::Solr::Response, documents: docs, prev_page: nil, next_page: 2, total_pages: 3) }
+  let(:docs) { [SolrDocument.new(id: '123', title_t: 'Book1'), SolrDocument.new(id: '456', title_t: 'Book2')] }
   let(:facets) { double("facets") }
-  let(:config) { instance_double(Blacklight::Configuration) }
+  let(:config) { Blacklight::Configuration.new }
   let(:presenter) { Blacklight::JsonPresenter.new(response, facets, config) }
 
   it "renders index json" do
+    allow(view).to receive(:blacklight_config).and_return(config)
     allow(presenter).to receive(:pagination_info).and_return({ current_page: 1, next_page: 2,
                                                                prev_page: nil })
     allow(presenter).to receive(:search_facets_as_json).and_return(
           [{ name: "format", label: "Format",
              items: [{ value: 'Book', hits: 30, label: 'Book' }] }])
     assign :presenter, presenter
+    assign :response, response
     render template: "catalog/index.json", format: :json
-    hash = JSON.parse(rendered)
-    expect(hash).to eq('response' => { 'docs' => [{ 'id' => '123', 'title_t' => 'Book1' },
-                                                  { 'id' => '456', 'title_t' => 'Book2' }],
-                                       'facets' => [{ 'name' => "format", 'label' => "Format",
-                                                      'items' => [
-                                                        { 'value' => 'Book',
-                                                          'hits' => 30,
-                                                          'label' => 'Book' }] }],
-                                       'pages' => { 'current_page' =>  1,
-                                                    'next_page' => 2,
-                                                    'prev_page' => nil } }
-                      )
+    hash = JSON.parse(rendered).with_indifferent_access
+    expect(hash).to include(links: hash_including(self: 'http://test.host/', next: 'http://test.host/?page=2', last: 'http://test.host/?page=3'))
+    expect(hash).to include(response: hash_including(facets: [
+      { 
+        'name' => "format", 'label' => "Format",
+        'items' => [
+          { 'value' => 'Book',
+            'hits' => 30,
+            'label' => 'Book' }] 
+      }]))
+    expect(hash).to include(response: hash_including(pages: 
+      { 
+        'current_page' =>  1,
+        'next_page' => 2,
+        'prev_page' => nil 
+      }))
+    expect(hash).to include(data: [
+      {
+        id: '123',
+        attributes: { 'id' => '123', 'title_t' => 'Book1' },
+        links: { self: 'http://test.host/catalog/123' }
+      },
+      {
+        id: '456',
+        attributes: { 'id' => '456', 'title_t' => 'Book2' },
+        links: { self: 'http://test.host/catalog/456' }
+      },
+    ])
   end
 end


### PR DESCRIPTION
This PR changes the existing catalog JSON serialization to adopt the [JSON-API](https://jsonapi.org) structure. Notably, this adds explicit URLs to documents, facets, search fields, and pagination.

This is a major change to the API and should be documented in the release notes.

```
{
   "links" : {
      "last" : "http://127.0.0.1:3000/catalog.json?page=1&q=nectar",
      "self" : "http://127.0.0.1:3000/catalog.json?q=nectar"
   },
   "included" : [
      {
         "attributes" : {
            "items" : [
               {
                  "attributes" : {
                     "hits" : 1,
                     "value" : "Book",
                     "label" : "Book"
                  },
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bformat%5D%5B%5D=Book&q=nectar"
                  }
               }
            ]
         },
         "id" : "format",
         "type" : "facet",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/format.json?q=nectar"
         }
      },
      {
         "type" : "facet",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/pub_date.json?q=nectar"
         },
         "attributes" : {
            "items" : [
               {
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bpub_date%5D%5B%5D=2002&q=nectar"
                  },
                  "attributes" : {
                     "value" : "2002",
                     "hits" : 1,
                     "label" : "2002"
                  }
               }
            ]
         },
         "id" : "pub_date"
      },
      {
         "id" : "subject_topic_facet",
         "attributes" : {
            "items" : [
               {
                  "attributes" : {
                     "hits" : 1,
                     "value" : "Padma Sambhava, ca. 717-ca. 762",
                     "label" : "Padma Sambhava, ca. 717-ca. 762"
                  },
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bsubject_topic_facet%5D%5B%5D=Padma+Sambhava%2C+ca.+717-ca.+762&q=nectar"
                  }
               },
               {
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bsubject_topic_facet%5D%5B%5D=Priests%2C+Buddhist&q=nectar"
                  },
                  "attributes" : {
                     "value" : "Priests, Buddhist",
                     "hits" : 1,
                     "label" : "Priests, Buddhist"
                  }
               }
            ]
         },
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/subject_topic_facet.json?q=nectar"
         },
         "type" : "facet"
      },
      {
         "type" : "facet",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/language_facet.json?q=nectar"
         },
         "id" : "language_facet",
         "attributes" : {
            "items" : [
               {
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Blanguage_facet%5D%5B%5D=English&q=nectar"
                  },
                  "attributes" : {
                     "hits" : 1,
                     "value" : "English",
                     "label" : "English"
                  }
               },
               {
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Blanguage_facet%5D%5B%5D=Tibetan&q=nectar"
                  },
                  "attributes" : {
                     "value" : "Tibetan",
                     "hits" : 1,
                     "label" : "Tibetan"
                  }
               }
            ]
         }
      },
      {
         "attributes" : {
            "items" : [
               {
                  "attributes" : {
                     "hits" : 1,
                     "value" : "B - Philosophy, Psychology, Religion",
                     "label" : "B - Philosophy, Psychology, Religion"
                  },
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Blc_1letter_facet%5D%5B%5D=B+-+Philosophy%2C+Psychology%2C+Religion&q=nectar"
                  }
               }
            ]
         },
         "id" : "lc_1letter_facet",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/lc_1letter_facet.json?q=nectar"
         },
         "type" : "facet"
      },
      {
         "attributes" : {
            "items" : [
               {
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bsubject_geo_facet%5D%5B%5D=India&q=nectar"
                  },
                  "attributes" : {
                     "hits" : 1,
                     "value" : "India",
                     "label" : "India"
                  }
               }
            ]
         },
         "id" : "subject_geo_facet",
         "type" : "facet",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/subject_geo_facet.json?q=nectar"
         }
      },
      {
         "id" : "subject_era_facet",
         "attributes" : {
            "items" : []
         },
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/subject_era_facet.json?q=nectar"
         },
         "type" : "facet"
      },
      {
         "attributes" : {
            "items" : [
               {
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bexample_pivot_field%5D%5B%5D=Book&q=nectar"
                  },
                  "attributes" : {
                     "label" : "Book",
                     "value" : "Book",
                     "hits" : 1
                  }
               }
            ]
         },
         "id" : "example_pivot_field",
         "type" : "facet",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/example_pivot_field.json?q=nectar"
         }
      },
      {
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/facet/example_query_facet_field.json?q=nectar"
         },
         "type" : "facet",
         "id" : "example_query_facet_field",
         "attributes" : {
            "items" : [
               {
                  "attributes" : {
                     "value" : "years_25",
                     "hits" : 1,
                     "label" : "within 25 Years"
                  },
                  "links" : {
                     "self" : "http://127.0.0.1:3000/catalog.json?f%5Bexample_query_facet_field%5D%5B%5D=years_25&q=nectar"
                  }
               }
            ]
         }
      },
      {
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&search_field=all_fields"
         },
         "type" : "search_field",
         "id" : "all_fields",
         "attributes" : {
            "label" : "All Fields"
         }
      },
      {
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&search_field=title"
         },
         "type" : "search_field",
         "attributes" : {
            "label" : "Title"
         },
         "id" : "title"
      },
      {
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&search_field=author"
         },
         "type" : "search_field",
         "id" : "author",
         "attributes" : {
            "label" : "Author"
         }
      },
      {
         "id" : "subject",
         "attributes" : {
            "label" : "Subject"
         },
         "type" : "search_field",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&search_field=subject"
         }
      },
      {
         "id" : "score desc, pub_date_sort desc, title_sort asc",
         "attributes" : {
            "label" : "relevance"
         },
         "type" : "sort",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&sort=score+desc%2C+pub_date_sort+desc%2C+title_sort+asc"
         }
      },
      {
         "type" : "sort",
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&sort=pub_date_sort+desc%2C+title_sort+asc"
         },
         "id" : "pub_date_sort desc, title_sort asc",
         "attributes" : {
            "label" : "year"
         }
      },
      {
         "id" : "author_sort asc, title_sort asc",
         "attributes" : {
            "label" : "author"
         },
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&sort=author_sort+asc%2C+title_sort+asc"
         },
         "type" : "sort"
      },
      {
         "id" : "title_sort asc, pub_date_sort desc",
         "attributes" : {
            "label" : "title"
         },
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog.json?q=nectar&sort=title_sort+asc%2C+pub_date_sort+desc"
         },
         "type" : "sort"
      }
   ],
   "data" : [
      {
         "links" : {
            "self" : "http://127.0.0.1:3000/catalog/2008308175"
         },
         "id" : "2008308175",
         "attributes" : {
            "score" : 2.0528193,
            "lc_callnum_display" : [
               "BQ5593.P3 N3313 2002"
            ],
            "language_facet" : [
               "English",
               "Tibetan"
            ],
            "published_display" : [
               "Dharamsala"
            ],
            "id" : "2008308175",
            "subject_geo_facet" : [
               "India"
            ],
            "author_display" : "Ṅag-dbaṅ-blo-bzaṅ-rgya-mtsho, Dalai Lama V, 1617-1682",
            "subtitle_display" : "a supplication to the noble Lama Mahaguru Padmasambhava",
            "isbn_t" : [
               "8186470336"
            ],
            "format" : "Book",
            "title_display" : "Pluvial nectar of blessings",
            "pub_date" : [
               "2002"
            ],
            "subject_topic_facet" : [
               "Padma Sambhava, ca. 717-ca. 762",
               "Priests, Buddhist"
            ],
            "material_type_display" : [
               "viii, 101 p."
            ]
         }
      }
   ],
   "meta" : {
      "pages" : {
         "total_count" : 1,
         "next_page" : null,
         "limit_value" : 10,
         "total_pages" : 1,
         "last_page?" : true,
         "prev_page" : null,
         "current_page" : 1,
         "first_page?" : true,
         "offset_value" : 0
      }
   }
}
```