### PR TITLE
Adjust responsive layout

### DIFF
--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -22,14 +22,14 @@ module Blacklight
     # Classes used for sizing the main content of a Blacklight page
     # @return [String]
     def main_content_classes
-      'col-md-9 col-sm-8'
+      'col-md-9'
     end
 
     ##
     # Classes used for sizing the sidebar content of a Blacklight page
     # @return [String]
     def sidebar_classes
-      'page-sidebar col-md-3 col-sm-4'
+      'page-sidebar col-md-3'
     end
 
     ##

--- a/spec/helpers/blacklight/layout_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/layout_helper_behavior_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe Blacklight::LayoutHelperBehavior do
   describe '#show_content_classes' do
     it 'returns a string of classes' do
       expect(helper.show_content_classes).to be_an String
-      expect(helper.show_content_classes).to eq 'col-md-9 col-sm-8 show-document'
+      expect(helper.show_content_classes).to eq 'col-md-9 show-document'
     end
   end
 
   describe '#show_sidebar_classes' do
     it 'returns a string of classes' do
       expect(helper.show_sidebar_classes).to be_an String
-      expect(helper.show_sidebar_classes).to eq 'page-sidebar col-md-3 col-sm-4'
+      expect(helper.show_sidebar_classes).to eq 'page-sidebar col-md-3'
     end
   end
 
   describe '#main_content_classes' do
     it 'returns a string of classes' do
       expect(helper.main_content_classes).to be_an String
-      expect(helper.main_content_classes).to eq 'col-md-9 col-sm-8'
+      expect(helper.main_content_classes).to eq 'col-md-9'
     end
   end
 
   describe '#sidebar_classes' do
     it 'returns a string of classes' do
       expect(helper.sidebar_classes).to be_an String
-      expect(helper.sidebar_classes).to eq 'page-sidebar col-md-3 col-sm-4'
+      expect(helper.sidebar_classes).to eq 'page-sidebar col-md-3'
     end
   end
 


### PR DESCRIPTION
This PR removes the sidebar column at the "small" viewport size, making the `sm` viewport layout similar to the `xs` layout. 

Rationale: Currently when you view the application at the small viewport size the sidebar column is shown but the facets are collapsed. Clicking on the expand icon simply shows the facets in the previously empty sidebar column. In other words, there's no reason to collapse the facets with this arrangement.

![before-facet-toggle](https://cloud.githubusercontent.com/assets/101482/25925304/9d2b8326-359c-11e7-8acd-465d0cf7d444.png)


One approach would be to remove the collapse behavior and just show the facets in the sidebar at the small viewport size. However, I wonder how useful the side-by-side arrangement actually is to a user at the small viewport size. Both the facets and the main content area are fairly squished at 577 to 767px:

![before-sm](https://cloud.githubusercontent.com/assets/101482/25925335/c99d737e-359c-11e7-902c-933e13db2804.png)

Alternatively, we could just use the same no-sidebar arrangement currently used in the `xs` viewport for the `sm` viewport as well. That's all this PR does (though someone more familiar with the layout decisions made in Blacklight should definitely make sure I'm not overlooking some negative ramifications of this approach). So with this PR the sidebar is not displayed until you get to the `md` viewport; until then the facets are shown in the expand/collapse section above the main content area:

![after-facet-toggle](https://cloud.githubusercontent.com/assets/101482/25925386/1c236356-359d-11e7-856f-c0f25c17272f.png)
