### PR TITLE
Prevent logo and toggle icon in topbar from overlapping

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -2,6 +2,13 @@
   Header bar at top (Bootstrap nav-bar)
 */
 
+.topbar > .container {
+  @media (max-width: breakpoint-max(xs)) {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
 .navbar-brand {  /* The main logo image for the Blacklight instance */
   @if $logo-image {
     background: transparent $logo-image no-repeat top left;
@@ -46,6 +53,6 @@
     // hide 'search' label at very small screens
     @media screen and (max-width: breakpoint-max(xs)) {
       @include sr-only();
-    }    
+    }
   }
 }

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse" role="navigation">
+<nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse topbar" role="navigation">
   <div class="<%= container_classes %>">
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
At the smallest (`xs`) viewport size, the Blacklight logo and the toggle icon for expanding the utility links overlap:

![before-logo toggler-overlap](https://cloud.githubusercontent.com/assets/101482/25925853/366fabf4-35a0-11e7-909a-ae8986c37429.png)

This PR prevents that overlap by enabling the logo to align left and the toggle icon to align right:

![after-facet-toggle](https://cloud.githubusercontent.com/assets/101482/25925883/594c9092-35a0-11e7-861e-88354a7555e2.png)

To do this I added a unique class to the `nav` element used for the topbar. I could also do it without adding that class (just using a `.navbar > .container` selector), which works fine for Blacklight, but I'm worried that approach could have unintended consequences for downstream applications that add additional `.navbar` elements with nested `.container`s. Seems safer to just add a class to the `nav` element so the CSS is scoped to that specific use of the `nav`.