### PR TITLE
Custom facet field sorting

### DIFF
--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -50,12 +50,18 @@ module Blacklight::FacetsHelperBehavior
     render(options)
   end
 
+  def render_sorted_facet_limit_list(paginator, facet_field, wrapping_element=:li)
+    sorting_hash = blacklight_configuration_context.evaluate_sorting_configuration facet_field
+    items = sorting_hash ? paginator.items.sort_by { |obj| sorting_hash[obj.value] } : paginator.items
+    render_facet_limit_list(items, facet_field, wrapping_element)
+  end
+
   ##
   # Renders the list of values 
   # removes any elements where render_facet_item returns a nil value. This enables an application
   # to filter undesireable facet items so they don't appear in the UI
-  def render_facet_limit_list(paginator, facet_field, wrapping_element=:li)
-    safe_join(paginator.items.map { |item| render_facet_item(facet_field, item) }.compact.map { |item| content_tag(wrapping_element,item)})
+  def render_facet_limit_list(items, facet_field, wrapping_element=:li)
+    safe_join(items.map { |item| render_facet_item(facet_field, item) }.compact.map { |item| content_tag(wrapping_element,item)})
   end
 
   ##

--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,6 +1,6 @@
 <ul class="facet-values list-unstyled">
   <% paginator = facet_paginator(facet_field, display_facet) %>
-  <%= render_facet_limit_list paginator, facet_field.key %>
+  <%= render_sorted_facet_limit_list paginator, facet_field %>
 
   <% unless paginator.last_page? || params[:action] == "facet" %>
     <li class="more_facets_link">

--- a/lib/blacklight/configuration/context.rb
+++ b/lib/blacklight/configuration/context.rb
@@ -43,6 +43,14 @@ module Blacklight
           proc_helper_or_boolean
         end
       end
+
+      def evaluate_sorting_configuration(config, *args)
+        if config.respond_to?(:sort_field_by)
+          context.send(config.sort_field_by, config)
+        else
+          nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is more of a POC than an actual pull request.
If this is something you'd like to introduce to the codebase then I'll refactor, handle edge cases, write tests etc..

The idea is to be able to call a custom sorting function when configuring a facet field, just like with the :if attribute. The sorting function should return a hash with the field values as keys and their order as values.

```ruby
config.add_facet_field 'format', :label => 'Format', sort_field_by: :format_sorting
...
def format_sorting field_config
  {"eBook"=>1, "Microfilm"=>3, "Book"=>2, "Unknown"=>4, ... }
end
```
Please let me know what you think.