### PR TITLE
Adds an explicit `#empty?` method for the GroupResponse

### DIFF
--- a/lib/blacklight/solr/response/group_response.rb
+++ b/lib/blacklight/solr/response/group_response.rb
@@ -32,6 +32,13 @@ class Blacklight::Solr::Response::GroupResponse
     params[:start].to_s.to_i
   end
 
+  ##
+  # Relying on a fallback (method missing) to @response is problematic as it
+  # will not evaluate the correct `total` method.
+  def empty?
+    total.zero?
+  end
+
   def method_missing meth, *args, &block
     if response.respond_to? meth
       response.send(meth, *args, &block)

--- a/spec/models/blacklight/solr/response/group_response_spec.rb
+++ b/spec/models/blacklight/solr/response/group_response_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Blacklight::Solr::Response::GroupResponse do
       expect(group.group_limit).to eq 5
     end
   end
+  
+  describe "empty?" do
+    it "uses the total from this object" do
+      expect(group.empty?).to be false
+    end
+  end
 end
 
 def create_response(response, params = {})


### PR DESCRIPTION
This is needed as the metaprogramming method missing calls `#empty`
on the `@response` object which in turn has the incorrect scope to
correctly evaluate the total.

Closes #1711 