### PR TITLE
use correct local variable for label_for_search_field and sort_field_label

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -98,14 +98,14 @@ module Blacklight::ConfigurationHelperBehavior
   # can't be found.
   def label_for_search_field(key)
     field_config = blacklight_config.search_fields[key]
-    field_config ||= Blacklight::Configuration::NullField.new(key: field)
+    field_config ||= Blacklight::Configuration::NullField.new(key: key)
 
     field_config.display_label('search')
   end
 
   def sort_field_label(key)
     field_config = blacklight_config.sort_fields[key]
-    field_config ||= Blacklight::Configuration::NullField.new(key: field)
+    field_config ||= Blacklight::Configuration::NullField.new(key: key)
 
     field_config.display_label('sort')
   end

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -261,4 +261,34 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
       expect(select_arguments).not_to include(["No Display", "no_display"])
     end
   end
+
+  context 'labels' do
+    let(:field_config) { { 'my-key' => double('field', display_label: 'My Field') } }
+
+    before do
+      allow(helper).to receive_messages(blacklight_config: config)
+    end
+
+    describe '#label_for_search_field' do
+      let(:config) { double('Blacklight configuration', search_fields: field_config) }
+
+      it 'handles a found key' do
+        expect(helper.label_for_search_field('my-key')).to eq 'My Field'
+      end
+      it 'handles a missing key' do
+        expect(helper.label_for_search_field('not-found')).to eq 'Not Found'
+      end
+    end
+
+    describe '#sort_field_label' do
+      let(:config) { double('Blacklight configuration', sort_fields: field_config) }
+
+      it 'handles a found key' do
+        expect(helper.sort_field_label('my-key')).to eq 'My Field'
+      end
+      it 'handles a missing key' do
+        expect(helper.sort_field_label('not-found')).to eq 'Not Found'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR corrects a `NameError` when these methods are called -- it cannot find the local variable/method `field` in these 2 methods.

```
NameError:
       undefined local variable or method `field' for #<#<Class:0x007fe047e32770>:0x007fe048f58270>
       Did you mean?  fields
```