### PR TITLE
Deserialize search history query parameters using search_state

### DIFF
--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -96,7 +96,7 @@ module Blacklight::SearchContext
   def setup_next_and_previous_documents
     if search_session['counter'] and current_search_session
       index = search_session['counter'].to_i - 1
-      response, documents = get_previous_and_next_documents_for_search index, ActiveSupport::HashWithIndifferentAccess.new(current_search_session.query_params)
+      response, documents = get_previous_and_next_documents_for_search index, search_state.reset(current_search_session.query_params).to_hash
 
       search_session['total'] = response.total
       @search_context_response = response

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -114,7 +114,7 @@ module Blacklight::UrlHelperBehavior
   #   link_back_to_catalog(label: 'Back to Search', route_set: my_engine)
   def link_back_to_catalog(opts={:label=>nil})
     scope = opts.delete(:route_set) || self
-    query_params = current_search_session.try(:query_params) || ActionController::Parameters.new
+    query_params = search_state.reset(current_search_session.try(:query_params)).to_hash
 
     if search_session['counter']
       per_page = (search_session['per_page'] || default_per_page).to_i

--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -10,7 +10,7 @@
   <table class="table table-striped search_history">
     <%-  @searches.each_with_index do |search,index| -%>
     <%= content_tag :tr, :id => "document_#{index + 1}" do %>
-      <td class="query"><%= link_to_previous_search(search.query_params) %></td>
+      <td class="query"><%= link_to_previous_search(search_state.reset(search.query_params).to_hash) %></td>
       <%- if has_user_authentication_provider? -%>
         <td class="actions">
           <%- if current_or_guest_user && search.saved? -%>

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -37,8 +37,8 @@ module Blacklight
     end
     alias to_h to_hash
 
-    def reset
-      self.class.new(ActionController::Parameters.new, blacklight_config, controller)
+    def reset(params = nil)
+      self.class.new(params || ActionController::Parameters.new, blacklight_config, controller)
     end
 
     ##

--- a/lib/blacklight/solr/response/group_response.rb
+++ b/lib/blacklight/solr/response/group_response.rb
@@ -32,6 +32,13 @@ class Blacklight::Solr::Response::GroupResponse
     params[:start].to_s.to_i
   end
 
+  ##
+  # Relying on a fallback (method missing) to @response is problematic as it
+  # will not evaluate the correct `total` method.
+  def empty?
+    total.zero?
+  end
+
   def method_missing meth, *args, &block
     if response.respond_to? meth
       response.send(meth, *args, &block)

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -8,9 +8,9 @@ describe Blacklight::SearchState do
     end
   end
 
+  subject(:search_state) { described_class.new(params, blacklight_config, controller) }
   let(:parameter_class) { ActionController::Parameters }
   let(:controller) { double }
-  let(:search_state) { described_class.new(params, blacklight_config, controller) }
   let(:params) { parameter_class.new }
 
   describe '#to_h' do
@@ -295,6 +295,14 @@ describe Blacklight::SearchState do
       params = search_state.remove_facet_params('some_field', 'some_value')
 
       expect(params).not_to have_key :f
+    end
+  end
+
+  describe '#reset' do
+    it 'returns a search state with the given parameters' do
+      new_state = search_state.reset('a' => 1)
+
+      expect(new_state.to_hash).to eq({ 'a' => 1 })
     end
   end
 end

--- a/spec/models/blacklight/solr/response/group_response_spec.rb
+++ b/spec/models/blacklight/solr/response/group_response_spec.rb
@@ -59,6 +59,12 @@ describe Blacklight::Solr::Response::GroupResponse do
       expect(group.group_limit).to eq 5
     end
   end
+  
+  describe "empty?" do
+    it "uses the total from this object" do
+      expect(group.empty?).to be false
+    end
+  end
 end
 
 def create_response(response, params = {})


### PR DESCRIPTION
This adds compatibility for loading search history parameters from older
versions of Blacklight (which persisted the ActionController::Parameters object
directly).

Backports #1715 