### PR TITLE
Don't serialize searches for bots and crawlers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Metrics/BlockNesting:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 181
+  Max: 182
 
 # Offense count: 20
 Metrics/CyclomaticComplexity:

--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -36,7 +36,9 @@ module Blacklight::SearchContext
   end
 
   def find_search_session
-    if params[:search_context].present?
+    if agent_is_crawler?
+      nil
+    elsif params[:search_context].present?
       find_or_initialize_search_session_from_params JSON.parse(params[:search_context])
     elsif params[:search_id].present?
       begin
@@ -61,6 +63,16 @@ module Blacklight::SearchContext
   # set to true
   def start_new_search_session?
     false
+  end
+
+  ##
+  # Determine if the current request is coming from an anonymous bot
+  # or search crawler
+  #
+  def agent_is_crawler?
+    crawler_proc = blacklight_config.crawler_detector
+    return false if crawler_proc.nil? || current_user.present?
+    crawler_proc.call(request)
   end
 
   def find_or_initialize_search_session_from_params params

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -118,7 +118,10 @@ module Blacklight
           # how many searches to save in session history
           search_history_window: 100,
           default_facet_limit: 10,
-          default_more_limit: 20
+          default_more_limit: 20,
+          # proc for determining whether the session is a crawler/bot
+          # ex.: crawler_detector: lambda { |req| req.env['HTTP_USER_AGENT'] =~ /bot/ }
+          crawler_detector: nil
           }
         end
         # rubocop:enable Metrics/MethodLength

--- a/spec/features/search_crawler_spec.rb
+++ b/spec/features/search_crawler_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe "Search History Page" do
+
+  describe "crawler search" do
+    let(:original_proc) { ::CatalogController.blacklight_config.crawler_detector }
+
+    before do
+      ::CatalogController.blacklight_config.crawler_detector = lambda { |req| req.env['HTTP_USER_AGENT'] =~ /Googlebot/ }
+    end
+
+    after do
+      ::CatalogController.blacklight_config.crawler_detector = original_proc
+    end
+
+    it "remembers human searches" do
+      visit root_path
+      fill_in "q", with: 'chicken'
+      expect { click_button 'search' }.to change { Search.count }.by(1)
+    end
+
+    it "doesn't remember bot searches" do
+      page.driver.header('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+      visit root_path
+      fill_in "q", with: 'chicken'
+      expect { click_button 'search' }.to_not change { Search.count }
+    end
+  end
+
+end


### PR DESCRIPTION
This PR does not change default behavior; it simply adds a configuration option that can be used to determine whether the session should be considered transient, so its search history will not be serialized to the database.