### PR TITLE
Provide a default application_name

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -9,10 +9,16 @@ module Blacklight::BlacklightHelperBehavior
   ##
   # Get the name of this application from an i18n string
   # key: blacklight.application_name
+  # Try first in the current locale, then the default locale
   #
   # @return [String] the application name
   def application_name
-    t('blacklight.application_name')
+    # It's important that we don't use ActionView::Helpers::CacheHelper#cache here
+    # because it returns nil.
+    Rails.cache.fetch 'blacklight/application_name' do
+      t('blacklight.application_name',
+        default: t('blacklight.application_name', locale: I18n.default_locale))
+    end
   end
 
   ##

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -12,8 +12,6 @@ de:
       next: 'Nächste &raquo;'
 
   blacklight:
-    application_name: 'Blacklight'
-
     header_links:
       login: 'Anmelden'
       logout: 'Ausloggen'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -13,7 +13,6 @@ en:
 
   blacklight:
     application_name: 'Blacklight'
-
     header_links:
       login: 'Login'
       logout: 'Log Out'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -12,8 +12,6 @@ es:
       next: 'Siguiente &raquo;'
 
   blacklight:
-    application_name: 'Blacklight'
-
     header_links:
       login: 'Entrar'
       logout: 'Salir'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -12,8 +12,6 @@ fr:
       next: 'Suivante &raquo;'
 
   blacklight:
-    application_name: 'Blacklight'
-
     header_links:
       login: 'Mon compte'
       logout: 'Me déconnecter'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -12,8 +12,6 @@ it:
       next: 'Pagina successiva &raquo;'
 
   blacklight:
-    application_name: 'Blacklight'
-
     header_links:
       login: 'Login'
       logout: 'Log out'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -12,8 +12,6 @@ pt-BR:
       next: 'próx &raquo;'
 
   blacklight:
-    application_name: 'Blacklight'
-
     header_links:
       login: 'Acessar'
       logout: 'Sair'

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -12,8 +12,6 @@ sq:
       next: 'Tjetra &raquo;'
 
   blacklight:
-    application_name: 'Blacklight'
-
     header_links:
       login: 'Hyr'
       logout: 'Dil'

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -8,8 +8,36 @@ RSpec.describe BlacklightHelper do
   end
 
   describe "#application_name" do
+    before do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::NullStore.new)
+    end
     it "defaults to 'Blacklight'" do
       expect(application_name).to eq "Blacklight"
+    end
+
+    context "when the language is not english " do
+      around do |example|
+        I18n.locale = :de
+        example.run
+        I18n.locale = :en
+      end
+
+      context "and no translation exists for that language" do
+        it "defaults to 'Blacklight'" do
+          expect(application_name).to eq "Blacklight"
+        end
+      end
+
+      context "and a translation exists for that language" do
+        around do |example|
+          I18n.backend.store_translations(:de, 'blacklight' => { 'application_name' => 'Schwarzlicht' } )
+          example.run
+          I18n.backend.reload!
+        end
+        it "uses the provided value" do
+          expect(application_name).to eq "Schwarzlicht"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Since the default is always `Blacklight` we may as well only have it in one spot with the option to override.