### PR TITLE
Suppress the sort by controls if there's only one option

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -9,11 +9,6 @@ module Blacklight::ConfigurationHelperBehavior
     blacklight_config.index_fields
   end
 
-  # Used in the document_list partial (search view) for building a select element
-  def sort_fields
-    active_sort_fields.map { |_sort_key, field_config| [sort_field_label(field_config.key), field_config.key] }
-  end
-
   def active_sort_fields
     blacklight_config.sort_fields.select { |_sort_key, field_config| should_render_field?(field_config) }
   end

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,4 +1,4 @@
-<% if show_sort_and_per_page? and !active_sort_fields.blank? %>
+<% if show_sort_and_per_page? and active_sort_fields.many? %>
 <div id="sort-dropdown" class="sort-dropdown btn-group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
       <%= t('blacklight.search.sort.label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -15,13 +15,6 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
     end
   end
 
-  describe "#sort_fields" do
-    it "converts the sort fields to select-ready values" do
-      allow(blacklight_config).to receive_messages(sort_fields: { 'a' => double(key: 'a', display_label: 'a'), 'b' => double(key: 'b', display_label: 'b'), c: double(key: 'c', if: false, display_label: nil)  })
-      expect(helper.sort_fields).to eq [['a', 'a'], ['b', 'b']]
-    end
-  end
-
   describe "#active_sort_fields" do
     it "restricts the configured sort fields to only those that should be displayed" do
       allow(blacklight_config).to receive_messages(sort_fields: { a: double(if: false, unless: false), b: double(if:true, unless: true) })

--- a/spec/views/catalog/_sort_widget.html.erb_spec.rb
+++ b/spec/views/catalog/_sort_widget.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe "catalog/_sort_widget" do
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:response) { instance_double(Blacklight::Solr::Response, empty?: false, sort: 'one') }
+
+  before do
+    allow(view).to receive_messages(blacklight_config: blacklight_config)
+    assign(:response, response)
+    controller.request.path_parameters[:action] = 'index'
+  end
+
+  context 'with no sort fields configured' do
+    it 'renders nothing' do
+      render
+      expect(rendered).to be_blank
+    end
+  end
+
+  context 'with a single sort field configured' do
+    before do
+      blacklight_config.add_sort_field 'one'
+    end
+    it 'renders nothing' do
+      render
+      expect(rendered).to be_blank
+    end
+  end
+
+  context 'with multiple sort fields configured' do
+    before do
+      blacklight_config.add_sort_field 'one'
+      blacklight_config.add_sort_field 'two'
+    end
+    it 'renders a dropdown with the various options' do
+      render
+      
+      expect(rendered).to have_button 'One'
+      expect(rendered).to have_link 'One'
+      expect(rendered).to have_link 'Two'
+    end
+  end
+end


### PR DESCRIPTION
c4c401a will also need to be deprecated in 6.x.