### PR TITLE
Remove option of passing false as the second argument to thumbnail_tag

### DIFF
--- a/app/presenters/blacklight/thumbnail_presenter.rb
+++ b/app/presenters/blacklight/thumbnail_presenter.rb
@@ -31,11 +31,8 @@ module Blacklight
     # rubocop:disable Lint/AssignmentInCondition
     def thumbnail_tag image_options = {}, url_options = {}
       return unless value = thumbnail_value(image_options)
-      if url_options == false || url_options[:suppress_link]
-        value
-      else
-        view_context.link_to_document document, value, url_options
-      end
+      return value if url_options[:suppress_link]
+      view_context.link_to_document document, value, url_options
     end
     # rubocop:enable Lint/AssignmentInCondition
 

--- a/spec/presenters/thumbnail_presenter_spec.rb
+++ b/spec/presenters/thumbnail_presenter_spec.rb
@@ -57,14 +57,6 @@ RSpec.describe Blacklight::ThumbnailPresenter do
           expect(subject).to eq "link"
         end
 
-        context "and url options are false" do
-          subject { presenter.thumbnail_tag({}, false) }
-
-          it "does not link to the document" do
-            expect(subject).to eq "some-thumbnail"
-          end
-        end
-
         context "and url options have :suppress_link" do
           subject { presenter.thumbnail_tag({}, suppress_link: true) }
 


### PR DESCRIPTION
It's much more clear to the reader what the intention of this code is:

```ruby
thumbnail_tag({}, suppress_link: true)
```
as compared to the more obtuse:
```ruby
thumbnail_tag({}, false)
```

Deprecated in 6.x in #1752