### PR TITLE
Upgrade rubocop to 0.49.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/LineLength:
 Style/StringLiterals:
   Enabled: false
 
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   EnforcedStyle: normal
 
 Rails/OutputSafety:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,7 +65,7 @@ Metrics/PerceivedComplexity:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
 # SupportedStyles: outdent, indent
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Exclude:
     - 'app/controllers/concerns/blacklight/catalog.rb'
     - 'app/controllers/concerns/blacklight/controller.rb'
@@ -97,7 +97,7 @@ Style/BracesAroundHashParameters:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentOneStep, IndentationWidth.
 # SupportedStyles: case, end
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Exclude:
     - 'app/helpers/blacklight/catalog_helper_behavior.rb'
     - 'app/presenters/blacklight/index_presenter.rb'
@@ -125,7 +125,7 @@ Style/Documentation:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: leading, trailing
-Style/DotPosition:
+Layout/DotPosition:
   Exclude:
     - 'lib/blacklight/search_builder.rb'
 
@@ -137,7 +137,7 @@ Style/DoubleNegation:
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment, ForceEqualSignAlignment.
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Exclude:
     - 'app/helpers/blacklight/catalog_helper_behavior.rb'
     - 'app/models/concerns/blacklight/document/dublin_core.rb'
@@ -189,13 +189,13 @@ Style/IfUnlessModifier:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
 # SupportedStyles: special_inside_parentheses, consistent, align_braces
-Style/IndentHash:
+Layout/IndentHash:
   Exclude:
     - 'lib/blacklight/configuration.rb'
 
 # Offense count: 5
 # Cop supports --auto-correct.
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Exclude:
     - 'app/models/blacklight/facet_paginator.rb'
     - 'app/models/concerns/blacklight/configurable.rb'
@@ -211,7 +211,7 @@ Style/MethodDefParentheses:
 
 # Offense count: 2
 # Cop supports --auto-correct.
-Style/MultilineBlockLayout:
+Layout/MultilineBlockLayout:
   Exclude:
     - 'lib/generators/blacklight/install_generator.rb'
     - 'lib/generators/blacklight/test_support_generator.rb'
@@ -227,7 +227,7 @@ Style/MultilineIfModifier:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
 # SupportedStyles: aligned, indented, indented_relative_to_receiver
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Exclude:
     - 'lib/blacklight/search_builder.rb'
 
@@ -235,7 +235,7 @@ Style/MultilineMethodCallIndentation:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
 # SupportedStyles: aligned, indented
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Exclude:
     - 'app/controllers/concerns/blacklight/default_component_configuration.rb'
     - 'app/helpers/blacklight/facets_helper_behavior.rb'
@@ -266,3 +266,81 @@ Style/PredicateName:
     - 'app/models/concerns/blacklight/document.rb'
     - 'app/models/concerns/blacklight/solr/document.rb'
     - 'lib/generators/blacklight/assets_generator.rb'
+
+Rails/ApplicationRecord:
+  Enabled: false
+
+Rails/Present:
+  Enabled: false
+
+Rails/Blank:
+  Enabled: false
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Layout/AlignParameters:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/EndOfLine:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceAfterComma:
+  Enabled: false
+
+Layout/SpaceInsideParens:
+  Enabled: false
+
+Layout/TrailingWhitespace:
+  Enabled: false
+
+Layout/TrailingBlankLines:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/UnneededInterpolation:
+  Enabled: false

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -47,6 +47,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency "coveralls"
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "rubocop", '~> 0.47.0' # pending release of 0.48.1
+  s.add_development_dependency "rubocop", '~> 0.49.1'
   s.add_development_dependency "rubocop-rspec", '~> 1.8.0'
 end


### PR DESCRIPTION
This matches what hound is using, so this prevents hound errors from
being loged as github comments.

I've disabled all the new checks that our code triggers for the time
being.