### PR TITLE
Allow semantics to be defined from multiple stored field names

### DIFF
--- a/app/models/concerns/blacklight/document/semantic_fields.rb
+++ b/app/models/concerns/blacklight/document/semantic_fields.rb
@@ -34,12 +34,14 @@ module Blacklight::Document
     # but extensions should call super and modify hash returned, to avoid
     # unintentionally erasing values provided by other extensions. 
     def to_semantic_values
-      @semantic_value_hash ||= self.class.field_semantics.each_with_object(Hash.new([])) do |(key, field_name), hash|
-        value = self[field_name]
+      @semantic_value_hash ||= self.class.field_semantics.each_with_object(Hash.new([])) do |(key, field_names), hash|
+        ##
+        # Handles single string field_name or an array of field_names
+        value = Array.wrap(field_names).map { |field_name| self[field_name] }.flatten.compact
 
         # Make single and multi-values all arrays, so clients
         # don't have to know.
-        hash[key] = Array.wrap(value) unless value.nil?
+        hash[key] = value unless value.empty?
       end
 
       @semantic_value_hash ||= {}

--- a/spec/models/blacklight/solr/document_spec.rb
+++ b/spec/models/blacklight/solr/document_spec.rb
@@ -199,17 +199,23 @@ describe "Blacklight::Solr::Document" do
           include Blacklight::Solr::Document                        
       end
       before do
-        MockDocument.field_semantics.merge!( :title => "title_field", :author => "author_field", :something => "something_field" )
-        
+        MockDocument.field_semantics.merge!(
+          title: ["title_field", "other_title"],
+          author: "author_field",
+          something: "something_field"
+        )
+
         @doc1 = MockDocument.new( 
            "title_field" => "doc1 title",
+           "other_title" => "doc1 title other",
            "something_field" => ["val1", "val2"],
            "not_in_list_field" => "weird stuff" 
          )
       end
 
       it "should return complete dictionary based on config'd fields" do        
-        expect(@doc1.to_semantic_values).to eq :title => ["doc1 title"], :something => ["val1", "val2"]
+        expect(@doc1.to_semantic_values)
+          .to eq title: ["doc1 title", "doc1 title other"], something: ["val1", "val2"]
       end      
       it "should return empty array for a key without a value" do
         expect(@doc1.to_semantic_values[:author]).to be_empty


### PR DESCRIPTION
This change is meant to allow for semantics to be combined from multiple
fields.

Backporting this.