### PR TITLE
Pass the document object to the path helpers referenced in…

### DIFF
--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -70,9 +70,9 @@ module Blacklight::UrlHelperBehavior
     return if document.nil?
 
     if respond_to?(controller_tracking_method)
-      send(controller_tracking_method, params.merge(id: document.id))
+      send(controller_tracking_method, params.merge(id: document))
     else
-      blacklight.track_search_context_path(params.merge(id: document.id))
+      blacklight.track_search_context_path(params.merge(id: document))
     end
   end
 

--- a/spec/helpers/blacklight/url_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/url_helper_behavior_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "converts the counter parameter into a data- attribute" do
-      allow(helper).to receive(:track_test_path).with(hash_including(id: '123456', counter: 5)).and_return('tracking url')
+      allow(helper).to receive(:track_test_path).with(hash_including(id: have_attributes(id: '123456'), counter: 5)).and_return('tracking url')
 
       expect(helper.link_to_document(document, :title_display, counter: 5)).to include 'data-context-href="tracking url"'
     end
@@ -283,12 +283,12 @@ RSpec.describe Blacklight::UrlHelperBehavior do
   describe "#session_tracking_path" do
     let(:document) { SolrDocument.new(id: 1) }
     it "determines the correct route for the document class" do
-      allow(helper).to receive(:track_test_path).with(id: 1).and_return('x')
+      allow(helper).to receive(:track_test_path).with(id: have_attributes(id: 1)).and_return('x')
       expect(helper.session_tracking_path(document)).to eq 'x'
     end
 
     it "passes through tracking parameters" do
-      allow(helper).to receive(:track_test_path).with(id: 1, x: 1).and_return('x')
+      allow(helper).to receive(:track_test_path).with(id: have_attributes(id: 1), x: 1).and_return('x')
       expect(helper.session_tracking_path(document, x: 1)).to eq 'x'
     end
   end


### PR DESCRIPTION
…session_tracking_path so that to_param is used instead of the id directly.

If this accepted I suppose I'll backport this as well as I need it in a 6.x release.