### PR TITLE
Modal 6.x

### DIFF
--- a/app/assets/javascripts/blacklight/ajax_modal.js
+++ b/app/assets/javascripts/blacklight/ajax_modal.js
@@ -126,7 +126,7 @@ Blacklight.ajaxModal.receiveAjax = function (contents) {
     $(Blacklight.ajaxModal.modalSelector).find('.modal-content').html(contents);
 
     // send custom event with the modal dialog div as the target
-    var e    = $.Event('loaded.blacklight.blacklight-modal')
+    var e    = $.Event('loaded.blacklight.ajax-modal');
     $(Blacklight.ajaxModal.modalSelector).trigger(e);
     // if they did preventDefault, don't show the dialog
     if (e.isDefaultPrevented()) return;

--- a/app/controllers/concerns/blacklight/default_component_configuration.rb
+++ b/app/controllers/concerns/blacklight/default_component_configuration.rb
@@ -56,13 +56,17 @@ module Blacklight
             flash[:success] ||= I18n.t("blacklight.#{name}.success", default: nil)
 
             respond_to do |format|
-              format.html { redirect_to action_success_redirect_path }
-              format.js { render "#{name}_success" }
+              format.html do
+                return render "#{name}_success" if request.xhr?
+                redirect_to action_success_redirect_path
+              end
             end
           else
             respond_to do |format|
-              format.html
-              format.js { render :layout => false }
+              format.html do
+                return render layout: false if request.xhr?
+                # Otherwise draw the full page
+              end
             end
           end
         end

--- a/app/controllers/concerns/blacklight/default_component_configuration.rb
+++ b/app/controllers/concerns/blacklight/default_component_configuration.rb
@@ -57,7 +57,7 @@ module Blacklight
 
             respond_to do |format|
               format.html do
-                return render "#{name}_success" if request.xhr?
+                return render "#{name}_success", layout: false if request.xhr?
                 redirect_to action_success_redirect_path
               end
             end


### PR DESCRIPTION
Backport https://github.com/projectblacklight/blacklight/commit/442f4cb0a293922972d64665e140a5f39abf7ca7 for SMS/email form to render the form html only within the modal dialog.
Also prevents the full layout from rendering within the modal after SMS/email form submissions.