### PR TITLE
Exclude generator templates

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --protected
+--exclude lib/generators/blacklight/templates/
 -
 app/**/*.rb
 


### PR DESCRIPTION
They are not straight ruby and Yard cannot parse them anyway, giving errors like:
```
[warn]: Syntax error in `lib/generators/blacklight/templates/solr_document.rb`:(2,7): syntax error, unexpected '<'
[warn]: ParserSyntaxError: syntax error in `lib/generators/blacklight/templates/solr_document.rb`:(2,7): syntax error, unexpected '<'
```