### PR TITLE
Indend the generated route to four spaces deep

### DIFF
--- a/lib/generators/blacklight/test_support_generator.rb
+++ b/lib/generators/blacklight/test_support_generator.rb
@@ -16,10 +16,10 @@ module Blacklight
     def alternate_controller
       copy_file "alternate_controller.rb", "app/controllers/alternate_controller.rb"
 
-      routing_code = <<-EOF.strip_heredoc
-        resource :alternate, controller: 'alternate', only: [:index] do
-          concerns :searchable
-        end
+      routing_code = <<-EOF
+    resource :alternate, controller: 'alternate', only: [:index] do
+      concerns :searchable
+    end
       EOF
 
       sentinel = /concern :searchable[^\n]+\n/


### PR DESCRIPTION
This matches the indenting in the rest of the file