### PR TITLE
Do not assume spelling is available.

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -110,6 +110,7 @@ module Blacklight::BlacklightHelperBehavior
   # @param [Blacklight::Solr::Response] response
   # @return [Boolean]
   def should_show_spellcheck_suggestions? response
+    # The spelling response field may be missing from non solr repositories.
     response.total <= spell_check_max &&
       !response.spelling.nil? &&
       response.spelling.words.any?

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -110,7 +110,9 @@ module Blacklight::BlacklightHelperBehavior
   # @param [Blacklight::Solr::Response] response
   # @return [Boolean]
   def should_show_spellcheck_suggestions? response
-    response.total <= spell_check_max && response.spelling.words.any?
+    response.total <= spell_check_max &&
+      !response.spelling.nil? &&
+      response.spelling.words.any?
   end
 
   ##

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -193,12 +193,16 @@ RSpec.describe BlacklightHelper do
       response = double(total: 10)
       expect(helper.should_show_spellcheck_suggestions? response).to be false
     end
-    it "onlies show suggestions if there are very few results" do
+    it "only shows suggestions if there are very few results" do
       response = double(total: 4, spelling: double(words: [1]))
       expect(helper.should_show_spellcheck_suggestions? response).to be true
     end
     it "shows suggestions only if there are spelling suggestions available" do
       response = double(total: 4, spelling: double(words: []))
+      expect(helper.should_show_spellcheck_suggestions? response).to be false
+    end
+    it "does not show suggestions if spelling is not available" do
+      response = double(total: 4, spelling: nil)
       expect(helper.should_show_spellcheck_suggestions? response).to be false
     end
   end


### PR DESCRIPTION
Solr is not always the repository so it's not safe to assume that the
spelling field is available in the response.

This commit short circuits the respose when spelling is not available
otherwise an exception is thrown when trying to get words from nil.