### PR TITLE
add a project solr_wrapper for developer happiness

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,0 +1,5 @@
+# Place any default configuration for solr_wrapper here
+# port: 8983
+collection:
+  dir: lib/generators/blacklight/templates/solr/conf/
+  name: blacklight-core


### PR DESCRIPTION
So a Blacklight dev can run solr separately from the rake tasks.