### PR TITLE
Dismiss modal on successful email / SMS form submission

### DIFF
--- a/app/views/catalog/email_success.html.erb
+++ b/app/views/catalog/email_success.html.erb
@@ -1,11 +1,13 @@
-<div class="modal-header">
-  <h1><%= t('blacklight.email.form.title') %></h1>
-  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
+<div data-blacklight-modal="container">
+  <div class="modal-header">
+    <h1><%= t('blacklight.email.form.title') %></h1>
+    <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
-<div class="modal-body">
-  <%= render partial: '/shared/flash_msg' %>
-  <span data-blacklight-modal="close"></span>
+  <div class="modal-body">
+    <%= render partial: '/shared/flash_msg' %>
+    <span data-blacklight-modal="close"></span>
+  </div>
 </div>

--- a/app/views/catalog/sms_success.html.erb
+++ b/app/views/catalog/sms_success.html.erb
@@ -1,11 +1,13 @@
-<div class="modal-header">
-  <h1 class="modal-title"><%= t('blacklight.sms.form.title') %></h1>
-  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
+<div data-blacklight-modal="container">
+  <div class="modal-header">
+    <h1 class="modal-title"><%= t('blacklight.sms.form.title') %></h1>
+    <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
-<div class="modal-body">
-  <%= render partial: '/shared/flash_msg' %>
-  <span data-blacklight-modal="close"></span>
+  <div class="modal-body">
+    <%= render partial: '/shared/flash_msg' %>
+    <span data-blacklight-modal="close"></span>
+  </div>
 </div>

--- a/spec/views/catalog/email_success.html.erb_spec.rb
+++ b/spec/views/catalog/email_success.html.erb_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe "catalog/email_success.html.erb" do
+
+  it "includes the data-blacklight-modal properties" do
+    render
+    expect(rendered).to have_selector "div[data-blacklight-modal=container]"
+  end
+end

--- a/spec/views/catalog/sms_success.html.erb_spec.rb
+++ b/spec/views/catalog/sms_success.html.erb_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe "catalog/sms_success.html.erb" do
+
+  it "includes the data-blacklight-modal properties" do
+    render
+    expect(rendered).to have_selector "div[data-blacklight-modal=container]"
+  end
+end


### PR DESCRIPTION
Fixes #1848 

This PR dismisses the Email This / SMS This modal after a form is successfully submitted and renders the flash message on the record page.

## Before
![before_email_sms_submit](https://user-images.githubusercontent.com/5402927/38113512-12eff298-335a-11e8-9a1b-3b092bc3d5f6.gif)

## After
![after_email_sms_submit](https://user-images.githubusercontent.com/5402927/38113516-15138224-335a-11e8-976a-81bf03ccfab3.gif)
