### PR TITLE
Adding a test for an inactive default sort value

### DIFF
--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -182,8 +182,13 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
       expect(helper.default_sort_field.key).to eq 'b'
     end
 
-    it "is the first per-page value if a default isn't set" do
+    it "is the first active sort field value if a default isn't set" do
       allow(helper).to receive_messages(blacklight_config: double(sort_fields: { a: double(key: 'a', default: nil), b: double(key: 'b', default: nil) }))
+      expect(helper.default_sort_field.key).to eq 'a'
+    end
+
+    it "is the first active sort field value if the configured default field is not active" do
+      allow(helper).to receive_messages(blacklight_config: double(sort_fields: { a: double(default: nil, key: 'a'), b: double(key: 'b', default: true, if: false) }))
       expect(helper.default_sort_field.key).to eq 'a'
     end
   end


### PR DESCRIPTION
This is a test for the additional option where the default sort value is not currently being displayed.

It is related to the PR #910 to prove @cbeer  comment that the code being replaced has additional functionality.