### PR TITLE
Small adaptations to make BL 6 work with Jquery 3

### DIFF
--- a/app/assets/javascripts/blacklight/checkbox_submit.js
+++ b/app/assets/javascripts/blacklight/checkbox_submit.js
@@ -49,7 +49,7 @@
         var unique_id = form.attr("data-doc-id") || Math.random();
         // if form is currently using method delete to change state, 
         // then checkbox is currently checked
-        var checked = (form.find("input[name=_method][value=delete]").size() != 0);
+        var checked = (form.find("input[name=_method][value=delete]").length != 0);
             
         var checkbox = $('<input type="checkbox">')	    
           .addClass( options.css_class )

--- a/app/assets/javascripts/blacklight/core.js
+++ b/app/assets/javascripts/blacklight/core.js
@@ -9,31 +9,22 @@ Blacklight = function() {
       for(var i = 0; i < buffer.length; i++) {
         buffer[i].call();
       }
-    },
-
-    listeners: function () {
-      var listeners = [];
-      if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-        // Turbolinks 5
-        if (Turbolinks.BrowserAdapter) {
-          listeners.push('turbolinks:load');
-        } else {
-          // Turbolinks < 5
-          listeners.push('page:load', 'ready');
-        }
-      } else {
-        listeners.push('ready');
-      }
-
-      return listeners.join(' ');
     }
   };
 }();
 
 // turbolinks triggers page:load events on page transition
-// If app isn't using turbolinks, this event will never be triggered, no prob. 
-$(document).on(Blacklight.listeners(), function() {
-  Blacklight.activate();  
-});
-
-
+// If app isn't using turbolinks, this event will never be triggered, no prob.
+// $(document).on('ready') is deprecated in JQuery 1.8
+if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+  // Turbolinks 5
+  if (Turbolinks.BrowserAdapter) {
+    $(document).on('turbolinks:load', function() { Blacklight.activate(); });
+  } else {
+    // Turbolinks < 5
+    $(document).on('page:load', function() { Blacklight.activate(); });
+    $(document).ready(function() { Blacklight.activate(); });
+  }
+} else {
+  $(document).ready(function() { Blacklight.activate(); });
+}


### PR DESCRIPTION
.size() is deprecated
$(document).on('ready') is deprecated in JQuery 1.8, I expanded the code so it works with Turbolinks < 5 (the double call to page:load and ready()