### PR TITLE
Low Contrast Errors from Bootstrap 4

### DIFF
--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -21,7 +21,31 @@
   }
 }
 
-
 .page-link {
   white-space: nowrap;
+}
+
+// Accessibility overrides for low contrast errors
+$primary: #006cdf;
+$success: #238f3c;
+$info: #138b9e;
+$gray: #6b686d;
+
+a,
+.page-link { color: $primary; }
+
+.btn-primary,
+.page-item.active .page-link {
+  background-color: $primary;
+  border-color: $primary;
+}
+
+.btn-success {
+  background-color: $success;
+  border-color: $success;
+}
+
+.btn-info {
+  background-color: $info;
+  border-color: $info;
 }


### PR DESCRIPTION
Overrides the primary, success, info, and gray variables from Bootstrap. Updates the colors for page links and buttons for the primary, success and info colors in case they are used out-of-the-box by users. There are some false positives for the facet headers because they inherit from the heading–all good.

*Before shot with some false positives for the facets*

![screen shot 2018-05-01 at 1 06 12 pm](https://user-images.githubusercontent.com/4163828/39587745-3d779500-4ec8-11e8-90b3-4e9ba99442bf.png)

![screen shot 2018-05-03 at 11 55 44 am](https://user-images.githubusercontent.com/4163828/39588059-f7ade2bc-4ec8-11e8-849e-9f0c04629e42.png)


*After shot with same false positives*

![screen shot 2018-05-03 at 11 53 42 am](https://user-images.githubusercontent.com/4163828/39587935-ae60615c-4ec8-11e8-91bf-28f539937bb6.png)

![screen shot 2018-05-03 at 11 52 51 am](https://user-images.githubusercontent.com/4163828/39587940-b2d59586-4ec8-11e8-9b5b-59f703333c0e.png)

