### PR TITLE
Normalize the bookmark_controller.delete method.

### DIFF
--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe BookmarksController do
       expect(response.code).to eq "500"
     end
   end
+
+  describe "create" do
+    it "can create bookmarks via params bookmarks attribute" do
+      @controller.send(:current_or_guest_user).save
+      put :create, xhr: true, params: {
+        id: "notused",
+        bookmarks: [
+          { document_id: "2007020969", document_type: "SolrDocument" },
+          { document_id: "2007020970", document_type: "SolrDocument" },
+          { document_id: "2007020971", document_type: "SolrDocument" }
+        ],
+        format: :js
+      }
+
+      expect(response).to be_success
+      expect(response.code).to eq "200"
+      expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 3
+    end
+  end
   
   describe "delete" do
     before do
@@ -34,6 +53,22 @@ RSpec.describe BookmarksController do
     
     it "has a 200 status code when delete is success" do
       delete :destroy, xhr: true, params: { id: '2007020969', format: :js }
+      expect(response).to be_success
+      expect(response.code).to eq "200"
+      expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 0
+    end
+
+    it "can handle bookmark deletion via :bookmarks param" do
+      class FooDocument < SolrDocument; end
+      @controller.send(:current_or_guest_user).bookmarks.create! document_id: '2007020970', document_type: "FooDocument"
+      delete :destroy, xhr: true, params: {
+        id: 'notused',
+        bookmarks: [
+          { document_id: '2007020969', document_type: 'SolrDocument' },
+          { document_id: '2007020970', document_type: 'FooDocument' }
+        ],
+        format: :js
+      }
       expect(response).to be_success
       expect(response.code).to eq "200"
       expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 0


### PR DESCRIPTION
Currently the `bookmark_controller.create` method allows the user to
pass an array of bookmarks via the parameters with a format of
`[{ id: foo, document_type: bar }]`.

This is useful because theoretically we can bookmark records that are
not of type SolrDocument.  Likewise the bookmark model does not make any
assumptions about document_type other than providing a default if one is
not given.

Contrary to these methods, the `bookmark_controller.delete` is not
implemented in a consistent fashion to its counterpart.

`bookmark_controller.delete` works on only one bookmark at a time and
its document type can only be derived from `blacklight_config`. This is
unfortunate because `blacklight_config` is copied from the
`CatalogController` and the document type is already set to be
`SolrDocument`.

This commit updates `bookmark_controller.delete` to work in
a complimentary manner to `bookmark_controller.create`.

The use case of this change is to allow for being able to bookmark non
SolrDocuments in an environment where there are multiple backends not
just of type Solr.

## Additionally
* This change also fixes bookmark creation via bookmarks params not working in Rails when strong parameters is enabled.