### PR TITLE
Fix blacklight:server task fails with missing file.

### DIFF
--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -52,8 +52,8 @@ namespace :blacklight do
       Rake::Task['engine_cart:generate'].invoke
     end
 
-    SolrWrapper.wrap(port: '8983') do |solr|
-      solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path("..", File.dirname(__FILE__)), "solr", "conf")) do
+    SolrWrapper.wrap(version: '7.1.0', port: '8983') do |solr|
+      solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path("..", File.dirname(__FILE__)), '.internal_test_app', 'solr', 'conf')) do
         Rake::Task['blacklight:internal:seed'].invoke
 
         within_test_app do


### PR DESCRIPTION
`rake blacklight:server` fails with

```
Failed to execute solr create:
Specified configuration directory blacklight/solr/conf not found!

. Further information may be available in
/var/folders/l8/8ljsh0p103d9m4gg3866jlhh0000gp
```

I've updated the task to be the same as the ci version.  This fixed the
issue for me.