### PR TITLE
Backport Safari bug fix to 6.x

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -5,13 +5,13 @@
 //
 // These javascript files are compiled in via the Rails asset pipeline:
 //= require blacklight/core
-//= require blacklight/autofocus
+//= require blacklight/autocomplete
 //= require blacklight/bookmark_toggle
-//= require blacklight/ajax_modal
-//= require blacklight/search_context
 //= require blacklight/collapsable
 //= require blacklight/facet_load
-//= require blacklight/autocomplete
+//= require blacklight/ajax_modal
+//= require blacklight/search_context
+//= require blacklight/autofocus
 //
 //Bootstrap JS for providing collapsable tablet/mobile menu/alert boxes
 //= require bootstrap/transition


### PR DESCRIPTION
REF projectblacklight/blacklight#1818

The order that JS files are compiled is contributing to a bug in the
Safari browser that makes the search form input inaccessible when
auto-complete is enabled for the field.

This commit fixes the issue by updating the order of the files to match
the BL-7.x order.

## Notes:
There is some discussion that `autofocus.js` is an extraneous file that could be potentially causing this issue, but I just checked removing that file and I still see the issue in Safari.  Therefore, the order of the other JS files is important.  Not necessarily that file.