### PR TITLE
Require globalid explicitly

### DIFF
--- a/app/models/concerns/blacklight/document.rb
+++ b/app/models/concerns/blacklight/document.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-##
+
+require 'globalid'
+
 ##
 # = Introduction
 # Blacklight::Document is the module with logic for a class representing


### PR DESCRIPTION
Typically globalid gets required by activejob, but a rails installation
may have deactivated that gem.  This ensures the `GlobalID` constant can
be found