### PR TITLE
Filter the attributes that display on the json index view

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -49,7 +49,7 @@ module Blacklight::Catalog
 
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }
-      format.json { render json: { response: { document: @document } } }
+      format.json
       additional_export_formats(@document, format)
     end
   end

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -12,7 +12,16 @@ end
 json.data do
   json.array! @presenter.documents do |document|
     json.id document.id
-    json.attributes document
+    json.attributes do
+      doc_presenter = index_presenter(document)
+
+      index_fields(document).each do |field_name, field|
+        if should_render_index_field? document, field
+          json.set! field_name, doc_presenter.field_value(field_name)
+        end
+      end
+    end
+
     json.links do
       json.self polymorphic_url(url_for_document(document))
     end

--- a/app/views/catalog/show.json.jbuilder
+++ b/app/views/catalog/show.json.jbuilder
@@ -1,0 +1,16 @@
+json.links do
+  json.self polymorphic_url(@document)
+end
+
+json.data do
+  json.id @document.id
+  json.attributes do
+    doc_presenter = show_presenter(@document)
+
+    document_show_fields(@document).each do |field_name, field|
+      if should_render_show_field? @document, field
+        json.set! field_name, doc_presenter.field_value(field_name)
+      end
+    end
+  end
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -141,9 +141,8 @@ RSpec.describe CatalogController do
 
       it "gets the documents" do
         expect(docs).to have(10).documents
-        expect(docs.first['attributes'].keys).to include(
-          "author_tsim", "format", "title_tsim", "id", "subject_ssim",
-           "language_ssim", "score", "timestamp")
+        expect(docs.first['attributes'].keys).to match_array(
+          %w[author_tsim format language_ssim lc_callnum_ssim published_ssim title_tsim])
         expect(docs.first['links']['self']).to eq solr_document_url(id: docs.first['id'])
       end
 
@@ -268,13 +267,14 @@ RSpec.describe CatalogController do
     end
 
     describe "with format :json" do
+      render_views
       it "gets the feed" do
         get :show, params: { id: doc_id, format: 'json' }
         expect(response).to be_success
         json = JSON.parse response.body
-        expect(json["response"]["document"].keys).to include(
-          "author_tsim", "format", "title_tsim", "id", "subject_ssim",
-          "language_ssim", "timestamp")
+        expect(json["data"]["attributes"].keys).to match_array(
+          %w[author_tsim format isbn_ssim language_ssim lc_callnum_ssim
+             published_ssim subtitle_tsim title_tsim url_suppl_ssim])
       end
     end
 

--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 RSpec.describe "catalog/index.json" do
   let(:response) { instance_double(Blacklight::Solr::Response, documents: docs, prev_page: nil, next_page: 2, total_pages: 3) }
-  let(:docs) { [SolrDocument.new(id: '123', title_tsim: 'Book1'), SolrDocument.new(id: '456', title_tsim: 'Book2')] }
+  let(:docs) do
+     [
+       SolrDocument.new(id: '123', title_tsim: 'Book1', author_tsim: 'Julie'),
+       SolrDocument.new(id: '456', title_tsim: 'Book2', author_tsim: 'Rosie')
+     ]
+  end
   let(:facets) { double("facets") }
-  let(:config) { Blacklight::Configuration.new }
+  let(:config) do
+    Blacklight::Configuration.new do |config|
+      config.add_index_field 'title_tsim', label: 'Title:'
+    end
+  end
   let(:presenter) { Blacklight::JsonPresenter.new(response, facets, config) }
 
   let(:hash) do
@@ -44,12 +53,12 @@ RSpec.describe "catalog/index.json" do
     expect(hash).to include(data: [
       {
         id: '123',
-        attributes: { 'id' => '123', 'title_tsim' => 'Book1' },
+        attributes: { 'title_tsim' => 'Book1' },
         links: { self: 'http://test.host/catalog/123' }
       },
       {
         id: '456',
-        attributes: { 'id' => '456', 'title_tsim' => 'Book2' },
+        attributes: { 'title_tsim' => 'Book2' },
         links: { self: 'http://test.host/catalog/456' }
       },
     ])

--- a/spec/views/catalog/show.json.jbuilder_spec.rb
+++ b/spec/views/catalog/show.json.jbuilder_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "catalog/show.json" do
+  let(:document) do
+    SolrDocument.new(id: '123', title_tsim: 'Book1', author_tsim: 'Julie')
+  end
+  let(:config) do
+    Blacklight::Configuration.new do |config|
+      config.add_show_field 'title_tsim', label: 'Title:'
+    end
+  end
+
+  let(:hash) do
+    render template: "catalog/show.json", format: :json
+    JSON.parse(rendered).with_indifferent_access
+  end
+
+  before do
+    allow(view).to receive(:blacklight_config).and_return(config)
+    assign :document, document
+  end
+
+  it "includes document attributes" do
+    expect(hash).to include(data:
+      {
+        id: '123',
+        attributes: { 'title_tsim' => 'Book1' }
+      }
+    )
+  end
+end


### PR DESCRIPTION
This prevents data from displaying through the APIs even though it
wasn't clear that it would be displayed.
Fixes #1899