### PR TITLE
Remove hardcoding of SolrDocument in url_for_document

### DIFF
--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -81,8 +81,7 @@ module Blacklight
     # documents
     def url_for_document(doc, options = {})
       if respond_to?(:blacklight_config) &&
-         blacklight_config.view_config(:show).route &&
-         (!doc.respond_to?(:to_model) || doc.to_model.is_a?(SolrDocument))
+       blacklight_config.view_config(:show).route
         route = blacklight_config.view_config(:show).route.merge(action: :show, id: doc).merge(options)
         route[:controller] = params[:controller] if route[:controller] == :current
         route


### PR DESCRIPTION
I want to open Blacklight to the possibility of being backed by a search engine other than Solr (e.g. ElasticSearch), so we don’t want to encode `SolrDocument` if the document comes from something other than Solr.