### PR TITLE
Pin selenium-webdriver to avoid DevToolsActivePort file doesn't exist…

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency "capybara", '~> 3'
   s.add_development_dependency "chromedriver-helper"
-  s.add_development_dependency "selenium-webdriver"
+  s.add_development_dependency "selenium-webdriver", '~> 3.12.0'
   s.add_development_dependency 'engine_cart', '~> 1.2'
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency "coveralls"


### PR DESCRIPTION
…' error

https://github.com/SeleniumHQ/selenium/issues/6049
https://bugs.chromium.org/p/chromedriver/issues/detail?id=2473
