### PR TITLE
Update mocking to use the search_service

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -102,6 +102,8 @@ module Blacklight::Catalog
     end
   end
 
+  # @return [Array] first value is a Blacklight::Solr::Response and the second
+  #                 is a list of documents
   def action_documents
     search_service.fetch(Array(params[:id]))
   end

--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -117,5 +117,6 @@ module Blacklight::SearchContext
     end
   rescue Blacklight::Exceptions::InvalidRequest => e
     logger.warn "Unable to setup next and previous documents: #{e}"
+    nil
   end
 end


### PR DESCRIPTION
The existing mocks were no longer doing anything since the
search_service had been introduced into the CatalogController