### PR TITLE
Remove unnecessary conditional

### DIFF
--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -8,7 +8,7 @@ module Blacklight::FacetsHelperBehavior
   # @param [Array<String>] fields
   # @return [Boolean]
   def has_facet_values? fields = facet_field_names
-    facets_from_request(fields).any? { |display_facet| !display_facet.items.empty? && should_render_facet?(display_facet) }
+    facets_from_request(fields).any? { |display_facet| should_render_facet?(display_facet) }
   end
 
   ##


### PR DESCRIPTION
The check for items is already carried out in should_render_facet? so
there's no need to duplicate it.