### PR TITLE
JsonPresenter has facets_from_request available to itself

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -33,7 +33,6 @@ module Blacklight::Catalog
       format.atom { render layout: false }
       format.json do
         @presenter = Blacklight::JsonPresenter.new(@response,
-                                                   facets_from_request,
                                                    blacklight_config)
       end
       additional_response_formats(format)

--- a/app/presenters/blacklight/json_presenter.rb
+++ b/app/presenters/blacklight/json_presenter.rb
@@ -4,11 +4,10 @@ module Blacklight
     include Blacklight::Facet
 
     # @param [Solr::Response] response raw solr response.
-    # @param [Array<Solr::Response::Facets::FacetField>] facets list of facets
     # @param [Configuration] blacklight_config the configuration
-    def initialize(response, facets, blacklight_config)
+    # @param [Array] facets list of facets
+    def initialize(response, blacklight_config)
       @response = response
-      @facets = facets
       @blacklight_config = blacklight_config
     end
 
@@ -19,7 +18,7 @@ module Blacklight
     end
 
     def search_facets_as_json
-      @facets.map do |display_facet|
+      facets_from_request.map do |display_facet|
         next if display_facet.items.empty?
         f = display_facet.as_json
         f.stringify_keys!

--- a/spec/presenters/blacklight/json_presenter_spec.rb
+++ b/spec/presenters/blacklight/json_presenter_spec.rb
@@ -2,7 +2,14 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::JsonPresenter, api: true do
-  let(:response) { instance_double(Blacklight::Solr::Response, documents: docs, prev_page: nil, next_page: 2, total_pages: 3) }
+  let(:response) do
+    instance_double(Blacklight::Solr::Response,
+                    documents: docs,
+                    prev_page: nil,
+                    next_page: 2,
+                    total_pages: 3,
+                    aggregations: aggregations)
+  end
   let(:docs) do
      [
        SolrDocument.new(id: '123', title_tsim: 'Book1', author_tsim: 'Julie'),
@@ -10,10 +17,8 @@ RSpec.describe Blacklight::JsonPresenter, api: true do
      ]
   end
 
-  let(:facets) do
-    [
-      Blacklight::Solr::Response::Facets::FacetField.new("format_si", [{ label: "Book", value: 'Book', hits: 20 }])
-    ]
+  let(:aggregations) do
+    { 'format_si' => Blacklight::Solr::Response::Facets::FacetField.new("format_si", [{ label: "Book", value: 'Book', hits: 20 }])}
   end
 
   let(:config) do
@@ -23,7 +28,7 @@ RSpec.describe Blacklight::JsonPresenter, api: true do
     end
   end
 
-  let(:presenter) { described_class.new(response, facets, config) }
+  let(:presenter) { described_class.new(response, config) }
 
 
   describe '#search_facets_as_json' do
@@ -41,11 +46,11 @@ RSpec.describe Blacklight::JsonPresenter, api: true do
         config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {}
       end
 
-      let(:facets) do
-        [
-          Blacklight::Solr::Response::Facets::FacetField.new("format_si", [{ label: "Book", value: 'Book', hits: 20 }]),
-          Blacklight::Solr::Response::Facets::FacetField.new("example_query_facet_field", [])
-        ]
+      let(:aggregations) do
+        {
+          'format_si' => Blacklight::Solr::Response::Facets::FacetField.new("format_si", [{ label: "Book", value: 'Book', hits: 20 }]),
+          'example_query_facet_field' => Blacklight::Solr::Response::Facets::FacetField.new("example_query_facet_field", [])
+        }
       end
 
       it 'shows only facets that are defined' do

--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe "catalog/index.json", api: true do
        SolrDocument.new(id: '456', title_tsim: 'Book2', author_tsim: 'Rosie')
      ]
   end
-  let(:facets) { double("facets") }
   let(:config) do
     Blacklight::Configuration.new do |config|
       config.add_index_field 'title_tsim', label: 'Title:'
     end
   end
-  let(:presenter) { Blacklight::JsonPresenter.new(response, facets, config) }
+  let(:presenter) { Blacklight::JsonPresenter.new(response, config) }
 
   let(:hash) do
     render template: "catalog/index.json", format: :json


### PR DESCRIPTION
So we don't need to pass it in as an argument.