### PR TITLE
size() is deprecated in jQuery 1.8, use length instead

### DIFF
--- a/app/javascript/blacklight/checkbox_submit.js
+++ b/app/javascript/blacklight/checkbox_submit.js
@@ -47,7 +47,7 @@
         var uniqueId = form.attr('data-doc-id') || Math.random();
         // if form is currently using method delete to change state,
         // then checkbox is currently checked
-        var checked = (form.find('input[name=_method][value=delete]').size() != 0);
+        var checked = (form.find('input[name=_method][value=delete]').length != 0);
 
         var checkbox = $('<input type="checkbox">')
           .addClass( options.cssClass )

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -119,7 +119,7 @@ Blacklight.modal.receiveAjax = function (contents) {
     // code modelled off of JQuery ajax.load. https://github.com/jquery/jquery/blob/master/src/ajax/load.js?source=c#L62
     var container =  $('<div>').
       append( jQuery.parseHTML(contents) ).find( Blacklight.modal.containerSelector ).first();
-    if (container.size() !== 0) {
+    if (container.length !== 0) {
       contents = container.html();
     }
 


### PR DESCRIPTION
I'm probably not following the right etiquette here, but size() was deprecated and in newer versions of jquery this breaks rendering