### PR TITLE
Resolve SVG icon alignment issues

### DIFF
--- a/app/assets/stylesheets/blacklight/_icons.scss
+++ b/app/assets/stylesheets/blacklight/_icons.scss
@@ -1,8 +1,14 @@
 .blacklight-icons {
-  display: inline-block;
+  display: inline-flex;
   height: $font-size-base;
-  vertical-align: text-top;
   width: $font-size-base;
+}
+
+.blacklight-icons svg {
+  height: 1rem;
+  width: 1rem;
+  top: .125rem;
+  position: relative;
 }
 
 @each $color, $value in $theme-colors {


### PR DESCRIPTION
Fixes #1953 by emulating the font-size and aligning the icon to the baseline. Hope this is helpful.