### PR TITLE
Resolve mobile limits/facet toggle alignment

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -9,7 +9,7 @@
   }
 }
 
-.navbar-brand {  /* The main logo image for the Blacklight instance */
+.topbar .navbar-brand {  /* The main logo image for the Blacklight instance */
   @if $logo-image {
     background: transparent $logo-image no-repeat top left;
   }

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,14 +1,15 @@
 <% # main container for facets/limits menu -%>
 <% if has_facet_values? %>
 <div id="facets" class="facets sidenav facets-toggleable-sm">
-  <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#facet-panel-collapse" aria-controls="facet-panel-collapse" aria-expanded="false" aria-label="Toggle facets">
-    <span class="navbar-toggler-icon"></span>
-  </button>
 
-  <div class="top-panel-heading">
-    <h2 class="facets-heading">
+  <div class="navbar">
+    <h2 class="facets-heading navbar-brand">
       <%= t('blacklight.search.facets.title') %>
     </h2>
+
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#facet-panel-collapse" aria-controls="facet-panel-collapse" aria-expanded="false" aria-label="Toggle facets">
+      <span class="navbar-toggler-icon"></span>
+    </button>
   </div>
 
   <div id="facet-panel-collapse" class="facets-collapse collapse">


### PR DESCRIPTION
Fixes #1957 

Reflow #facets children for Bootstrap 4's .navbar expectactions. Make the .topbar's .navbar-brand selector more specific to prevent logo from repeating on additional page .navbars.

Using the lightest touch possible to solve this immediate issue here. BL7's mobile view still has some "bad rag" edges, because all page content is trapped within a main bootstrap container class. As such, the facet .navbar cannot stretch full-width to fill the same size as the header navbar.

![screen shot 2018-07-27 at 12 11 49 pm](https://user-images.githubusercontent.com/69827/43336473-a6766e26-9196-11e8-9d1d-9240a320dd9d.png)