### PR TITLE
issue #1844: suggest responses blank if suggester name is not the default

### DIFF
--- a/app/models/concerns/blacklight/suggest/response.rb
+++ b/app/models/concerns/blacklight/suggest/response.rb
@@ -2,17 +2,19 @@
 module Blacklight
   module Suggest
     class Response
-      attr_reader :response, :request_params, :suggest_path
+      attr_reader :response, :request_params, :suggest_path, :suggester_name
 
       ##
       # Creates a suggest response
       # @param [RSolr::HashWithResponse] response
       # @param [Hash] request_params
       # @param [String] suggest_path
-      def initialize(response, request_params, suggest_path)
+      # @param [String] suggester_name
+      def initialize(response, request_params, suggest_path, suggester_name)
         @response = response
         @request_params = request_params
         @suggest_path = suggest_path
+        @suggester_name = suggester_name
       end
 
       ##
@@ -20,7 +22,7 @@ module Blacklight
       # present
       # @return [Array]
       def suggestions
-        response.try(:[], suggest_path).try(:[], 'mySuggester').try(:[], request_params[:q]).try(:[], 'suggestions') || []
+        (response.try(:[], suggest_path).try(:[], suggester_name).try(:[], request_params[:q]).try(:[], 'suggestions') || []).uniq
       end
     end
   end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -122,7 +122,8 @@ module Blacklight
           default_more_limit: 20,
           # proc for determining whether the session is a crawler/bot
           # ex.: crawler_detector: lambda { |req| req.env['HTTP_USER_AGENT'] =~ /bot/ }
-          crawler_detector: nil
+          crawler_detector: nil,
+          autocomplete_suggester: 'mySuggester'
           }
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -26,7 +26,7 @@ module Blacklight::Solr
     # @return [Blacklight::Suggest::Response]
     def suggestions(request_params)
       suggest_results = connection.send_and_receive(suggest_handler_path, params: request_params)
-      Blacklight::Suggest::Response.new suggest_results, request_params, suggest_handler_path
+      Blacklight::Suggest::Response.new suggest_results, request_params, suggest_handler_path, suggester_name
     end
 
     ##
@@ -70,6 +70,10 @@ module Blacklight::Solr
     # @return [String]
     def suggest_handler_path
       blacklight_config.autocomplete_path
+    end
+
+    def suggester_name
+      blacklight_config.autocomplete_suggester
     end
 
     def build_connection

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -194,5 +194,8 @@ class <%= controller_name.classify %>Controller < ApplicationController
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = true
     config.autocomplete_path = 'suggest'
+    # if the name of the solr.SuggestComponent provided in your solrcongig.xml is not the 
+    # default 'mySuggester', uncomment and provide it below
+    # config.autocomplete_suggester = 'mySuggester'
   end
 end

--- a/spec/models/blacklight/suggest/response_spec.rb
+++ b/spec/models/blacklight/suggest/response_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Blacklight::Suggest::Response, api: true do
-  let(:empty_response) { described_class.new({}, { q: 'hello' }, 'suggest') }
+  let(:empty_response) { described_class.new({}, { q: 'hello' }, 'suggest', 'mySuggester') }
   let(:full_response) do
     described_class.new(
       {
@@ -36,7 +36,8 @@ RSpec.describe Blacklight::Suggest::Response, api: true do
       {
         q: 'new'
       },
-      'suggest'
+      'suggest',
+      'mySuggester'
     )
   end
 


### PR DESCRIPTION
add optional autocomplete_suggester parameter, in case it has been changed from the default suggested in the Lucene documentation