### PR TITLE
Webpacker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pkg/*
 .vagrant
 /spec/examples.txt
 node_modules/*
+yarn.lock

--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,4 @@ end
 # END ENGINE_CART BLOCK
 
 eval_gemfile File.expand_path("spec/test_app_templates/Gemfile.extra", File.dirname(__FILE__))
+gem 'webpacker', '~> 3.5'

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -34,11 +34,3 @@
   <h2 class='card-header collapsed collapse-toggle' data-toggle="collapse" data-target="#about-content"><a href="/rails/info/properties">About your application&rsquo;s environment</a></h2>
   <div id="about-content" class="card-body collapse"></div>
 </div>
-
-<script>
-  Blacklight.onLoad(function() {
-    $('#about .card-header').one('click', function() {
-      $($(this).data('target')).load($(this).find('a').attr('href'));
-    });
-  });
-</script>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,35 +1,43 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
-    <!-- Internet Explorer use the highest version available -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!-- Mobile viewport optimization h5bp.com/ad -->
+  <meta name="HandheldFriendly" content="True">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
-    <title><%= render_page_title %></title>
-    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
-    <%= favicon_link_tag %>
-    <%= stylesheet_link_tag "application", media: "all" %>
-    <%= javascript_include_tag "application" %>
-    <%= csrf_meta_tags %>
-    <%= content_for(:head) %>
-  </head>
-  <body class="<%= render_body_class %>">
-  <%= render partial: 'shared/header_navbar' %>
+  <!-- Internet Explorer use the highest version available -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <div id="main-container" class="<%= container_classes %>">
-    <%= content_for(:container_header) %>
+  <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
+  <!--[if IEMobile]>
+  <meta http-equiv="cleartype" content="on">
+  <![endif]-->
 
-    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+  <title><%= render_page_title %></title>
+  <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+  <%= favicon_link_tag %>
+  <%= stylesheet_link_tag "application", media: "all" %>
+  <%= javascript_pack_tag 'application' %>
+  <%= csrf_meta_tags %>
+  <%= content_for(:head) %>
+</head>
+<body class="<%= render_body_class %>">
+<%= render partial: 'shared/header_navbar' %>
 
-    <div class="row">
-      <%= content_for?(:content) ? yield(:content) : yield %>
-    </div>
+<div id="main-container" class="<%= container_classes %>">
+  <%= content_for(:container_header) %>
+
+  <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
+  <div class="row">
+    <%= content_for?(:content) ? yield(:content) : yield %>
   </div>
+</div>
 
-  <%= render partial: 'shared/footer' %>
-  <%= render partial: 'shared/modal' %>
-  </body>
+<%= render partial: 'shared/footer' %>
+<%= render partial: 'shared/modal' %>
+</body>
 </html>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,43 +1,35 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <!-- Mobile viewport optimization h5bp.com/ad -->
-  <meta name="HandheldFriendly" content="True">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- Internet Explorer use the highest version available -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <!-- Internet Explorer use the highest version available -->
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title><%= render_page_title %></title>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= javascript_pack_tag 'application' %>
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+  </head>
+  <body class="<%= render_body_class %>">
+  <%= render partial: 'shared/header_navbar' %>
 
-  <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
-  <!--[if IEMobile]>
-  <meta http-equiv="cleartype" content="on">
-  <![endif]-->
+  <div id="main-container" class="<%= container_classes %>">
+    <%= content_for(:container_header) %>
 
-  <title><%= render_page_title %></title>
-  <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
-  <%= favicon_link_tag %>
-  <%= stylesheet_link_tag "application", media: "all" %>
-  <%= javascript_pack_tag 'application' %>
-  <%= csrf_meta_tags %>
-  <%= content_for(:head) %>
-</head>
-<body class="<%= render_body_class %>">
-<%= render partial: 'shared/header_navbar' %>
+    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 
-<div id="main-container" class="<%= container_classes %>">
-  <%= content_for(:container_header) %>
-
-  <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
-
-  <div class="row">
-    <%= content_for?(:content) ? yield(:content) : yield %>
+    <div class="row">
+      <%= content_for?(:content) ? yield(:content) : yield %>
+    </div>
   </div>
-</div>
 
-<%= render partial: 'shared/footer' %>
-<%= render partial: 'shared/modal' %>
-</body>
+  <%= render partial: 'shared/footer' %>
+  <%= render partial: 'shared/modal' %>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "3.5",
-    "blacklight-frontend": "https://github.com/projectblacklight/blacklight#master",
+    "blacklight-frontend": "https://github.com/projectblacklight/blacklight#c435caddf14af6aa36c1428995b8cc52d76d4bf2",
     "caniuse-lite": "^1.0.30000697",
     "popper.js": "^1.14.3",
     "twitter-typeahead-rails": "https://github.com/yourabi/twitter-typeahead-rails.git#v0.11.1.pre.corejavascript"

--- a/package.json
+++ b/package.json
@@ -1,29 +1,15 @@
 {
-  "name": "blacklight-frontend",
-  "version": "7.0.0-alpha.1",
-  "description": "[![Build Status](https://travis-ci.org/projectblacklight/blacklight.png?branch=master)](https://travis-ci.org/projectblacklight/blacklight) [![Gem Version](https://badge.fury.io/rb/blacklight.png)](http://badge.fury.io/rb/blacklight) [![Coverage Status](https://coveralls.io/repos/github/projectblacklight/blacklight/badge.svg?branch=master)](https://coveralls.io/github/projectblacklight/blacklight?branch=master)",
-  "main": "app/assets/javascripts/blacklight",
-  "scripts": {
-    "js-compile-bundle": "shx cat app/javascript/blacklight/core.js app/javascript/blacklight/autocomplete.js app/javascript/blacklight/bookmark_toggle.js app/javascript/blacklight/checkbox_submit.js app/javascript/blacklight/collapsable.js app/javascript/blacklight/facet_load.js app/javascript/blacklight/modal.js app/javascript/blacklight/search_context.js | shx sed \"s/^(import|export).*//\" | babel --filename app/javascript/blacklight/blacklight.js > app/assets/javascripts/blacklight/blacklight.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/projectblacklight/blacklight.git"
-  },
-  "author": "",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/projectblacklight/blacklight/issues"
-  },
-  "homepage": "https://github.com/projectblacklight/blacklight#readme",
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "shx": "^0.2.2"
-  },
+  "name": "blacklight",
+  "private": true,
   "dependencies": {
-    "bootstrap": "^4.0.0",
-    "jquery": "^3.2.1",
-    "typeahead.js": "^0.11.1",
-    "bloodhound-js": "^1.2.2"
+    "@rails/webpacker": "3.5",
+    "blacklight-frontend": "https://github.com/cdmo/blacklight.git#master",
+    "caniuse-lite": "^1.0.30000697",
+    "popper.js": "^1.14.3",
+    "twitter-typeahead-rails": "https://github.com/yourabi/twitter-typeahead-rails.git#v0.11.1.pre.corejavascript"
+  },
+  "devDependencies": {
+    "webpack-dev-server": "2.11.2",
+    "webpack": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "3.5",
-    "blacklight-frontend": "https://github.com/cdmo/blacklight.git#master",
+    "blacklight-frontend": "https://github.com/projectblacklight/blacklight#master",
     "caniuse-lite": "^1.0.30000697",
     "popper.js": "^1.14.3",
     "twitter-typeahead-rails": "https://github.com/yourabi/twitter-typeahead-rails.git#v0.11.1.pre.corejavascript"


### PR DESCRIPTION
Putting this out there as a starting point really for getting webpacker to work inside Blacklight. I'm pairing this with an update I've added to https://github.com/projectblacklight/blacklight/wiki/Using-Webpacker-to-compile-javascript-assets. 

More would have to be done in terms of clearing out the old asset pipeline, like removing the Action Cable stuff and it's derivatives and a lot of other pruning of gems that help in the asset pipeline, but these changes will allow Blacklight 7 to run with webpacker compiling, generating zero errors (typeahead working, modals rendering properly, expand/collapse stuff all good, etc). 

The changes to `base.html.erb` are a little over-zealous probably, all that really matters is changing out the ` <%= javascript_include_tag "application" %>`. I'm not exactly sure why my `base.html.erb` is so different, maybe because we (Penn State) are also upgrading to rails 5.2 for our project, so perhaps this is a result of that.