### PR TITLE
aria-expanded attributes always extant on per-page and sort widgets

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -1,7 +1,7 @@
 <% if show_sort_and_per_page? and !blacklight_config.per_page.blank? %>
 <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
 <div id="per_page-dropdown" class="per-page-dropdown btn-group">
-  <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
     <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
   </button>
   <div class="dropdown-menu dropdown-menu-right" role="menu">

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,6 +1,6 @@
 <% if show_sort_and_per_page? and active_sort_fields.many? %>
 <div id="sort-dropdown" class="sort-dropdown btn-group">
-  <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
       <%= t('blacklight.search.sort.label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
   </button>
 


### PR DESCRIPTION
From an Accessibility360 audit report that was performed on the [Hyrax Project](https://github.com/samvera/hyrax/issues/2985), it was reported that the aria-expanded attribute is not assigned until after the button is clicked on the sort and per_page widgets used to sort search results.

It was recommended to mark up these buttons with the `aria-expanded` attribute always remaining extant, both before and after the button is clicked.

* This change adds `aria-expanded="false"` to these widgets, before they are clicked, so that screen readers will know there is toggle-able content present.