### PR TITLE
Add aria attributes to pagination for improved accessibility

### DIFF
--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,9 +1,9 @@
 <% if show_pagination? and @response.total_pages > 1 %>
  <div class="row record-padding">
   <div class="col-md-12">
-    <div class="pagination">
+    <nav class="pagination" role="region" aria-label="<%= t('views.pagination.aria.container_label') %>">
       <%= paginate @response, :outer_window => 2, :theme => 'blacklight' %>
-    </div>
+    </nav>
   </div>
  </div>
 <% end %>

--- a/app/views/kaminari/blacklight/_first_page.html.erb
+++ b/app/views/kaminari/blacklight/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <li class="page-item <%= 'disabled' if current_page.first? %>">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, class: 'page-link' %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_first_page') } %>
 </li>

--- a/app/views/kaminari/blacklight/_last_page.html.erb
+++ b/app/views/kaminari/blacklight/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <li class="page-item <%= 'disabled' if current_page.last? %>">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, class: 'page-link' %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_last_page') } %>
 </li>

--- a/app/views/kaminari/blacklight/_next_page.html.erb
+++ b/app/views/kaminari/blacklight/_next_page.html.erb
@@ -8,10 +8,10 @@
 -%>
 <% if current_page.last? %>
     <li class="page-item disabled">
-      <%= link_to raw(t 'views.pagination.next'), '#', :rel => 'next', :onclick=>'return false;', class: 'page-link' %>
+      <%= link_to raw(t 'views.pagination.next'), '#', :rel => 'next', :onclick=>'return false;', class: 'page-link', aria: { label: t('views.pagination.aria.go_to_next_page') } %>
     </li>
 <% else %>
     <li class="page-item">
-      <%= link_to raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, class: 'page-link' %>
+      <%= link_to raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_next_page') } %>
     </li>
 <% end %>

--- a/app/views/kaminari/blacklight/_page.html.erb
+++ b/app/views/kaminari/blacklight/_page.html.erb
@@ -7,11 +7,13 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
+<% page_display = number_with_delimiter(page.to_s) %>
+
 <li class="page-item <%= 'active' if page.current? %>">
   <% if page.current? %>
-    <span class="page-link"><%= number_with_delimiter(page.to_s) %></span>
+    <span class="page-link" aria-label="<%= t('views.pagination.aria.current_page', page: page_display) %>" aria-current="true"><%= page_display %></span>
   <% else %>
-    <%= link_to number_with_delimiter(page.to_s), url, :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil, class: 'page-link' %>
+    <%= link_to page_display, url, :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_page', page: page_display) } %>
   <% end %>
 </li>
 

--- a/app/views/kaminari/blacklight/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight/_prev_page.html.erb
@@ -8,11 +8,11 @@
 -%>
 <% if current_page.first? %>
     <li class="page-item disabled">
-      <%= link_to raw(t 'views.pagination.previous'), '#', :rel => 'prev', :onclick=>'return false;', class: 'page-link' %>
+      <%= link_to raw(t 'views.pagination.previous'), '#', :rel => 'prev', :onclick=>'return false;', class: 'page-link', aria: { label: t('views.pagination.aria.go_to_previous_page') } %>
     </li>
 <% else %>
     <li class="page-item">
-      <%= link_to raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, class: 'page-link' %>
+      <%= link_to raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_previous_page') } %>
     </li>
 <% end %>
 

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -6,6 +6,14 @@ en:
       previous: '&laquo; Previous'
       next: 'Next &raquo;'
       truncate: '…'
+      aria:
+        container_label: 'pagination links'
+        current_page: 'Current Page, Page %{page}'
+        go_to_page: 'Go to page %{page}'
+        go_to_previous_page: 'Go to previous page'
+        go_to_next_page: 'Go to next page'
+        go_to_first_page: 'Go to first page'
+        go_to_last_page: 'Go to last page'
 
     pagination_compact:
       previous: '&laquo; Previous'


### PR DESCRIPTION
Adds `aria-` attributes to pagination items.  Work coming from this Hyrax issue:  https://github.com/samvera/hyrax/issues/3138

@no-reply suggested we make PRs to blacklight, so any and all feedback welcome.  Or if there's a better way to re-factor any of the proposed changes in this PR.   The blacklight code is great by the way, super clean and organized having a first look around.

![pagination-aria](https://user-images.githubusercontent.com/3020266/45513139-7bb87200-b767-11e8-9c90-d8b2e6d8f3e9.png)
