### PR TITLE
Makes aria-expanded attribute extant for facet toggle in search

### DIFF
--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,5 +1,5 @@
 <div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
-  <h3 class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
+  <h3 class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
     <%= link_to facet_field_label(facet_field.key), "##{ facet_field_id(facet_field)}", "data-turbolinks": false %>
   </h3>
   <div id="<%= facet_field_id(facet_field) %>" class="card-body panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">


### PR DESCRIPTION
Part II. (Sorry for the two separate PR's). 

From an Accessibility360 audit report that was performed on the [Hyrax Project](https://github.com/samvera/hyrax/issues/2985), it was reported that the `aria-expanded` attribute is not assigned until after the button is clicked on the facet headers used to limit search results.

It was recommended to mark up these buttons with the `aria-expanded` attribute always remaining extant, both before and after the facet is clicked.

* This change adds `aria-expanded="false"` to the facets, before they are clicked, so that screen readers will know there is toggle-able content present.