### PR TITLE
Backport to 6.x - Improves accessibility of per page and sort widgets

### DIFF
--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,5 +1,5 @@
 <div class="panel panel-default facet_limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.key) %>">
-  <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
+  <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
     <h3 class="panel-title facet-field-heading">
       <%= link_to facet_field_label(facet_field.key), "#", :"data-turbolinks" => false, :"data-no-turbolink" => true %>
     </h3>

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -2,7 +2,7 @@
 
   <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
 <div id="per_page-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
     <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu">

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,6 +1,6 @@
 <% if show_sort_and_per_page? and active_sort_fields.many? %>
 <div id="sort-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
       <%= t('blacklight.search.sort.label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
   </button>
 


### PR DESCRIPTION
* Makes `aria-expanded` always present on per page and sort widgets so screen readers know that there is additional content available.

Please let me know if this is not the right process to backport something to 6.x. 