### PR TITLE
Add sym link to .internal/solr dir.

### DIFF
--- a/solr
+++ b/solr
@@ -1,0 +1,1 @@
+.internal_test_app/solr


### PR DESCRIPTION
REF projectblacklight/blacklight#1974

Fixes issue with ./solr/conf dir not found per instructions set in
`.internal_test_app/.solr_wrapper.yml`