### PR TITLE
do not update checkbox state if the request fails

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -185,7 +185,6 @@ Blacklight.onLoad(function () {
           data: form.serialize(),
           error: function () {
             alert('Error');
-            updateStateFor(checked);
             label.removeAttr('disabled');
             checkbox.removeAttr('disabled');
           },
@@ -200,7 +199,6 @@ Blacklight.onLoad(function () {
               options.success.call(form, checked, xhr.responseJSON);
             } else {
               alert('Error');
-              updateStateFor(checked);
               label.removeAttr('disabled');
               checkbox.removeAttr('disabled');
             }

--- a/app/javascript/blacklight/checkbox_submit.js
+++ b/app/javascript/blacklight/checkbox_submit.js
@@ -95,7 +95,6 @@
                 data: form.serialize(),
                 error: function() {
                    alert('Error');
-                   updateStateFor(checked);
                    label.removeAttr('disabled');
                    checkbox.removeAttr('disabled');
                 },
@@ -110,7 +109,6 @@
                     options.success.call(form, checked, xhr.responseJSON);
                   } else {
                     alert('Error');
-                    updateStateFor(checked);
                     label.removeAttr('disabled');
                     checkbox.removeAttr('disabled');
                   }


### PR DESCRIPTION
This PR fixes a bug where the checkboxes will get updated (changed) even when the request to update fails. This can cause some inconsistency between the UI and the actual state of checkboxes.

This does change the behavior of the JavaScript API, but from my analysis the behavior (at least 6+ years old) seems to be a "bug".

Part of https://github.com/sul-dlss/SearchWorks/issues/1370