### PR TITLE
Allow configuration of email and sms fields.

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -260,7 +260,7 @@ module Blacklight::Catalog
 
   # Email Action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
   def email_action documents
-    mail = RecordMailer.email_record(documents, { to: params[:to], message: params[:message] }, url_options)
+    mail = RecordMailer.email_record(documents, { to: params[:to], message: params[:message], config: blacklight_config }, url_options)
     if mail.respond_to? :deliver_now
       mail.deliver_now
     else
@@ -271,7 +271,7 @@ module Blacklight::Catalog
   # SMS action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
   def sms_action documents
     to = "#{params[:to].gsub(/[^\d]/, '')}@#{params[:carrier]}"
-    mail = RecordMailer.sms_record(documents, { to: to }, url_options)
+    mail = RecordMailer.sms_record(documents, { to: to, config: blacklight_config }, url_options)
     if mail.respond_to? :deliver_now
       mail.deliver_now
     else

--- a/app/models/concerns/blacklight/document/email.rb
+++ b/app/models/concerns/blacklight/document/email.rb
@@ -2,13 +2,25 @@
 # This module provides the body of an email export based on the document's semantic values
 module Blacklight::Document::Email
   # Return a text string that will be the body of the email
-  def to_email_text
-    semantics = to_semantic_values
+  def to_email_text(config = nil)
     body = []
-    body << I18n.t('blacklight.email.text.title', value: semantics[:title].join(" ")) if semantics[:title].present?
-    body << I18n.t('blacklight.email.text.author', value: semantics[:author].join(" ")) if semantics[:author].present?
-    body << I18n.t('blacklight.email.text.format', value: semantics[:format].join(" ")) if semantics[:format].present?
-    body << I18n.t('blacklight.email.text.language', value: semantics[:language].join(" ")) if semantics[:language].present?
+
+    if config
+      body = config.email_fields.map do |name, field|
+        values = [self[name]].flatten
+        "#{field.label} #{values.join(' ')}" if self[name].present?
+      end
+    end
+
+    # Use to_semantic_values for backwards compatibility
+    if body.empty?
+      semantics = to_semantic_values
+      body << I18n.t('blacklight.email.text.title', value: semantics[:title].join(" ")) if semantics[:title].present?
+      body << I18n.t('blacklight.email.text.author', value: semantics[:author].join(" ")) if semantics[:author].present?
+      body << I18n.t('blacklight.email.text.format', value: semantics[:format].join(" ")) if semantics[:format].present?
+      body << I18n.t('blacklight.email.text.language', value: semantics[:language].join(" ")) if semantics[:language].present?
+    end
+
     return body.join("\n") unless body.empty?
   end
 end

--- a/app/models/concerns/blacklight/document/sms.rb
+++ b/app/models/concerns/blacklight/document/sms.rb
@@ -2,11 +2,23 @@
 # This module provides the body of an email export based on the document's semantic values
 module Blacklight::Document::Sms
   # Return a text string that will be the body of the email
-  def to_sms_text
-    semantics = to_semantic_values
+  def to_sms_text(config = nil)
     body = []
-    body << I18n.t('blacklight.sms.text.title', value: semantics[:title].first) if semantics[:title].present?
-    body << I18n.t('blacklight.sms.text.author', value: semantics[:author].first) if semantics[:author].present?
+
+    if config
+      body = config.sms_fields.map do |name, field|
+        values = [self[name]].flatten
+        "#{field.label} #{values.first}" if self[name].present?
+      end
+    end
+
+    # Use to_semantic_values for backwards compatibility
+    if body.empty?
+      semantics = to_semantic_values
+      body << I18n.t('blacklight.sms.text.title', value: semantics[:title].first) if semantics[:title].present?
+      body << I18n.t('blacklight.sms.text.author', value: semantics[:author].first) if semantics[:author].present?
+    end
+
     return body.join unless body.empty?
   end
 end

--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -3,7 +3,12 @@
 class RecordMailer < ActionMailer::Base
   def email_record(documents, details, url_gen_params)
     title = begin
-              documents.first.to_semantic_values[:title]
+              title_field = details[:config].email.title_field
+              if title_field
+                [documents.first[title_field]].flatten.first
+              else
+                documents.first.to_semantic_values[:title]
+              end
             rescue
               I18n.t('blacklight.email.text.default_title')
             end
@@ -14,6 +19,7 @@ class RecordMailer < ActionMailer::Base
 
     @documents      = documents
     @message        = details[:message]
+    @config         = details[:config]
     @url_gen_params = url_gen_params
 
     mail(to: details[:to],  subject: subject)
@@ -21,7 +27,9 @@ class RecordMailer < ActionMailer::Base
 
   def sms_record(documents, details, url_gen_params)
     @documents      = documents
+    @config         = details[:config]
     @url_gen_params = url_gen_params
+
     mail(to: details[:to], subject: "")
   end
 end

--- a/app/views/record_mailer/sms_record.text.erb
+++ b/app/views/record_mailer/sms_record.text.erb
@@ -1,4 +1,4 @@
 <% @documents.each do |document| %>
-<%= document.to_sms_text %>
+<%= document.to_sms_text(@config) %>
 <%= t('blacklight.sms.text.url', :url => polymorphic_url(document, @url_gen_params) ) %>
 <% end %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -101,6 +101,9 @@ module Blacklight
             show: { top_level_config: :show },
             citation: { parent_config: :show }
           ),
+          # SMS and Email configurations.
+          sms: ViewConfig.new,
+          email: ViewConfig.new,
           # Configurations for specific types of index views
           view: NestedOpenStructWithHashAccess.new(ViewConfig,
                                                    list: {},
@@ -166,6 +169,12 @@ module Blacklight
 
     # solr fields to use for sorting results
     define_field_access :sort_field
+
+    # solr fields to use in text message
+    define_field_access :sms_field
+
+    # solr fields to use in email message
+    define_field_access :email_field
 
     def initialize(hash = {})
       super(self.class.default_values.deep_dup.merge(hash))

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -501,6 +501,12 @@ RSpec.describe CatalogController, api: true do
     end
 
     describe "email", api: false do
+      let(:config) { Blacklight::Configuration.new }
+
+      before do
+        allow(controller).to receive(:blacklight_config).and_return(config)
+      end
+
       it "gives error if no TO parameter" do
         post :email, params: { id: doc_id }
         expect(request.flash[:error]).to eq "You must enter a recipient in order to send this message"
@@ -518,7 +524,7 @@ RSpec.describe CatalogController, api: true do
 
       it "redirects back to the record upon success" do
         allow(RecordMailer).to receive(:email_record)
-          .with(anything, { to: 'test_email@projectblacklight.org', message: 'xyz' }, hash_including(host: 'test.host'))
+          .with(anything, { to: 'test_email@projectblacklight.org', message: 'xyz', config: config }, hash_including(host: 'test.host'))
           .and_return double(deliver: nil)
         post :email, params: { id: doc_id, to: 'test_email@projectblacklight.org', message: 'xyz' }
         expect(request.flash[:error]).to be_nil
@@ -533,6 +539,12 @@ RSpec.describe CatalogController, api: true do
     end
 
     describe "sms", api: false do
+      let(:config) { Blacklight::Configuration.new }
+
+      before do
+        allow(controller).to receive(:blacklight_config).and_return(config)
+      end
+
       it "gives error if no phone number is given" do
         post :sms, params: { id: doc_id, carrier: 'att' }
         expect(request.flash[:error]).to eq "You must enter a recipient's phone number in order to send this message"
@@ -562,7 +574,7 @@ RSpec.describe CatalogController, api: true do
       it "sends to the appropriate carrier email address" do
         expect(RecordMailer)
           .to receive(:sms_record)
-          .with(anything, { to: '5555555555@txt.att.net' }, hash_including(host: 'test.host'))
+          .with(anything, { to: '5555555555@txt.att.net', config: config }, hash_including(host: 'test.host'))
           .and_return double(deliver: nil)
         post :sms, params: { id: doc_id, to: '5555555555', carrier: 'txt.att.net' }
       end

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -543,6 +543,98 @@ RSpec.describe "Blacklight::Configuration", api: true do
     end
   end
 
+  describe "add_sms_field" do
+    it "takes hash form" do
+      config.add_sms_field("title_tsim", label: "Title")
+
+      expect(config.sms_fields["title_tsim"]).not_to be_nil
+      expect(config.sms_fields["title_tsim"].label).to eq "Title"
+    end
+
+    it "takes ShowField argument" do
+      config.add_sms_field("title_tsim", Blacklight::Configuration::SmsField.new(field: "title_display", label: "Title"))
+
+      expect(config.sms_fields["title_tsim"]).not_to be_nil
+      expect(config.sms_fields["title_tsim"].label).to eq "Title"
+    end
+
+    it "takes block form" do
+      config.add_sms_field("title_tsim") do |f|
+        f.label = "Title"
+      end
+
+      expect(config.sms_fields["title_tsim"]).not_to be_nil
+      expect(config.sms_fields["title_tsim"].label).to eq "Title"
+    end
+
+    it "creates default label humanized from field" do
+      config.add_sms_field("my_custom_field")
+
+      expect(config.sms_fields["my_custom_field"].label).to eq "My Custom Field"
+    end
+
+    it "raises on nil solr field name" do
+      expect { config.add_sms_field(nil) }.to raise_error ArgumentError
+    end
+
+    it "takes wild-carded field names and dereference them to solr fields" do
+      allow(config).to receive(:reflected_fields).and_return(
+        "some_field_display" => {},
+        "another_field_display" => {},
+        "a_facet_field" => {}
+      )
+      config.add_sms_field "*_display"
+
+      expect(config.sms_fields.keys).to eq %w[some_field_display another_field_display]
+    end
+  end
+
+  describe "add_email_field" do
+    it "takes hash form" do
+      config.add_email_field("title_tsim", label: "Title")
+
+      expect(config.email_fields["title_tsim"]).not_to be_nil
+      expect(config.email_fields["title_tsim"].label).to eq "Title"
+    end
+
+    it "takes ShowField argument" do
+      config.add_email_field("title_tsim", Blacklight::Configuration::EmailField.new(field: "title_display", label: "Title"))
+
+      expect(config.email_fields["title_tsim"]).not_to be_nil
+      expect(config.email_fields["title_tsim"].label).to eq "Title"
+    end
+
+    it "takes block form" do
+      config.add_email_field("title_tsim") do |f|
+        f.label = "Title"
+      end
+
+      expect(config.email_fields["title_tsim"]).not_to be_nil
+      expect(config.email_fields["title_tsim"].label).to eq "Title"
+    end
+
+    it "creates default label humanized from field" do
+      config.add_email_field("my_custom_field")
+
+      expect(config.email_fields["my_custom_field"].label).to eq "My Custom Field"
+    end
+
+    it "raises on nil solr field name" do
+      expect { config.add_email_field(nil) }.to raise_error ArgumentError
+    end
+
+    it "takes wild-carded field names and dereference them to solr fields" do
+      allow(config).to receive(:reflected_fields).and_return(
+        "some_field_display" => {},
+        "another_field_display" => {},
+        "a_facet_field" => {}
+      )
+      config.add_email_field "*_display"
+
+      expect(config.email_fields.keys).to eq %w[some_field_display another_field_display]
+    end
+  end
+
   describe "#default_search_field" do
     it "uses the field with a :default key" do
       config.add_search_field('search_field_1')

--- a/spec/models/blacklight/document/email_spec.rb
+++ b/spec/models/blacklight/document/email_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe "Blacklight::Document::Email" do
+  let(:config) do
+    Blacklight::Configuration.new
+  end
+
   before(:all) do
     SolrDocument.use_extension(Blacklight::Document::Email)
   end
@@ -21,5 +25,33 @@ RSpec.describe "Blacklight::Document::Email" do
   it "returns nil if there are no valid field semantics to build the email body from" do
     doc = SolrDocument.new(id: "1234")
     expect(doc.to_email_text).to be_nil
+  end
+
+  context "we pass in configuration with email fields set" do
+    it "uses the email fields for to_email_text" do
+      config.add_email_field("foo", label: "Foo:")
+      config.add_email_field("bar", label: "Bar:")
+      doc = SolrDocument.new(id: "1234", foo: ["Fuzz Fuzz", "Fizz Fizz"], bar: ["Buzz Buzz", "Bizz Bizz"])
+
+      expect(doc.to_email_text(config)).to eq("Foo: Fuzz Fuzz Fizz Fizz\nBar: Buzz Buzz Bizz Bizz")
+    end
+  end
+
+  context "we pass in configuration with email fields no set" do
+    it "falls back on default semantics setup" do
+      doc = SolrDocument.new(id: "1234", title_tsim: ["My Title", "My Alt. Title"])
+      email_body = doc.to_email_text(config)
+      expect(email_body).to match(/Title: My Title/)
+    end
+  end
+
+  context "document field is single valued" do
+    it "handles the single value field correctly" do
+      config.add_email_field("foo", label: "Foo:")
+      config.add_email_field("bar", label: "Bar:")
+      doc = SolrDocument.new(id: "1234", foo: "Fuzz Fuzz", bar: ["Buzz Buzz", "Bizz Bizz"])
+
+      expect(doc.to_email_text(config)).to eq("Foo: Fuzz Fuzz\nBar: Buzz Buzz Bizz Bizz")
+    end
   end
 end

--- a/spec/models/blacklight/document/sms_spec.rb
+++ b/spec/models/blacklight/document/sms_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe "Blacklight::Document::Email" do
+  let(:config) do
+    Blacklight::Configuration.new
+  end
+
   before(:all) do
     SolrDocument.use_extension(Blacklight::Document::Sms)
   end
@@ -21,5 +25,34 @@ RSpec.describe "Blacklight::Document::Email" do
   it "returns nil if there are no valid field semantics to build the email body from" do
     doc = SolrDocument.new(id: "1234")
     expect(doc.to_sms_text).to be_nil
+  end
+
+  context "we pass in configuration with sms fields set" do
+    it "uses the sms fields for to_sms_text" do
+      config.add_sms_field("foo", label: "Foo:")
+      config.add_sms_field("bar", label: " by")
+      doc = SolrDocument.new(id: "1234", foo: ["Fuzz Fuzz", "Fizz Fizz"], bar: ["Buzz Buzz", "Bizz Bizz"])
+
+      expect(doc.to_sms_text(config)).to eq("Foo: Fuzz Fuzz by Buzz Buzz")
+    end
+  end
+
+  context "we pass in configuration with sms fields no set" do
+    it "falls back on default semantics setup" do
+      doc = SolrDocument.new(id: "1234", title_tsim: ["My Title", "My Alt. Title"])
+      sms_text = doc.to_sms_text(config)
+      expect(sms_text).to match(/My Title/)
+      expect(sms_text).not_to match(/My Alt\. Title/)
+    end
+  end
+
+  context "document field is single valued" do
+    it "handles the single value field correctly" do
+      config.add_sms_field("foo", label: "Foo:")
+      config.add_sms_field("bar", label: " by")
+      doc = SolrDocument.new(id: "1234", foo: "Fuzz Fuzz", bar: ["Buzz Buzz", "Bizz Bizz"])
+
+      expect(doc.to_sms_text(config)).to eq("Foo: Fuzz Fuzz by Buzz Buzz")
+    end
   end
 end


### PR DESCRIPTION
REF: projectblacklight/blacklight#1923

Adds a `add_email_field` and `add_sms_field` functionality.  If
configured will use that for the email and sms, otherwise it keeps
backwards compatibility with semantic fields and continues to use that.