### PR TITLE
Do not add facet limit unless it is known.

### DIFF
--- a/spec/components/blacklight/constraints_component_spec.rb
+++ b/spec/components/blacklight/constraints_component_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     it 'renders the query' do
       expect(rendered).to have_selector('.constraint-value > .filter-name', text: 'Facet').and(have_selector('.constraint-value > .filter-value', text: 'some value'))
     end
+
+    context 'that is not configured' do
+      let(:query_params) { { f: { facet: ['some value'], missing: ['another value'] } } }
+
+      it 'renders only the configured constraints' do
+        expect(rendered).to have_selector('.constraint-value > .filter-name', text: 'Facet').and(have_selector('.constraint-value > .filter-value', text: 'some value'))
+        expect(rendered).not_to have_selector('.constraint-value > .filter-name', text: 'Missing')
+      end
+    end
   end
 
   describe '.for_search_history' do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -115,9 +115,4 @@ RSpec.describe "Search Page" do
     expect(page).to have_content "Welcome!"
     expect(page).not_to have_selector "#q[value='history']"
   end
-
-  it "sanitizes searches with unconfigured facet parameters" do
-    visit root_path f: { missing_s: [1] }
-    expect(page).not_to have_text "Missing S"
-  end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -115,4 +115,9 @@ RSpec.describe "Search Page" do
     expect(page).to have_content "Welcome!"
     expect(page).not_to have_selector "#q[value='history']"
   end
+
+  it "sanitizes searches with unconfigured facet parameters" do
+    visit root_path f: { missing_s: [1] }
+    expect(page).not_to have_text "Missing S"
+  end
 end

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -572,6 +572,17 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
 
       expect(solr_parameters[:fq]).to be_a_kind_of Array
     end
+
+    context "facet not defined in config" do
+      let(:single_facet) { { unknown_facet_field: "foo" } }
+      let(:user_params) { { f: single_facet } }
+
+      it "does not add facet to solr_parameters" do
+        solr_parameters = Blacklight::Solr::Request.new
+        subject.add_facet_fq_to_solr(solr_parameters)
+        expect(solr_parameters[:fq]).to be_blank
+      end
+    end
   end
 
   describe "#add_solr_fields_to_query" do


### PR DESCRIPTION
REF: #1990 

This commit updates the code that adds facet limits from user supplied
parameters so that facets are only added if they have been configured
as facet fields.  This is done to allow for multiple faceted searches to
be defined in the same URL while still keeping the facets separate.