### PR TITLE
Make solr generator bundle install it's gems

### DIFF
--- a/lib/generators/blacklight/solr_generator.rb
+++ b/lib/generators/blacklight/solr_generator.rb
@@ -33,5 +33,11 @@ module Blacklight
     def add_rsolr_gem
       gem 'rsolr', '>= 1.0', '< 3'
     end
+
+    def bundle_install
+      Bundler.with_clean_env do
+        run "bundle install"
+      end
+    end
   end
 end


### PR DESCRIPTION
blacklight-marc builds on Travis were failing because after calling the `add_solr_wrapper` task, which adds rsolr to the gemfile, it immediately calls `copy_public_assets` which sends the message that rsolr cannot be found, silently fails to run any blacklight:assets generator tasks, and continues on to the next generator task.

This change forces the solr generator to bundle install all gems it has added.