### PR TITLE
 Deprecate unnecessary conditions 

### DIFF
--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -12,14 +12,21 @@ module Blacklight::UrlHelperBehavior
   # so we only need the +counter+ param here. We also need to know if we are viewing to document as part of search results.
   # TODO: move this to the IndexPresenter
   def link_to_document(doc, field_or_opts = nil, opts = { counter: nil })
-    if field_or_opts.is_a? Hash
-      opts = field_or_opts
-    else
-      field = field_or_opts
-    end
+    label = case field_or_opts
+            when NilClass
+              index_presenter(doc).label document_show_link_field(doc), opts
+            when Hash
+              opts = field_or_opts
+              index_presenter(doc).label document_show_link_field(doc), opts
+            when Proc, Symbol
+              Deprecation.warn(self, "passing a #{field_or_opts.class} to link_to_document is deprecated and will be removed in Blacklight 8")
+              Deprecation.silence(Blacklight::IndexPresenter) do
+                index_presenter(doc).label field_or_opts, opts
+              end
+            else # String
+              field_or_opts
+            end
 
-    field ||= document_show_link_field(doc)
-    label = index_presenter(doc).label field, opts
     link_to label, url_for_document(doc), document_link_params(doc, opts)
   end
 

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -29,8 +29,12 @@ module Blacklight
                   config = field_config(field_or_string_or_proc)
                   document[field_or_string_or_proc]
                 when Proc
+                  Deprecation.warn(self, "calling IndexPresenter.label with a Proc is deprecated. " \
+                                         "First argument must be a symbol. This will be removed in Blacklight 8")
                   field_or_string_or_proc.call(document, opts)
                 when String
+                  Deprecation.warn(self, "calling IndexPresenter.label with a String is deprecated. " \
+                                         "First argument must be a symbol. This will be removed in Blacklight 8")
                   field_or_string_or_proc
               end
 

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -15,7 +15,7 @@
         <%= t('blacklight.search.documents.counter', counter: counter) %>
       </span>
     <% end %>
-    <%= link_to_document document, document_show_link_field(document), counter: counter %>
+    <%= link_to_document document, counter: counter %>
   </h3>
 
   <%= document_actions %>

--- a/app/views/catalog/_show_more_like_this.html.erb
+++ b/app/views/catalog/_show_more_like_this.html.erb
@@ -1,3 +1,3 @@
 <li class="more_like_this_document">
-  <span class="mlt_title"><%= link_to_document document, document_show_link_field(document) %></span>
+  <span class="mlt_title"><%= link_to_document document %></span>
 </li>

--- a/spec/helpers/blacklight/url_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/url_helper_behavior_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "consists of the document title wrapped in a <a>" do
+      expect(Deprecation).to receive(:warn)
       expect(helper.link_to_document(document, :title_tsim)).to have_selector("a", text: '654321', count: 1)
     end
 
@@ -212,6 +213,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "accepts and returns a Proc" do
+      expect(Deprecation).to receive(:warn).twice
       expect(helper.link_to_document(document, proc { |doc, _opts| doc[:id] + ": " + doc.first(:title_tsim) })).to have_selector("a", text: '123456: 654321', count: 1)
     end
 
@@ -219,10 +221,12 @@ RSpec.describe Blacklight::UrlHelperBehavior do
       let(:data) { { 'id' => id } }
 
       it "returns id" do
+        expect(Deprecation).to receive(:warn)
         expect(helper.link_to_document(document, :title_tsim)).to have_selector("a", text: '123456', count: 1)
       end
 
       it "is html safe" do
+        expect(Deprecation).to receive(:warn)
         expect(helper.link_to_document(document, :title_tsim)).to be_html_safe
       end
 
@@ -245,7 +249,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
 
     it "converts the counter parameter into a data- attribute" do
       allow(helper).to receive(:track_test_path).with(hash_including(id: have_attributes(id: '123456'), counter: 5)).and_return('tracking url')
-
+      expect(Deprecation).to receive(:warn)
       expect(helper.link_to_document(document, :title_tsim, counter: 5)).to include 'data-context-href="tracking url"'
     end
 


### PR DESCRIPTION
This makes the code easier to trace.

The Proc parameter was introduced way back in https://github.com/projectblacklight/blacklight/commit/9f1b79aac6fe5d0364954f606cf0df87f14bb4b3#diff-d60c901f4d059652ee1ba78a44e7fc11R260 and I don't think its still necessary to maintain it.

Depends on #1998