### PR TITLE
Remove deprecated Solr StandardFilter

### DIFF
--- a/lib/generators/blacklight/templates/solr/conf/schema.xml
+++ b/lib/generators/blacklight/templates/solr/conf/schema.xml
@@ -350,7 +350,6 @@
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
@@ -359,7 +358,6 @@
     <fieldType  name="textSuggest" class="solr.TextField" positionIncrementGap="100">
        <analyzer>
           <tokenizer class="solr.KeywordTokenizerFactory"/>
-          <filter class="solr.StandardFilterFactory"/>
           <filter class="solr.LowerCaseFilterFactory"/>
           <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
        </analyzer>


### PR DESCRIPTION
This filter is deprecated and according to the solr docs it is
inoperative if "luceneMatchVersion (in solrconfig.xml) is higher than
3.1."  The luceneMatchVersion in blacklight is currently 6.1.0

See https://lucene.apache.org/solr/guide/7_0/filter-descriptions.html#FilterDescriptions-StandardFilter

Fixes #2015 