### PR TITLE
Use the fully qualified class name

### DIFF
--- a/app/controllers/concerns/blacklight/controller.rb
+++ b/app/controllers/concerns/blacklight/controller.rb
@@ -95,7 +95,7 @@ module Blacklight::Controller
 
   # Returns a list of Searches from the ids in the user's history.
   def searches_from_history
-    session[:history].blank? ? Search.none : Search.where(id: session[:history]).order("updated_at desc")
+    session[:history].blank? ? ::Search.none : ::Search.where(id: session[:history]).order("updated_at desc")
   end
 
   # Should be provided by authentication provider


### PR DESCRIPTION
Because sometimes Rails is too helpful and creates `Blacklight::Search`
even when you haven't declared that module in Ruby.

Ref: https://github.com/rails/rails/issues/34397
Fixes #2025 