### PR TITLE
Remove unnecessary route

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -356,7 +356,7 @@ RSpec/MessageChain:
 # Configuration parameters: .
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:
-  EnforcedStyle: receive
+  Enabled: false
 
 # Offense count: 339
 # Configuration parameters: AggregateFailuresByDefault.

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -81,13 +81,14 @@ module Blacklight::UrlHelperBehavior
   ##
   # Get the URL for tracking search sessions across pages using polymorphic routing
   def session_tracking_path document, params = {}
-    return if document.nil?
+    return if document.nil? || controller_name == 'bookmarks'
 
-    if respond_to?(controller_tracking_method)
-      send(controller_tracking_method, params.merge(id: document))
-    else
-      blacklight.track_search_context_path(params.merge(id: document))
+    if main_app.respond_to?(controller_tracking_method)
+      return main_app.public_send(controller_tracking_method, params.merge(id: document))
     end
+
+    raise "Unable to find #{controller_tracking_method} route helper. " \
+    "Did you add `concerns :searchable` routing mixin to your `config/routes.rb`?"
   end
 
   def controller_tracking_method

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,4 @@
 Blacklight::Engine.routes.draw do
   get "search_history",             to: "search_history#index",   as: "search_history"
   delete "search_history/clear",       to: "search_history#clear",   as: "clear_search_history"
-  post "/catalog/:id/track", to: 'catalog#track', as: 'track_search_context'
 end

--- a/spec/helpers/blacklight/url_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/url_helper_behavior_spec.rb
@@ -201,6 +201,8 @@ RSpec.describe Blacklight::UrlHelperBehavior do
 
     before do
       allow(controller).to receive(:action_name).and_return('index')
+      allow(helper.main_app).to receive(:track_test_path).and_return('tracking url')
+      allow(helper.main_app).to receive(:respond_to?).with('track_test_path').and_return(true)
     end
 
     it "consists of the document title wrapped in a <a>" do
@@ -248,9 +250,9 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "converts the counter parameter into a data- attribute" do
-      allow(helper).to receive(:track_test_path).with(hash_including(id: have_attributes(id: '123456'), counter: 5)).and_return('tracking url')
       expect(Deprecation).to receive(:warn)
       expect(helper.link_to_document(document, :title_tsim, counter: 5)).to include 'data-context-href="tracking url"'
+      expect(helper.main_app).to have_received(:track_test_path).with(hash_including(id: have_attributes(id: '123456'), counter: 5))
     end
 
     it "includes the data- attributes from the options" do
@@ -259,15 +261,10 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it 'adds a controller-specific tracking attribute' do
-      expect(helper).to receive(:track_test_path).and_return('/asdf')
+      expect(helper.main_app).to receive(:track_test_path).and_return('/asdf')
       link = helper.link_to_document document, data: { x: 1 }
 
       expect(link).to have_selector '[data-context-href="/asdf"]'
-    end
-
-    it 'adds a global tracking attribute' do
-      link = helper.link_to_document document, data: { x: 1 }
-      expect(link).to have_selector '[data-context-href="/catalog/123456/track"]'
     end
   end
 
@@ -292,12 +289,12 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     let(:document) { SolrDocument.new(id: 1) }
 
     it "determines the correct route for the document class" do
-      allow(helper).to receive(:track_test_path).with(id: have_attributes(id: 1)).and_return('x')
+      allow(helper.main_app).to receive(:track_test_path).with(id: have_attributes(id: 1)).and_return('x')
       expect(helper.session_tracking_path(document)).to eq 'x'
     end
 
     it "passes through tracking parameters" do
-      allow(helper).to receive(:track_test_path).with(id: have_attributes(id: 1), x: 1).and_return('x')
+      allow(helper.main_app).to receive(:track_test_path).with(id: have_attributes(id: 1), x: 1).and_return('x')
       expect(helper.session_tracking_path(document, x: 1)).to eq 'x'
     end
   end

--- a/spec/views/catalog/_index_header.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header.html.erb_spec.rb
@@ -8,12 +8,10 @@ RSpec.describe "catalog/_index_header" do
   let(:blacklight_config) { Blacklight::Configuration.new }
 
   before do
-    allow(controller).to receive(:action_name).and_return('index')
     assign :response, instance_double(Blacklight::Solr::Response, start: 0)
     allow(view).to receive(:render_grouped_response?).and_return false
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
-    allow(view).to receive(:current_search_session).and_return nil
-    allow(view).to receive(:search_session).and_return({})
+    allow(view).to receive(:session_tracking_params).and_return({})
   end
 
   it "renders the document header" do

--- a/spec/views/catalog/_show_sidebar.erb_spec.rb
+++ b/spec/views/catalog/_show_sidebar.erb_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe "/catalog/_show_sidebar.html.erb" do
   end
 
   before do
-    allow(controller).to receive(:action_name).and_return('show')
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     allow(view).to receive(:has_user_authentication_provider?).and_return(false)
-    allow(view).to receive(:current_search_session).and_return nil
-    allow(view).to receive(:search_session).and_return({})
     allow(view).to receive(:document_actions).and_return([])
+    allow(view).to receive(:session_tracking_params).and_return({})
   end
 
   it "shows more-like-this titles in the sidebar" do

--- a/spec/views/catalog/_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail.html.erb_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "catalog/_thumbnail" do
     assign :response, instance_double(Blacklight::Solr::Response, start: 0)
     allow(view).to receive(:render_grouped_response?).and_return false
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
-    allow(view).to receive(:current_search_session).and_return nil
-    allow(view).to receive(:search_session).and_return({})
+    allow(view).to receive(:session_tracking_params).and_return({})
   end
 
   it "renders the thumbnail if the document has one" do


### PR DESCRIPTION
This was already defined by `lib/blacklight/routes/searchable.rb`

This is an alternative to #2005.