### PR TITLE
Remove TEST_JETTY_PORT variable from blacklight.yml

### DIFF
--- a/lib/generators/blacklight/templates/config/blacklight.yml
+++ b/lib/generators/blacklight/templates/config/blacklight.yml
@@ -1,21 +1,9 @@
-# = jetty_path key
-# each environment can have a jetty_path with absolute or relative
-# (to app root) path to a jetty/solr install. This is used
-# by the rake tasks that start up solr automatically for testing
-# and by rake solr:marc:index.  
-#
-# jetty_path is not used by a running Blacklight application
-# at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
-# however you want.  
-# jetty_path is only required for rake tasks that need to know
-# how to start up solr, generally for automated testing. 
-
 development:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>


### PR DESCRIPTION
This is not something we use in Blacklight and can easily be set in an application that uses blacklight if needed.

Also removed old comments about jetty_path, a configuration option that was removed long ago.