### PR TITLE
Remove document.id fallback from document_show_link_field helper; it …

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -163,7 +163,6 @@ module Blacklight::ConfigurationHelperBehavior
     field = fields.first if document.nil?
     field ||= fields.find { |f| document.has? f }
     field &&= field.try(:to_sym)
-    field ||= document.id
 
     field
   end

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -114,12 +114,6 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
       f = helper.document_show_link_field document
       expect(f).to eq :b
     end
-
-    it "fallbacks on the id" do
-      blacklight_config.index.title_field = [:zzz, :yyy]
-      f = helper.document_show_link_field document
-      expect(f).to eq 123
-    end
   end
 
   describe "#view_label" do


### PR DESCRIPTION
…was always weird and never worked the way one might expect.

The expected fallback behavior (when rendering titles, fall back to id) is already covered in the `Presenter#label` anyway.