### PR TITLE
There's no need for us to update rubygems and bundler at this time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
   fast_finish: true
 
 before_install:
-  - gem update --system
-  - gem install bundler
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
 notifications:


### PR DESCRIPTION
Revert https://github.com/projectblacklight/blacklight/commit/df554de8a94e1727f948d64f8716dfcc1fcc62bc
and https://github.com/projectblacklight/blacklight/commit/cc7d5f538520f62cf05dc6ef63a54d66eb470161