### PR TITLE
Move `User#to_s` from generator to `Blacklight::User`

### DIFF
--- a/app/models/concerns/blacklight/user.rb
+++ b/app/models/concerns/blacklight/user.rb
@@ -5,6 +5,8 @@ module Blacklight::User
   # SEE ALSO:  The lib/blacklight/generator/user_generator.rb class for where this
   # is generated into the hosting application.
   included do
+    class_attribute :string_display_key
+
     has_many :bookmarks, dependent: :destroy, as: :user
     has_many :searches,  dependent: :destroy, as: :user
   end
@@ -34,17 +36,5 @@ module Blacklight::User
     return send(string_display_key) if respond_to?(string_display_key)
 
     super
-  end
-
-  module ClassMethods
-    def string_display_key(attr_name = nil)
-      return @string_display_key if attr_name.blank?
-
-      @string_display_key = attr_name
-    end
-
-    def string_display_key_unless(attr_name)
-      @string_display_key || string_display_key(attr_name)
-    end
   end
 end

--- a/app/models/concerns/blacklight/user.rb
+++ b/app/models/concerns/blacklight/user.rb
@@ -26,4 +26,10 @@ module Blacklight::User
   def existing_bookmark_for(document)
     bookmarks_for_documents([document]).first
   end
+
+  ##
+  # @return [String] a user-displayable login/identifier for the user account
+  def to_s
+    email
+  end
 end

--- a/app/models/concerns/blacklight/user.rb
+++ b/app/models/concerns/blacklight/user.rb
@@ -30,8 +30,21 @@ module Blacklight::User
   ##
   # @return [String] a user-displayable login/identifier for the user account
   def to_s
-    return email if respond_to?(:email)
+    string_display_key = self.class.string_display_key
+    return send(string_display_key) if respond_to?(string_display_key)
 
     super
+  end
+
+  module ClassMethods
+    def string_display_key(attr_name = nil)
+      return @string_display_key if attr_name.blank?
+
+      @string_display_key = attr_name
+    end
+
+    def string_display_key_unless(attr_name)
+      @string_display_key || string_display_key(attr_name)
+    end
   end
 end

--- a/app/models/concerns/blacklight/user.rb
+++ b/app/models/concerns/blacklight/user.rb
@@ -30,6 +30,8 @@ module Blacklight::User
   ##
   # @return [String] a user-displayable login/identifier for the user account
   def to_s
-    email
+    return email if respond_to?(:email)
+
+    super
   end
 end

--- a/lib/generators/blacklight/user_generator.rb
+++ b/lib/generators/blacklight/user_generator.rb
@@ -34,6 +34,13 @@ module Blacklight
       generate "devise", model_name.classify
       generate "devise_guests", model_name.classify
 
+      # add the #to_s to the model.
+      insert_into_file("app/models/#{model_name}.rb", before: /end(\n| )*$/) do
+        "\n  # Configuration added by Blacklight; Blacklight::User uses a method key on your\n" \
+          "  # user class to get a user-displayable login/identifier for\n" \
+          "  # the account.\n" \
+          "  string_display_key_unless(:email)\n"
+      end
       gsub_file("config/initializers/devise.rb", "config.sign_out_via = :delete", "config.sign_out_via = :get")
     end
 

--- a/lib/generators/blacklight/user_generator.rb
+++ b/lib/generators/blacklight/user_generator.rb
@@ -34,15 +34,6 @@ module Blacklight
       generate "devise", model_name.classify
       generate "devise_guests", model_name.classify
 
-      # add the #to_s to the model.
-      insert_into_file("app/models/#{model_name}.rb", before: /end(\n| )*$/) do
-        "\n  # Method added by Blacklight; Blacklight uses #to_s on your\n" \
-          "  # user class to get a user-displayable login/identifier for\n" \
-          "  # the account.\n" \
-          "  def to_s\n" \
-          "    email\n" \
-          "  end\n"
-      end
       gsub_file("config/initializers/devise.rb", "config.sign_out_via = :delete", "config.sign_out_via = :get")
     end
 

--- a/lib/generators/blacklight/user_generator.rb
+++ b/lib/generators/blacklight/user_generator.rb
@@ -39,7 +39,7 @@ module Blacklight
         "\n  # Configuration added by Blacklight; Blacklight::User uses a method key on your\n" \
           "  # user class to get a user-displayable login/identifier for\n" \
           "  # the account.\n" \
-          "  string_display_key_unless(:email)\n"
+          "  self.string_display_key = :email unless string_display_key?\n"
       end
       gsub_file("config/initializers/devise.rb", "config.sign_out_via = :delete", "config.sign_out_via = :get")
     end

--- a/lib/generators/blacklight/user_generator.rb
+++ b/lib/generators/blacklight/user_generator.rb
@@ -39,7 +39,7 @@ module Blacklight
         "\n  # Configuration added by Blacklight; Blacklight::User uses a method key on your\n" \
           "  # user class to get a user-displayable login/identifier for\n" \
           "  # the account.\n" \
-          "  self.string_display_key = :email unless string_display_key?\n"
+          "  self.string_display_key ||= :email\n"
       end
       gsub_file("config/initializers/devise.rb", "config.sign_out_via = :delete", "config.sign_out_via = :get")
     end

--- a/spec/models/blacklight/user_spec.rb
+++ b/spec/models/blacklight/user_spec.rb
@@ -50,5 +50,20 @@ RSpec.describe "Blacklight::User", api: true do
     it 'is the email by default' do
       expect(subject.to_s).to eq subject.email
     end
+
+    context 'when no email method is provided' do
+      before do
+        @old_method = subject.class.instance_method(:email)
+        subject.class.send(:undef_method, :email)
+      end
+
+      after do
+        subject.class.send(:define_method, :email, @old_method)
+      end
+
+      it 'still provides a string' do
+        expect(subject.to_s).to be_a String
+      end
+    end
   end
 end

--- a/spec/models/blacklight/user_spec.rb
+++ b/spec/models/blacklight/user_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe "Blacklight::User", api: true do
       expect(subject.existing_bookmark_for(SolrDocument.new(id: 1))).to eq subject.bookmarks.first
     end
   end
+
+  describe '#to_s' do
+    it 'is the email by default' do
+      expect(subject.to_s).to eq subject.email
+    end
+  end
 end

--- a/spec/models/blacklight/user_spec.rb
+++ b/spec/models/blacklight/user_spec.rb
@@ -52,13 +52,14 @@ RSpec.describe "Blacklight::User", api: true do
     end
 
     context 'when no email method is provided' do
+      let(:old_method) { subject.class.instance_method(:email) }
+
       before do
-        @old_method = subject.class.instance_method(:email)
-        subject.class.send(:undef_method, :email)
+        subject.class.send(:undef_method, old_method.name)
       end
 
       after do
-        subject.class.send(:define_method, :email, @old_method)
+        subject.class.send(:define_method, old_method.name, old_method)
       end
 
       it 'still provides a string' do


### PR DESCRIPTION
This method had been injected directly into the application's `User`, but inheritance seems like the stronger approach.