### PR TITLE
Add merge_facet method to include in solr response.

### DIFF
--- a/lib/blacklight/solr/response/facets.rb
+++ b/lib/blacklight/solr/response/facets.rb
@@ -120,6 +120,15 @@ module Blacklight::Solr::Response::Facets
     @facet_pivot ||= facet_counts['facet_pivot'] || {}
   end
 
+  # Merge or add new facet count values to existing response
+  def merge_facet(name:, value:, hits: nil)
+    if dig('facet_counts', 'facet_fields', name)
+      self['facet_counts']['facet_fields'][name] << value << hits
+    else
+      self['facet_counts']['facet_fields'][name] = [value, hits]
+    end
+  end
+
   private
 
   ##

--- a/spec/models/blacklight/solr/response/facets_spec.rb
+++ b/spec/models/blacklight/solr/response/facets_spec.rb
@@ -104,6 +104,43 @@ RSpec.describe Blacklight::Solr::Response::Facets, api: true do
     end
   end
 
+  describe "#merge_facet" do
+    let(:response) { Blacklight::Solr::Response.new(facet_counts, {}, {}) }
+    let(:facet) { { name: "foo", value: "bar", hits: 1 } }
+
+    before do
+      response.merge_facet(facet)
+    end
+
+    context "facet does not already exist" do
+      it "adds the facet and appends the new field name and value" do
+        expect(response.facet_fields["foo"]).to eq(["bar", 1])
+      end
+    end
+
+    context "facet exists but field does not exist" do
+      let(:facet) { { name: "cat", value: "bar", hits: 1 } }
+
+      it "appends the new field name and value" do
+        expect(response.facet_fields["cat"]).to eq(["memory", 3, "card", 2, "bar", 1])
+      end
+    end
+
+    context "facet exists and field exists" do
+      let(:facet) { { name: "cat", value: "memory", hits: 4 } }
+
+      it "appends the new field name and value and aggregations uses new value" do
+        expect(response.aggregations["cat"].items.count).to eq(2)
+        expect(response.aggregations["cat"].items.first.value).to eq("memory")
+        expect(response.aggregations["cat"].items.first.hits).to eq(4)
+      end
+    end
+
+    def facet_counts
+      { "facet_counts" => { "facet_fields" => { "cat" => ["memory", 3, "card", 2] } } }
+    end
+  end
+
   context "facet.missing" do
     subject { Blacklight::Solr::Response.new(response, {}) }
 


### PR DESCRIPTION
This commit adds the method `merge_facet` which comes in handy when
creating a federated facets that merges results from multiple sources.

This seems to be a missing method since it is already possible to add
a :url_method for configuring facet fields, which suggest it's already
possible to potentially federate a facet field.