### PR TITLE
Add explicit configuration to enable search session tracking

### DIFF
--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -14,6 +14,7 @@ module Blacklight::Bookmarks
 
     before_action :verify_user
 
+    blacklight_config.track_search_session = false
     blacklight_config.http_method = Blacklight::Engine.config.bookmarks_http_method
     blacklight_config.add_results_collection_tool(:clear_bookmarks_widget)
 

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -81,7 +81,7 @@ module Blacklight::UrlHelperBehavior
   ##
   # Get the URL for tracking search sessions across pages using polymorphic routing
   def session_tracking_path document, params = {}
-    return if document.nil? || controller_name == 'bookmarks'
+    return if document.nil? || !blacklight_config&.track_search_session
 
     if main_app.respond_to?(controller_tracking_method)
       return main_app.public_send(controller_tracking_method, params.merge(id: document))

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -126,7 +126,8 @@ module Blacklight
           # ex.: crawler_detector: lambda { |req| req.env['HTTP_USER_AGENT'] =~ /bot/ }
           crawler_detector: nil,
           autocomplete_suggester: 'mySuggester',
-          raw_endpoint: OpenStructWithHashAccess.new(enabled: false)
+          raw_endpoint: OpenStructWithHashAccess.new(enabled: false),
+          track_search_session: true
           }
         end
         # rubocop:enable Metrics/MethodLength

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe BookmarksController do
     it 'uses POST requests for querying solr' do
       expect(@controller.blacklight_config.http_method).to eq :post
     end
+
+    it 'opts out of search session tracking' do
+      expect(@controller.blacklight_config.track_search_session).to eq false
+    end
   end
 
   # jquery 1.9 ajax does error callback if 200 returns empty body. so use 204 instead.

--- a/spec/helpers/blacklight/url_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/url_helper_behavior_spec.rb
@@ -297,5 +297,10 @@ RSpec.describe Blacklight::UrlHelperBehavior do
       allow(helper.main_app).to receive(:track_test_path).with(id: have_attributes(id: 1), x: 1).and_return('x')
       expect(helper.session_tracking_path(document, x: 1)).to eq 'x'
     end
+
+    it "uses the track_search_session configuration to determine whether to track the search session" do
+      blacklight_config.track_search_session = false
+      expect(helper.session_tracking_path(document, x: 1)).to eq nil
+    end
   end
 end


### PR DESCRIPTION
Blacklight 7 raises an error when the tracking routes are not available (previously, session tracking was just not used); this is a little closer to the previous behavior.