### PR TITLE
Pass the context through to the search service to restore function…

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -4,6 +4,7 @@ module Blacklight::Catalog
 
   include Blacklight::Base
   include Blacklight::Facet
+  include Blacklight::Searchable
 
   # The following code is executed when someone includes blacklight::catalog in their
   # own controller.
@@ -164,14 +165,6 @@ module Blacklight::Catalog
     sms_mappings.present?
   end
 
-  def search_service
-    search_service_class.new(config: blacklight_config, user_params: search_state.to_h, context: search_service_context)
-  end
-
-  def search_service_context
-    {}
-  end
-
   ##
   # If the params specify a view, then store it in the session. If the params
   # do not specifiy the view, set the view parameter to the value stored in the
@@ -297,10 +290,6 @@ module Blacklight::Catalog
 
   def start_new_search_session?
     action_name == "index"
-  end
-
-  def suggestions_service
-    Blacklight::SuggestSearch.new(params, search_service.repository).suggestions
   end
 
   def determine_layout

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -165,7 +165,11 @@ module Blacklight::Catalog
   end
 
   def search_service
-    search_service_class.new(config: blacklight_config, user_params: search_state.to_h)
+    search_service_class.new(config: blacklight_config, user_params: search_state.to_h, context: search_service_context)
+  end
+
+  def search_service_context
+    {}
   end
 
   ##

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Blacklight::Searchable
+  # @return [Blacklight::SearchService]
+  def search_service
+    search_service_class.new(config: blacklight_config, user_params: search_state.to_h, **search_service_context)
+  end
+
+  # @return [Hash] a hash of context information to pass through to the search service
+  def search_service_context
+    {}
+  end
+
+  # @return [Blacklight::SuggestSearch]
+  def suggestions_service
+    Blacklight::SuggestSearch.new(params, search_service.repository).suggestions
+  end
+end

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -2,14 +2,15 @@
 # SearchService returns search results from the repository
 module Blacklight
   class SearchService
-    def initialize(config:, user_params: {}, search_builder_class: config.search_builder_class)
+    def initialize(config:, user_params: {}, search_builder_class: config.search_builder_class, context: {})
       @blacklight_config = config
       @user_params = user_params
       @search_builder_class = search_builder_class
+      @context = context
     end
 
-    # The blacklight_config is accessed by the search_builder
-    attr_reader :blacklight_config
+    # The blacklight_config + controller are accessed by the search_builder
+    attr_reader :blacklight_config, :context
 
     def search_builder
       search_builder_class.new(self)

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -2,7 +2,7 @@
 # SearchService returns search results from the repository
 module Blacklight
   class SearchService
-    def initialize(config:, user_params: {}, search_builder_class: config.search_builder_class, context: {})
+    def initialize(config:, user_params: {}, search_builder_class: config.search_builder_class, **context)
       @blacklight_config = config
       @user_params = user_params
       @search_builder_class = search_builder_class

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -11,7 +11,8 @@
 RSpec.describe Blacklight::SearchService, api: true do
   subject { service }
 
-  let(:service) { described_class.new(config: blacklight_config, user_params: user_params) }
+  let(:context) { { whatever: :value } }
+  let(:service) { described_class.new(config: blacklight_config, user_params: user_params, **context) }
   let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
   let(:user_params) { {} }
 
@@ -483,6 +484,12 @@ RSpec.describe Blacklight::SearchService, api: true do
 
     it 'contains the search suggestions as the second element in the response' do
       expect(service.opensearch_response.last).to match_array %w[A B C]
+    end
+  end
+
+  describe '#context' do
+    it 'has a context attribute' do
+      expect(subject.context).to eq context
     end
   end
 end


### PR DESCRIPTION
…al compatibility with Blacklight 7.

Some uses of search builders expect access to controller methods (e.g. current user, `can?` from cancan, etc). Instead of making consumers always override the search service, we can provide the context from the controller as a convenience. 