### PR TITLE
Encapsulate the blacklight config

### DIFF
--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -16,7 +16,7 @@ module Blacklight::Bookmarks
     before_action :verify_user
 
     blacklight_config.track_search_session = false
-    blacklight_config.http_method = Blacklight::Engine.config.bookmarks_http_method
+    blacklight_config.http_method = Blacklight::Engine.config.blacklight.bookmarks_http_method
     blacklight_config.add_results_collection_tool(:clear_bookmarks_widget)
 
     blacklight_config.show.document_actions[:bookmark].if = false if blacklight_config.show.document_actions[:bookmark]

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -257,13 +257,13 @@ module Blacklight::Catalog
   end
 
   def sms_mappings
-    Blacklight::Engine.config.sms_mappings
+    Blacklight::Engine.config.blacklight.sms_mappings
   end
 
   def validate_email_params
     if params[:to].blank?
       flash[:error] = I18n.t('blacklight.email.errors.to.blank')
-    elsif !params[:to].match(Blacklight::Engine.config.email_regexp)
+    elsif !params[:to].match(Blacklight::Engine.config.blacklight.email_regexp)
       flash[:error] = I18n.t('blacklight.email.errors.to.invalid', to: params[:to])
     end
 

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -30,7 +30,9 @@ module Blacklight
       end
     end
 
-    Blacklight::Engine.config.sms_mappings = {
+    bl_global_config = OpenStruct.new
+
+    bl_global_config.sms_mappings = {
       'Virgin' => 'vmobl.com',
       'AT&T' => 'txt.att.net',
       'Verizon' => 'vtext.com',
@@ -42,9 +44,14 @@ module Blacklight
       'Google Fi' => 'msg.fi.google.com'
     }
 
-    config.bookmarks_http_method = :post
+    bl_global_config.bookmarks_http_method = :post
 
-    config.email_regexp = defined?(Devise) ? Devise.email_regexp : /\A[^@\s]+@[^@\s]+\z/
+    bl_global_config.email_regexp = defined?(Devise) ? Devise.email_regexp : /\A[^@\s]+@[^@\s]+\z/
+
+    # Anything that goes into Blacklight::Engine.config is stored as a class
+    # variable on Railtie::Configuration.  we're going to encapsulate all the
+    # Blacklight specific stuff in this single struct:
+    Blacklight::Engine.config.blacklight = bl_global_config
 
     config.action_dispatch.rescue_responses["Blacklight::Exceptions::RecordNotFound"] = :not_found
 

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -30,7 +30,7 @@ module Blacklight
       end
     end
 
-    bl_global_config = OpenStruct.new
+    bl_global_config = OpenStructWithHashAccess.new
 
     bl_global_config.sms_mappings = {
       'Virgin' => 'vmobl.com',


### PR DESCRIPTION
All values set on Blacklight::Engine.config are actually stored
in a class variable on Railtie::Configuration. So these pollute
that namespace.  All other railties are encapsulating their configs
onto a single entry in that scope.  This change makes Blacklight do
likewise.

This probably needs to be a major revision