### PR TITLE
Fix a field name for author in the example schema

### DIFF
--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -48,7 +48,7 @@
           alternative_title_tsim
           active_fedora_model_ssi
           title_tsim
-          author_tsimesim
+          author_tsim
           subject_tsim
           all_text_timv
         </str>


### PR DESCRIPTION
The current value is not a dynamic field and causes an error in Solr 8