### PR TITLE
No need to generate popper_js into Gemfile

### DIFF
--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -6,7 +6,6 @@ module Blacklight
     # This could be skipped if you want to use webpacker
     def add_javascript_dependencies
       gem 'bootstrap', '~> 4.0'
-      gem 'popper_js'
       gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
     end
 


### PR DESCRIPTION
It's already a dependency of Blacklight 4.x, no need for it to be in top-level Gemfile.
https://rubygems.org/gems/bootstrap/versions/4.0.0
https://rubygems.org/gems/bootstrap/versions/4.3.1