### PR TITLE
Use bg-light

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -11,7 +11,7 @@
   </div>
 </nav>
 
-<div class="navbar-search navbar navbar-light bg-faded" role="navigation">
+<div class="navbar-search navbar navbar-light bg-light" role="navigation">
   <div class="<%= container_classes %>">
     <%= render_search_bar  %>
   </div>


### PR DESCRIPTION
Change needed for Twitter Bootstrap 4, `bg-faded`(`#f7f7f7`) is deprecated in favor of `bg-light` (`#f8f9fa`). Subtle difference in color. Looks like `bg-faded` was there in TB4 alpha, but removed at some point.