### PR TITLE
Use webdrivers in place of chromedriver-helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
   fast_finish: true
 
 before_install:
-  - gem install chromedriver-helper --no-document
-  - chromedriver-update 73.0.3683.68
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
 notifications:

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency "capybara", '~> 3'
-  s.add_development_dependency 'chromedriver-helper', '~> 2.1'
+  s.add_development_dependency 'webdrivers', '~> 3.0'
   s.add_development_dependency "selenium-webdriver", '>= 3.13.1'
   s.add_development_dependency 'engine_cart', '~> 2.1'
   s.add_development_dependency "equivalent-xml"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/collection_matchers'
 require 'capybara/rspec'
 require 'selenium-webdriver'
 require 'equivalent-xml'
-require 'chromedriver-helper'
+require 'webdrivers'
 
 Capybara.javascript_driver = :headless_chrome
 


### PR DESCRIPTION
`chromedriver-helper` has been deprecated and `webdrivers` is a superior replacement.