### PR TITLE
Forcing 'counter' to integer to avoid XSS

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -102,7 +102,7 @@ module Blacklight::CatalogHelperBehavior
   # @see #page_entries_info
   # @return [String]
   def item_page_entry_info
-    t('blacklight.search.entry_pagination_info.other', current: number_with_delimiter(search_session['counter']),
+    t('blacklight.search.entry_pagination_info.other', current: number_with_delimiter(search_session['counter'].to_i),
                                                        total: number_with_delimiter(search_session['total']),
                                                        count: search_session['total'].to_i).html_safe
   end


### PR DESCRIPTION
Appscan claims it successfully embedded a script through 'counter' of Previous/Next links. When users click on modified Previous/Next links, the script will be executed.
To avoid unwanted scripts execute when page loads, 'counter' should be sanitized.