### PR TITLE
Obsolete documentation?

### DIFF
--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,12 +1,3 @@
-<%-
-  # Compare with render_document_functions_partial helper, and
-  # _document_functions partial. BL actually has two groups
-  # of document-related tools. "document functions" by default
-  # contains Bookmark functionality shown on both results and
-  # item view. While "document tools" contains external export type
-  # functions by default only on detail.
-
--%>
 <% if show_doc_actions? %>
   <div class="card show-tools">
     <div class="card-header">


### PR DESCRIPTION
`render_document_functions_partial` doesn't exist and neither does a partial named `_document_functions`. Not sure what document function is or document tools (?). I think they're all just actions now and handled by `render_show_doc_actions` and `render_index_doc_actions`. Is that right? Might it even make sense to rename the view partial `_show_tools.html.erb` to `_show_actions.html.erb`? There are other places where tools and functions is used. Maybe these should be replaced with action terminology?