### PR TITLE
Use capybara :selenium_chrome_headless built-in driver definition

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,17 +24,7 @@ require 'selenium-webdriver'
 require 'equivalent-xml'
 require 'webdrivers'
 
-Capybara.javascript_driver = :headless_chrome
-
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu no-sandbox] }
-  )
-
-  Capybara::Selenium::Driver.new(app,
-                                 browser: :chrome,
-                                 desired_capabilities: capabilities)
-end
+Capybara.javascript_driver = :selenium_chrome_headless
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Instead of trying to define our own with custom settings. Figure the one built into capybara is probably set up right.

Trying this due to recent failures around chromedriver/webdrivers in travis. In some of my other projects, they have had no problems with the recently released new version of chrome/chromedriver. I am thinking possily because they use :selenium_chrome_headless instead of defining custom driver configuration.