### PR TITLE
Adding the Blacklight namespace to these helper behaviors

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 # Methods added to this helper will be available to all templates in the hosting application
 module Blacklight::BlacklightHelperBehavior
-  include UrlHelperBehavior
-  include HashAsHiddenFieldsHelperBehavior
-  include LayoutHelperBehavior
-  include IconHelperBehavior
+  include Blacklight::UrlHelperBehavior
+  include Blacklight::HashAsHiddenFieldsHelperBehavior
+  include Blacklight::LayoutHelperBehavior
+  include Blacklight::IconHelperBehavior
 
   ##
   # Get the name of this application from an i18n string


### PR DESCRIPTION
I'm adding this because it solved a problem we encountered locally where, in development mode, making changes to certain code always resulted in the same error: 

`uninitialized constant Blacklight::BlacklightHelperBehavior::UrlHelperBehavior`

For example, 1) with the Rails server running, load a view of an item in browser, 2) make a change to local application's `catalog_helper.rb` 3) get error 4) restart Rails server 5) go back to step 1

It looks like the Modules being included in this file aren't qualified. Adding this change allows for free changing of `catalog_helper.rb`. I guess ruby is assuming that the includes are relative to the module it is within? So you have to specify it more explicitly? 

I can't account for why this problem only shows up after an edit to a local `catalog_helper.rb` and isn't caught on fresh server starts.