### PR TITLE
Match bootstrap4 accordion example, avoids 'jankiness' on facet open/close

### DIFF
--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,8 +1,8 @@
 <div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
-  <h3 class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
+  <h3 class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>" id="<%= facet_field_id(facet_field) %>-header">
     <%= link_to facet_field_label(facet_field.key), "##{ facet_field_id(facet_field)}", "data-turbolinks": false %>
   </h3>
-  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
+  <div id="<%= facet_field_id(facet_field) %>" aria-labelledby="<%= facet_field_id(facet_field) %>-header" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
     <div  class="card-body">
       <%= yield %>
     </div>

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -2,7 +2,9 @@
   <h3 class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
     <%= link_to facet_field_label(facet_field.key), "##{ facet_field_id(facet_field)}", "data-turbolinks": false %>
   </h3>
-  <div id="<%= facet_field_id(facet_field) %>" class="card-body panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
-    <%= yield %>
+  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
+    <div  class="card-body">
+      <%= yield %>
+    </div>
   </div>
 </div>

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "catalog/facet_layout" do
   it "is collapsable" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
     expect(rendered).to have_selector '.card-header.collapsed'
-    expect(rendered).to have_selector '.collapse.card-body'
+    expect(rendered).to have_selector '.collapse .card-body'
   end
 
   it "is configured to be open by default" do
     allow(facet_field).to receive_messages(collapse: false)
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
     expect(rendered).not_to have_selector '.card-header.collapsed'
-    expect(rendered).to have_selector '.show.card-body'
+    expect(rendered).to have_selector '.show .card-body'
   end
 end


### PR DESCRIPTION
Some had noticed that Blacklight 7 seemed to have "jankiness" in the slide up/down animation for opening/closing facet areas.

From past experience, I guessed this may have to do with "margin" or "padding" on the div that is the the target for actual collapse/expand. Debugging, I confirmed that removing "padding" removed jankiness for me. But of course we want padding. Did that suggest we need a separate 'wrapper' div?

Consulting the bootstrap4 example for using a bootstrap4 "card" as the target of an expand/contract, at: https://getbootstrap.com/docs/4.1/components/collapse/

I noticed the canonical example DID have a separate div -- there was a wrapper div that was the collapse target, which contained a separate div which was the actual 'class="card-body"' As opposed to Blacklight before this PR, which used the card-body div itself as the collapse target.

## Also accessibilty: aria-labelledby

When looking at the bootstrap4 collapsible card example, I noticed they used an aria attribute we didn’t have yet either. aria-labelledby on the collapsible content, with an id assigned to the collapse link. 

This is presumably an accessibity improvement, to to make our DOM match the bootstrap4 example with the aria-labelledby, in a second commit I added an id to the collapse trigger, and an aria-labelledby to facet collapse content pointing to it. 

I used the existing routine for making an id for facet body, but added “-header” to it, to get an id for particular facet header.