### PR TITLE
Port 'Contributing to Blacklight' wiki page to a CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Blacklight
+
+Blacklight is a collaborative, open source project produced by developers from many diverse  organizations. The Blacklight developers want to create an out-of-the-box framework that is easy to install and get started with, both as a service to the community and in the interests of our own institutions in creating a sustainable project and product.
+
+Development is largely motivated by the needs of each developer’s organization, and we work on the shared project together so we can benefit from the community’s development efforts, experiences building discovery systems, and shared problem solving.
+
+We always welcome contributions from the community, especially to add new features, address bugs or defects, and clarify existing code for future developers.
+
+## Adding a ticket
+Let us know you're interested in working on a feature by filing a ticket in our [[issue tracker|https://github.com/projectblacklight/blacklight/issues]].
+
+## Making Your Changes
+
+* Fork the project
+* Start a feature/bugfix branch
+* Commit and push until you are happy with your contribution
+* Make sure to add tests for it. This is important so we don't break it in a future version unintentionally.
+* After making your changes, be sure to run the [[Blacklight tests|Testing]] to make sure everything works.
+* Submit your change as a [[Pull Request|http://help.github.com/pull-requests/]].
+
+## Support
+If you are interested in working on the Blacklight plugin, but want guidance or support, please send an email to our [[Blacklight-development mailing list|http://groups.google.com/group/blacklight-development]] and we'll be glad to help.
+
+## Becoming a Committer
+
+Anyone can contribute to Blacklight using pull requests, the issue tracker, and being active on the mailing list and IRC channels. Being a contributor means that you take an active interest in the project and contribute regularly in some way, ranging from asking sensible questions (which documents the project and provides feedback to developers) to providing new features as patches.
+
+If you become a valuable contributor to the project you may be invited to become a committer.  Blacklight code contributors become committers after being sponsored by one of the current active committers.  The committers will take an Apache-style (+1/0/-1) vote to elevate them, and then a formal invitation will be extended to the contributor.
+
+Committers should be:
+
+- technically adept
+- constructive, positive members of the Blacklight software community
+- committed to producing useful, practical code for the community
+
+You're expected to:
+
+- contribute patches and new functionality to Blacklight and other shared development efforts (RSolr, Blacklight plugins, etc)
+- actively participate in technical discussions on the email list, IRC, and github
+- answer user support questions via the various channels
+- review pull requests from fellow committers and the community
+- test-drive new release candidates against your own institution's Blacklight applications
+- participate in regular committer meetings, usually in the form of conference calls, to coordinate development & direction

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Development is largely motivated by the needs of each developer’s organization
 We always welcome contributions from the community, especially to add new features, address bugs or defects, and clarify existing code for future developers.
 
 ## Adding a ticket
-Let us know you're interested in working on a feature by filing a ticket in our [[issue tracker|https://github.com/projectblacklight/blacklight/issues]].
+Let us know you're interested in working on a feature by filing a ticket in our [issue tracker](https://github.com/projectblacklight/blacklight/issues).
 
 ## Making Your Changes
 
@@ -15,11 +15,11 @@ Let us know you're interested in working on a feature by filing a ticket in our 
 * Start a feature/bugfix branch
 * Commit and push until you are happy with your contribution
 * Make sure to add tests for it. This is important so we don't break it in a future version unintentionally.
-* After making your changes, be sure to run the [[Blacklight tests|Testing]] to make sure everything works.
-* Submit your change as a [[Pull Request|http://help.github.com/pull-requests/]].
+* After making your changes, be sure to run the [Blacklight tests](https://github.com/projectblacklight/blacklight/wiki/testing) to make sure everything works.
+* Submit your change as a [Pull Request](https://help.github.com/en/articles/about-pull-requests).
 
 ## Support
-If you are interested in working on the Blacklight plugin, but want guidance or support, please send an email to our [[Blacklight-development mailing list|http://groups.google.com/group/blacklight-development]] and we'll be glad to help.
+If you are interested in working on the Blacklight plugin, but want guidance or support, please send an email to our [Blacklight-development mailing list](http://groups.google.com/group/blacklight-development) and we'll be glad to help.
 
 ## Becoming a Committer
 


### PR DESCRIPTION
I suggest we move the "Contributing to Blacklight" page to a CONTRIBUTING.md. to make it easier to discuss and vote on proposed changes to contribution process. Currently, much of this discussion happens on the code4lib Slack. I'll submit a follow-on PR with a proposal for PR / code review process.

cc: @jrochkind @mejackreed @jcoyne 