### PR TITLE
Return a default presenter instead of nil.

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -260,7 +260,7 @@ module Blacklight::BlacklightHelperBehavior
     case action_name
     when 'show', 'citation'
       show_presenter(document)
-    when 'index'
+    else
       index_presenter(document)
     end
   end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -388,4 +388,46 @@ RSpec.describe BlacklightHelper do
       expect(helper.render_document_heading(document, tag: "h3")).to have_selector "h3", text: "Document Heading"
     end
   end
+
+  describe "#presenter" do
+    let(:document) { double }
+
+    before do
+      allow(helper).to receive(:index_presenter).and_return(:index_presenter)
+      allow(helper).to receive(:show_presenter).and_return(:show_presenter)
+      allow(helper).to receive(:action_name).and_return(action_name)
+    end
+
+    context "action is show" do
+      let(:action_name) { "show" }
+
+      it "uses the show presenter" do
+        expect(helper.presenter(document)).to eq(:show_presenter)
+      end
+    end
+
+    context "action is citation" do
+      let(:action_name) { "citation" }
+
+      it "uses the show presenter" do
+        expect(helper.presenter(document)).to eq(:show_presenter)
+      end
+    end
+
+    context "action is index" do
+      let(:action_name) { "index" }
+
+      it "uses the index presenter" do
+        expect(helper.presenter(document)).to eq(:index_presenter)
+      end
+    end
+
+    context "action is foo" do
+      let(:action_name) { "foo" }
+
+      it "uses the index presenter (by default)" do
+        expect(helper.presenter(document)).to eq(:index_presenter)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `presenter` helper method should return a default presenter instead of
nil.  Otherwise an error occurs when you have a new action that is
not one of "show", "citation", or "index".