### PR TITLE
RecordMailer: clean up formatting

### DIFF
--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -7,7 +7,10 @@ class RecordMailer < ActionMailer::Base
             rescue
               I18n.t('blacklight.email.text.default_title')
             end
-    subject = I18n.t('blacklight.email.text.subject', count: documents.length, title: title)
+
+    subject = I18n.t('blacklight.email.text.subject',
+                     count: documents.length,
+                     title: Array(title).first)
 
     @documents      = documents
     @message        = details[:message]

--- a/app/views/record_mailer/email_record.text.erb
+++ b/app/views/record_mailer/email_record.text.erb
@@ -1,5 +1,6 @@
 <% @documents.each do |document| %>
 <%= document.to_email_text %>
 <%= t('blacklight.email.text.url', :url =>polymorphic_url(document, @url_gen_params)) %>
+
 <% end %>
 <%= t('blacklight.email.text.message', :message => @message) %>


### PR DESCRIPTION
## add an extra linebreak between records
<img width="403" alt="Screen Shot 2019-07-10 at 6 55 38 PM" src="https://user-images.githubusercontent.com/985416/61017956-ea476b80-a349-11e9-815e-83356ba63a38.png">

## remove array cruft from record title
<img width="404" alt="Screen Shot 2019-07-10 at 6 55 45 PM" src="https://user-images.githubusercontent.com/985416/61017985-09de9400-a34a-11e9-96a7-4182880ede6d.png">
