### PR TITLE
Remove jquery dependency from search_context.js

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,6 +15,7 @@
   "unused": true,
   "eqnull": true,
   "predef": [
-    "Blacklight"
+    "Blacklight",
+    "Rails"
   ]
 }

--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -431,54 +431,68 @@ Blacklight.onLoad(function () {
   Blacklight.modal.setupModal();
 });
 
-(function ($) {
-  Blacklight.doSearchContextBehavior = function () {
-    if (typeof Blacklight.do_search_context_behavior == 'function') {
-      console.warn("do_search_context_behavior is deprecated. Use doSearchContextBehavior instead.");
-      return Blacklight.do_search_context_behavior();
-    }
+Blacklight.doSearchContextBehavior = function () {
+  if (typeof Blacklight.do_search_context_behavior == 'function') {
+    console.warn("do_search_context_behavior is deprecated. Use doSearchContextBehavior instead.");
+    return Blacklight.do_search_context_behavior();
+  }
 
-    $('a[data-context-href]').on('click.search-context', Blacklight.handleSearchContextMethod);
-  }; // this is the $.rails.handleMethod with a couple adjustments, described inline:
-  // first, we're attaching this directly to the event handler, so we can check for meta-keys
+  const elements = document.querySelectorAll('a[data-context-href]'); // Equivalent to Array.from(), but supports ie11
 
-
-  Blacklight.handleSearchContextMethod = function (event) {
-    if (typeof Blacklight.handle_search_context_method == 'function') {
-      console.warn("handle_search_context_method is deprecated. Use handleSearchContextMethod instead.");
-      return Blacklight.handle_search_context_method(event);
-    }
-
-    var link = $(this); // instead of using the normal href, we need to use the context href instead
-
-    var href = link.data('context-href'),
-        method = 'post',
-        target = link.attr('target'),
-        csrfToken = $('meta[name=csrf-token]').attr('content'),
-        csrfParam = $('meta[name=csrf-param]').attr('content'),
-        form = $('<form method="post" action="' + href + '"></form>'),
-        metadataInput = '<input name="_method" value="' + method + '" type="hidden" />',
-        redirectHref = '<input name="redirect" value="' + link.attr('href') + '" type="hidden" />'; // check for meta keys.. if set, we should open in a new tab
-
-    if (event.metaKey || event.ctrlKey) {
-      target = '_blank';
-    }
-
-    if (csrfParam !== undefined && csrfToken !== undefined) {
-      metadataInput += '<input name="' + csrfParam + '" value="' + csrfToken + '" type="hidden" />';
-    }
-
-    if (target) {
-      form.attr('target', target);
-    }
-
-    form.hide().append(metadataInput).append(redirectHref).appendTo('body');
-    form.submit();
-    return false;
-  };
-
-  Blacklight.onLoad(function () {
-    Blacklight.doSearchContextBehavior();
+  const nodes = Array.prototype.slice.call(elements);
+  nodes.forEach(function (element) {
+    element.addEventListener('click', function (e) {
+      Blacklight.handleSearchContextMethod.call(e.target, e);
+    });
   });
-})(jQuery);
+}; // this is the Rails.handleMethod with a couple adjustments, described inline:
+// first, we're attaching this directly to the event handler, so we can check for meta-keys
+
+
+Blacklight.handleSearchContextMethod = function (event) {
+  if (typeof Blacklight.handle_search_context_method == 'function') {
+    console.warn("handle_search_context_method is deprecated. Use handleSearchContextMethod instead.");
+    return Blacklight.handle_search_context_method(event);
+  }
+
+  var link = this; // instead of using the normal href, we need to use the context href instead
+
+  let href = link.getAttribute('data-context-href');
+  let target = link.getAttribute('target');
+  let csrfToken = Rails.csrfToken();
+  let csrfParam = Rails.csrfParam();
+  let form = document.createElement('form');
+  form.method = 'post';
+  form.action = href;
+  let formContent = `<input name="_method" value="post" type="hidden" />
+    <input name="redirect" value="${link.getAttribute('href')}" type="hidden" />`; // check for meta keys.. if set, we should open in a new tab
+
+  if (event.metaKey || event.ctrlKey) {
+    target = '_blank';
+  }
+
+  if (csrfParam !== undefined && csrfToken !== undefined) {
+    formContent += `<input name="${csrfParam}" value="${csrfToken}" type="hidden" />`;
+  } // Must trigger submit by click on a button, else "submit" event handler won't work!
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
+
+
+  formContent += '<input type="submit" />';
+
+  if (target) {
+    form.setAttribute('target', target);
+  }
+
+  form.style.display = 'none';
+  form.innerHTML = formContent;
+  document.body.appendChild(form);
+  form.querySelector('[type="submit"]').click();
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+};
+
+Blacklight.onLoad(function () {
+  Blacklight.doSearchContextBehavior();
+});
 

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -66,7 +66,7 @@ module Blacklight::UrlHelperBehavior
   # @param [Integer] counter
   # @example
   #   session_tracking_params(SolrDocument.new(id: 123), 7)
-  #   => { data: { :'tracker-href' => '/catalog/123/track?counter=7&search_id=999' } }
+  #   => { data: { :'context-href' => '/catalog/123/track?counter=7&search_id=999' } }
   def session_tracking_params document, counter
     path = session_tracking_path(document, per_page: params.fetch(:per_page, search_session['per_page']), counter: counter, search_id: current_search_session.try(:id))
 

--- a/app/javascript/blacklight/search_context.js
+++ b/app/javascript/blacklight/search_context.js
@@ -1,49 +1,67 @@
-(function($) {
-  Blacklight.doSearchContextBehavior = function() {
-    if (typeof Blacklight.do_search_context_behavior == 'function') {
-      console.warn("do_search_context_behavior is deprecated. Use doSearchContextBehavior instead.");
-      return Blacklight.do_search_context_behavior();
-    }
-    $('a[data-context-href]').on('click.search-context', Blacklight.handleSearchContextMethod);
-  };
+Blacklight.doSearchContextBehavior = function() {
+  if (typeof Blacklight.do_search_context_behavior == 'function') {
+    console.warn("do_search_context_behavior is deprecated. Use doSearchContextBehavior instead.");
+    return Blacklight.do_search_context_behavior();
+  }
 
-  // this is the $.rails.handleMethod with a couple adjustments, described inline:
-  // first, we're attaching this directly to the event handler, so we can check for meta-keys
-  Blacklight.handleSearchContextMethod = function(event) {
-    if (typeof Blacklight.handle_search_context_method == 'function') {
-      console.warn("handle_search_context_method is deprecated. Use handleSearchContextMethod instead.");
-      return Blacklight.handle_search_context_method(event);
-    }
-    var link = $(this);
+  const elements = document.querySelectorAll('a[data-context-href]')
+  // Equivalent to Array.from(), but supports ie11
+  const nodes = Array.prototype.slice.call(elements)
 
-    // instead of using the normal href, we need to use the context href instead
-    var href = link.data('context-href'),
-      method = 'post',
-      target = link.attr('target'),
-      csrfToken = $('meta[name=csrf-token]').attr('content'),
-      csrfParam = $('meta[name=csrf-param]').attr('content'),
-      form = $('<form method="post" action="' + href + '"></form>'),
-      metadataInput = '<input name="_method" value="' + method + '" type="hidden" />',
-      redirectHref = '<input name="redirect" value="' + link.attr('href') + '" type="hidden" />';
+  nodes.forEach(function(element) {
+    element.addEventListener('click', function(e) {
+      Blacklight.handleSearchContextMethod.call(e.target, e)
+    })
+  })
+};
 
-    // check for meta keys.. if set, we should open in a new tab
-    if(event.metaKey || event.ctrlKey) {
-      target = '_blank';
-    }
+// this is the Rails.handleMethod with a couple adjustments, described inline:
+// first, we're attaching this directly to the event handler, so we can check for meta-keys
+Blacklight.handleSearchContextMethod = function(event) {
+  if (typeof Blacklight.handle_search_context_method == 'function') {
+    console.warn("handle_search_context_method is deprecated. Use handleSearchContextMethod instead.");
+    return Blacklight.handle_search_context_method(event);
+  }
+  var link = this
 
-    if (csrfParam !== undefined && csrfToken !== undefined) {
-      metadataInput += '<input name="' + csrfParam + '" value="' + csrfToken + '" type="hidden" />';
-    }
+  // instead of using the normal href, we need to use the context href instead
+  let href = link.getAttribute('data-context-href')
+  let target = link.getAttribute('target')
+  let csrfToken = Rails.csrfToken()
+  let csrfParam = Rails.csrfParam()
+  let form = document.createElement('form')
+  form.method = 'post'
+  form.action = href
 
-    if (target) { form.attr('target', target); }
 
-    form.hide().append(metadataInput).append(redirectHref).appendTo('body');
-    form.submit();
+  let formContent = `<input name="_method" value="post" type="hidden" />
+    <input name="redirect" value="${link.getAttribute('href')}" type="hidden" />`
 
-    return false;
-  };
+  // check for meta keys.. if set, we should open in a new tab
+  if(event.metaKey || event.ctrlKey) {
+    target = '_blank';
+  }
 
-  Blacklight.onLoad(function() {
-      Blacklight.doSearchContextBehavior();
-  });
-})(jQuery);
+  if (csrfParam !== undefined && csrfToken !== undefined) {
+    formContent += `<input name="${csrfParam}" value="${csrfToken}" type="hidden" />`
+  }
+
+  // Must trigger submit by click on a button, else "submit" event handler won't work!
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
+  formContent += '<input type="submit" />'
+
+  if (target) { form.setAttribute('target', target); }
+
+  form.style.display = 'none'
+  form.innerHTML = formContent
+  document.body.appendChild(form)
+  form.querySelector('[type="submit"]').click()
+
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation()
+};
+
+Blacklight.onLoad(function() {
+  Blacklight.doSearchContextBehavior();
+});


### PR DESCRIPTION
Bootstrap 5 is removing the jquery dependency, so this gets Blacklight moving towards not requiring that dependency.