### PR TITLE
update text method to use html for checkbox label toggle

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -160,17 +160,17 @@ Blacklight.onLoad(function () {
           //Set the Rails hidden field that fakes an HTTP verb
           //properly for current state action.
           form.find('input[name=_method]').val('delete');
-          span.text(form.attr('data-present'));
+          span.html(form.attr('data-present'));
         } else {
           form.find('input[name=_method]').val('put');
-          span.text(form.attr('data-absent'));
+          span.html(form.attr('data-absent'));
         }
       }
 
       form.append(checkboxDiv);
       updateStateFor(checked);
       checkbox.click(function () {
-        span.text(form.attr('data-inprogress'));
+        span.html(form.attr('data-inprogress'));
         label.attr('disabled', 'disabled');
         checkbox.attr('disabled', 'disabled');
         $.ajax({

--- a/app/javascript/blacklight/checkbox_submit.js
+++ b/app/javascript/blacklight/checkbox_submit.js
@@ -73,10 +73,10 @@
                //Set the Rails hidden field that fakes an HTTP verb
                //properly for current state action.
                form.find('input[name=_method]').val('delete');
-               span.text(form.attr('data-present'));
+               span.html(form.attr('data-present'));
             } else {
                form.find('input[name=_method]').val('put');
-               span.text(form.attr('data-absent'));
+               span.html(form.attr('data-absent'));
             }
           }
 
@@ -84,7 +84,7 @@
         updateStateFor(checked);
 
         checkbox.click(function() {
-            span.text(form.attr('data-inprogress'));
+            span.html(form.attr('data-inprogress'));
             label.attr('disabled', 'disabled');
             checkbox.attr('disabled', 'disabled');
 


### PR DESCRIPTION
This is part of projectblacklight/arclight#711

<a href="https://cl.ly/f76558e649a4" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2v0E3V2H1k2a0I0q2B3S/Screen%20Shot%202019-09-11%20at%202.19.46%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

Arclight wants to support markup in bookmark labels. When using .text the html would be escaped.  By using .html, we can use markup and this should be backwards compatible for any bookmark implementations.

Paired with @camillevilla and @jkeck 