### PR TITLE
Facet html and behavior change

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -95,6 +95,16 @@ Blacklight.onLoad(function () {
     Blacklight.doBookmarkToggleBehavior();
   });
 })(jQuery);
+
+Blacklight.onLoad(function () {
+  // Button clicks should change focus. As of 10/2/19, Firefox for Mac and
+  // Safari both do not do this correctly.
+  document.addEventListener('click', event => {
+    if (event.target.matches('button')) {
+      event.target.focus();
+    }
+  });
+});
 /* A JQuery plugin (should this be implemented as a widget instead? not sure)
    that will convert a "toggle" form, with single submit button to add/remove
    something, like used for Bookmarks, into an AJAXy checkbox instead.
@@ -125,7 +135,6 @@ Blacklight.onLoad(function () {
         }
    });
 */
-
 
 (function ($) {
   $.fn.blCheckboxSubmit = function (argOpts) {
@@ -215,16 +224,6 @@ Blacklight.onLoad(function () {
     success: function () {} //callback
 
   };
-})(jQuery);
-
-(function ($) {
-  Blacklight.onLoad(function () {
-    // when clicking on a link that toggles the collapsing behavior, don't do anything
-    // with the hash or the page could jump around.
-    $(document).on('click', 'a[data-toggle=collapse][href="#"], [data-toggle=collapse] a[href="#"]', function (event) {
-      event.preventDefault();
-    });
-  });
 })(jQuery);
 /*global Blacklight */
 

--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -97,12 +97,12 @@ Blacklight.onLoad(function () {
 })(jQuery);
 
 Blacklight.onLoad(function () {
-  // Button clicks should change focus. As of 10/2/19, Firefox for Mac and
-  // Safari both do not do this correctly.
-  document.addEventListener('click', event => {
-    if (event.target.matches('button')) {
+  // Button clicks should change focus. As of 10/3/19, Firefox for Mac and
+  // Safari both do not set focus to a button on button click.
+  document.querySelectorAll('button.collapse-toggle').forEach(button => {
+    button.addEventListener('click', () => {
       event.target.focus();
-    }
+    });
   });
 });
 /* A JQuery plugin (should this be implemented as a widget instead? not sure)

--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -3,21 +3,25 @@
 }
 
 // Facet field headings and buttons
-.facet-field-heading button {
-font-weight: $headings-font-weight;
-
-  &::after {
-    content: "❯";
-    float: right;
-    transform: rotate(90deg);
-  }
-
-  &.collapsed {
-    border-bottom: 0;
+.facet-field-heading {
+  border-bottom: 0;
+  
+  button {
+    font-weight: $headings-font-weight;
 
     &::after {
-      transform: rotate(0deg);
-      transition: transform 0.1s ease;
+      content: "❯";
+      float: right;
+      transform: rotate(90deg);
+    }
+
+    &.collapsed {
+      border-bottom: 0;
+
+      &::after {
+        transform: rotate(0deg);
+        transition: transform 0.1s ease;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -2,7 +2,8 @@
   @extend .py-2;
 }
 
-.card-header.collapse-toggle {
+// Facet field headings and buttons
+.facet-field-heading button {
   margin-bottom: 0;
 
   &::after {
@@ -20,7 +21,6 @@
     }
   }
 }
-
 
 .page-link {
   white-space: nowrap;

--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -4,7 +4,7 @@
 
 // Facet field headings and buttons
 .facet-field-heading button {
-  margin-bottom: 0;
+font-weight: $headings-font-weight;
 
   &::after {
     content: "❯";

--- a/app/javascript/blacklight/button_focus.js
+++ b/app/javascript/blacklight/button_focus.js
@@ -1,9 +1,9 @@
 Blacklight.onLoad(function() {
-  // Button clicks should change focus. As of 10/2/19, Firefox for Mac and
-  // Safari both do not do this correctly.
-  document.addEventListener('click', event => {
-    if (event.target.matches('button')) {
+  // Button clicks should change focus. As of 10/3/19, Firefox for Mac and
+  // Safari both do not set focus to a button on button click.
+  document.querySelectorAll('button.collapse-toggle').forEach((button) => {
+    button.addEventListener('click', () => {
       event.target.focus();
-    }
+    });
   });
 });

--- a/app/javascript/blacklight/button_focus.js
+++ b/app/javascript/blacklight/button_focus.js
@@ -1,0 +1,9 @@
+Blacklight.onLoad(function() {
+  // Button clicks should change focus. As of 10/2/19, Firefox for Mac and
+  // Safari both do not do this correctly.
+  document.addEventListener('click', event => {
+    if (event.target.matches('button')) {
+      event.target.focus();
+    }
+  });
+});

--- a/app/javascript/blacklight/collapsable.js
+++ b/app/javascript/blacklight/collapsable.js
@@ -1,9 +1,0 @@
-(function($) {
-  Blacklight.onLoad(function() {
-    // when clicking on a link that toggles the collapsing behavior, don't do anything
-    // with the hash or the page could jump around.
-    $(document).on('click', 'a[data-toggle=collapse][href="#"], [data-toggle=collapse] a[href="#"]', function(event) {
-      event.preventDefault();
-    });
-  });
-})(jQuery);

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,7 +1,7 @@
 <div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
   <h3 class="card-header p-0 facet-field-heading" id="<%= facet_field_id(facet_field) %>-header">
     <button
-      class="btn btn-block text-left <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle"
+      class="btn btn-block p-2 text-left <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle"
       data-toggle="collapse"
       data-target="#<%= facet_field_id(facet_field) %>"
       aria-expanded="false"

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,6 +1,13 @@
 <div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
-  <h3 class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>" id="<%= facet_field_id(facet_field) %>-header">
-    <%= link_to facet_field_label(facet_field.key), "##{ facet_field_id(facet_field)}", class: "stretched-link", "data-turbolinks": false %>
+  <h3 class="card-header p-0 facet-field-heading" id="<%= facet_field_id(facet_field) %>-header">
+    <button
+      class="btn btn-block text-left <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle"
+      data-toggle="collapse"
+      data-target="#<%= facet_field_id(facet_field) %>"
+      aria-expanded="false"
+    >
+      <%= facet_field_label(facet_field.key) %>
+    </button>
   </h3>
   <div id="<%= facet_field_id(facet_field) %>" aria-labelledby="<%= facet_field_id(facet_field) %>-header" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
     <div  class="card-body">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blacklight-frontend",
-  "version": "7.1.0-alpha",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "[![Build Status](https://travis-ci.org/projectblacklight/blacklight.png?branch=master)](https://travis-ci.org/projectblacklight/blacklight) [![Gem Version](https://badge.fury.io/rb/blacklight.png)](http://badge.fury.io/rb/blacklight) [![Coverage Status](https://coveralls.io/repos/github/projectblacklight/blacklight/badge.svg?branch=master)](https://coveralls.io/github/projectblacklight/blacklight?branch=master)",
   "main": "app/assets/javascripts/blacklight",
   "scripts": {
-    "js-compile-bundle": "shx cat app/javascript/blacklight/core.js app/javascript/blacklight/autocomplete.js app/javascript/blacklight/bookmark_toggle.js app/javascript/blacklight/checkbox_submit.js app/javascript/blacklight/collapsable.js app/javascript/blacklight/facet_load.js app/javascript/blacklight/modal.js app/javascript/blacklight/search_context.js | shx sed \"s/^(import|export).*//\" | babel --filename app/javascript/blacklight/blacklight.js > app/assets/javascripts/blacklight/blacklight.js"
+    "js-compile-bundle": "shx cat app/javascript/blacklight/core.js app/javascript/blacklight/autocomplete.js app/javascript/blacklight/bookmark_toggle.js app/javascript/blacklight/button_focus.js app/javascript/blacklight/checkbox_submit.js app/javascript/blacklight/facet_load.js app/javascript/blacklight/modal.js app/javascript/blacklight/search_context.js | shx sed \"s/^(import|export).*//\" | babel --filename app/javascript/blacklight/blacklight.js > app/assets/javascripts/blacklight/blacklight.js"
   },
   "repository": {
     "type": "git",

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Facets" do
       page.find('button.navbar-toggler').click
     end
 
-    page.find('h3.facet-field-heading a', text: 'Format').click
+    page.find('h3.facet-field-heading', text: 'Format').click
 
     sleep(1) # let facet animation finish and wait for it to potentially re-collapse
 

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Facets" do
       page.find('button.navbar-toggler').click
     end
 
-    page.find('h3.facet-field-heading', text: 'Format').click
+    page.find('h3.facet-field-heading button', text: 'Format').click
 
     sleep(1) # let facet animation finish and wait for it to potentially re-collapse
 

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Facets" do
     expect(page).to have_css('#facet-format', visible: true) # assert that it didn't re-collapse
   end
 
-  describe 'Facet heading button focus with Firefox' do
+  describe 'heading button focus with Firefox' do
     before do
       Capybara.current_driver = :selenium_headless
     end

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -67,6 +67,26 @@ RSpec.describe "Facets" do
     expect(page).to have_css('#facet-format', visible: true) # assert that it didn't re-collapse
   end
 
+  describe 'Facet heading button focus with Firefox' do
+    before do
+      Capybara.current_driver = :selenium_headless
+      page.current_window.resize_to(1200, 700)
+    end
+
+    it 'changes to the button on button click in Firefox' do
+      visit root_path
+      page.find('h3.facet-field-heading button', text: 'Format').click
+      focused_element = page.evaluate_script("document.activeElement")
+      focused_element_data_target = page.evaluate_script("document.activeElement")['data-target']
+      expect(focused_element_data_target).to eq '#facet-format'
+    end
+
+    after do
+      page.current_window.resize_to(400, 700)
+      Capybara.current_driver = :rack_test
+    end
+  end
+
   describe '"More" links' do
     it 'has default more link with sr-only text' do
       visit root_path

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -70,20 +70,17 @@ RSpec.describe "Facets" do
   describe 'Facet heading button focus with Firefox' do
     before do
       Capybara.current_driver = :selenium_headless
-      page.current_window.resize_to(1200, 700)
+    end
+
+    after do
+      Capybara.current_driver = :rack_test
     end
 
     it 'changes to the button on button click in Firefox' do
       visit root_path
       page.find('h3.facet-field-heading button', text: 'Format').click
-      focused_element = page.evaluate_script("document.activeElement")
       focused_element_data_target = page.evaluate_script("document.activeElement")['data-target']
       expect(focused_element_data_target).to eq '#facet-format'
-    end
-
-    after do
-      page.current_window.resize_to(400, 700)
-      Capybara.current_driver = :rack_test
     end
   end
 

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe "Facets" do
     end
 
     within(".blacklight-subject_ssim") do
-      click_link "Topic"
+      page.find('h3.facet-field-heading', text: 'Topic').click
       expect(page).to have_selector(".panel-collapse", visible: true)
     end
     within(".blacklight-subject_ssim") do

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "Facets" do
       expect(page).not_to have_selector(".card-body", visible: true)
     end
   end
-  it "expands when the heading is clicked", js: true do
+  it "expands when the heading button is clicked", js: true do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
 
@@ -188,11 +188,11 @@ RSpec.describe "Facets" do
 
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
-      find(".card-header").click
+      find(".card-header button").click
       expect(page).to have_selector(".card-body", visible: true)
     end
   end
-  it "expands when the anchor is clicked", js: true do
+  it "expands when the button is clicked", js: true do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
 

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "catalog/facet_layout" do
 
   it "is collapsable" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
-    expect(rendered).to have_selector '.card-header.collapsed'
+    expect(rendered).to have_selector 'button.collapsed'
     expect(rendered).to have_selector '.collapse .card-body'
   end
 

--- a/spec/views/catalog/_facets.html.erb_spec.rb
+++ b/spec/views/catalog/_facets.html.erb_spec.rb
@@ -71,12 +71,6 @@ RSpec.describe "catalog/_facets" do
         expect(rendered).to have_selector('.facet-content a.facet-select')
         expect(rendered).to have_selector('.facet-content .facet-count')
       end
-      it "has a stretched anchor" do
-        render
-        # This is to ensure that iOS devices (iOS 12), especially, stretch the
-        # anchor tag in the facet heading area.
-        expect(rendered).to have_selector('a.stretched-link')
-      end
     end
   end
 end


### PR DESCRIPTION
I noticed a problem with the latest release (7.1.0) locally for me. The window jumps when you click on a facet heading. This is due to the stretched-link class that I ([ducks!](https://github.com/projectblacklight/blacklight/pull/2132)) added (sorry). The toggle behavior from Bootstrap is added to the h3 and that is what should be clicked. I think maybe there's some sort of unintended but beneficial interaction between the h3 and the anchor where a click on that area generally does what you want. Otherwise I have trouble explaining how a click on the anchor tag inside the h3 toggles [the expand collapse behavior](https://getbootstrap.com/docs/4.0/components/collapse).

But, after playing with this a bit it seems to me that the anchor tag is extraneous and so is the collapsable.js. I could be wrong.

The one thing that would make sense to me is adding `cursor: pointer` to the h3 via CSS. I didn't do this, mainly because I wanted to make sure this was making sense first.

Again, apologies for the inadvertent bug creation, but hopefully this solves it or starts a conversation to solve it.