### PR TITLE
Add a new i18n key for the sort/per page labels that include HTML  …

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -2,7 +2,7 @@
 <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
 <div id="per_page-dropdown" class="per-page-dropdown btn-group">
   <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
+    <%= t(:'blacklight.search.per_page.button_label_html', :count => current_per_page) %> <span class="caret"></span>
   </button>
   <div class="dropdown-menu dropdown-menu-right" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,7 +1,7 @@
 <% if show_sort_and_per_page? and active_sort_fields.many? %>
 <div id="sort-dropdown" class="sort-dropdown btn-group">
   <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-      <%= t('blacklight.search.sort.label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
+      <%= t('blacklight.search.sort.label_html', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
   </button>
 
   <div class="dropdown-menu" role="menu">

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -143,11 +143,13 @@ de:
         invalid_solr_id: "Entschuldigung, Sie haben einen nicht vorhandenen Datensatz angefordert."
       per_page:
         label: '%{count}<span class="sr-only"> pro Seite</span>'
-        button_label: '%{count} pro Seite'
+        button_label: '%{count} pro Seite' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> pro Seite</span>'
         title: 'Anzahl der Ergebnisse, die pro Seite angezeigt werden'
         submit: 'Aktualisieren'
       sort:
-        label: 'Ordnen nach %{field}'
+        label: 'Ordnen nach %{field}' # TODO: Remove during major release
+        label_html: 'Ordnen<span class="d-none d-sm-inline"> nach %{field}</span>'
         submit: 'Ergebnisse ordnen'
       form:
         search_field:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -143,11 +143,13 @@ en:
         invalid_solr_id: "Sorry, you have requested a record that doesn't exist."
       per_page:
         label: '%{count}<span class="sr-only"> per page</span>'
-        button_label: '%{count} per page'
+        button_label: '%{count} per page' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> per page</span>'
         title: 'Number of results to display per page'
         submit: 'Update'
       sort:
-        label: 'Sort by %{field}'
+        label: 'Sort by %{field}' # TODO: Remove during major release
+        label_html: 'Sort<span class="d-none d-sm-inline"> by %{field}</span>'
         submit: 'sort results'
       form:
         search_field:

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -143,11 +143,13 @@ es:
         invalid_solr_id: "Lo sentimos, usted ha solicitado un registro que no existe."
       per_page:
         label: '%{count}<span class="sr-only"> por página</span>'
-        button_label: '%{count} por página'
+        button_label: '%{count} por página' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> por página</span>'
         title: 'El número de resultados a mostrar por página'
         submit: 'Actualización'
       sort:
-        label: 'Ordenar por %{field}'
+        label: 'Ordenar por %{field}' # TODO: Remove during major release
+        label_html: 'Ordenar<span class="d-none d-sm-inline"> por %{field}</span>'
         submit: 'Resultados de ordenación'
       form:
         search_field:

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -146,11 +146,13 @@ fr:
         invalid_solr_id: "Vous avez demandé une notice qui n'existe pas."
       per_page:
         label: '%{count}<span class="sr-only"> par page</span>'
-        button_label: '%{count} par page'
+        button_label: '%{count} par page' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> par page</span>'
         title: 'Nombre de résultats à afficher par page'
         submit: 'mettre à jour'
       sort:
-        label: 'Trier par %{field}'
+        label: 'Trier par %{field}' # TODO: Remove during major release
+        label_html: 'Trier<span class="d-none d-sm-inline"> par %{field}</span>'
         submit: 'trier les résultats'
       form:
         search_field:

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -136,11 +136,13 @@ hu:
         invalid_solr_id: "Elnézést, de az Ön által kért rekord nem létezik."
       per_page:
         label: '%{count}<span class="sr-only"> oldalanként</span>'
-        button_label: '%{count} oldalanként'
+        button_label: '%{count} oldalanként' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> oldalanként</span>'
         title: 'Az eredmények száma oldalanként'
         submit: 'Frissítés'
       sort:
-        label: 'Rendezés %{field}'
+        label: 'Rendezés %{field}' # TODO: Remove during major release
+        label_html: 'Rendezés<span class="d-none d-sm-inline"> %{field}</span>'
         submit: 'Eredmények rendezése'
       form:
         search_field:

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -143,11 +143,13 @@ it:
         invalid_solr_id: "Il numero di scheda richiesto non esiste."
       per_page:
         label: '%{count}<span class="sr-only"> per pagina</span>'
-        button_label: '%{count} per pagina'
+        button_label: '%{count} per pagina' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> per pagina</span>'
         title: 'Risultati per pagina'
         submit: 'Aggiorna'
       sort:
-        label: 'Ordina per %{field}'
+        label: 'Ordina per %{field}' # TODO: Remove during major release
+        label_html: 'Ordina<span class="d-none d-sm-inline"> per %{field}</span>'
         submit: 'Ordina i risultati'
       form:
         search_field:

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -136,11 +136,13 @@ nl:
         invalid_solr_id: "Sorry, u vroeg een onbestaande record op."
       per_page:
         label: '%{count}<span class="sr-only"> per pagina</span>'
-        button_label: '%{count} per pagina'
+        button_label: '%{count} per pagina' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> per pagina</span>'
         title: 'Toon aantal zoekresultaten per pagina'
         submit: 'Update'
       sort:
-        label: 'Sorteer op %{field}'
+        label: 'Sorteer op %{field}' # TODO: Remove during major release
+        label_html: 'Sorteer<span class="d-none d-sm-inline"> op %{field}</span>'
         submit: 'sorteer resultaten'
       form:
         search_field:

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -144,11 +144,13 @@ pt-BR:
         invalid_solr_id: "Desculpe, você solicitou um cadastro que não existe."
       per_page:
         label: '%{count}<span class="hide-text"> por página</span>'
-        button_label: '%{count} por página'
+        button_label: '%{count} por página' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> por página</span>'
         title: 'Número de resultados para mostrar por página'
         submit: 'Atualizar'
       sort:
-        label: 'Ordenar por %{field}'
+        label: 'Ordenar por %{field}' # TODO: Remove during major release
+        label_html: 'Ordenar<span class="d-none d-sm-inline"> por %{field}</span>'
         submit: 'ordenar resultados'
       form:
         search_field:

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -134,11 +134,13 @@ sq:
         invalid_solr_id: "Na vjen keq, ju keni kërkuar një të dhënë që nuk ekziston."
       per_page:
         label: '%{count}<span class="sr-only"> për faqe</span>'
-        button_label: '%{count} për faqe'
+        button_label: '%{count} për faqe' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> për faqe</span>'
         title: 'Numri i rezultateve që do të shfaqen për faqe'
         submit: 'Përditëso'
       sort:
-        label: 'Klasifikoj sipas %{field}'
+        label: 'Klasifikoj sipas %{field}' # TODO: Remove during major release
+        label_html: 'Klasifikoj<span class="d-none d-sm-inline"> sipas %{field}</span>'
         submit: 'klasifiko rezultatet'
       form:
         search_field:

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -136,11 +136,13 @@ zh:
         invalid_solr_id: "抱歉，你要找的结果不存在。"
       per_page:
         label: '%{count}<span class="sr-only"> 每页</span>'
-        button_label: '%{count} 每页'
+        button_label: '%{count} 每页' # TODO: Remove during major release
+        button_label_html: '%{count}<span class="d-none d-sm-inline"> 每页</span>'
         title: '每页显示结果数'
         submit: '更新'
       sort:
-        label: '按 %{field} 排序'
+        label: '按 %{field} 排序' # TODO: Remove during major release
+        label_html: '<span class="d-none d-sm-inline">按 %{field} </span>排序'
         submit: '排序'
       form:
         search_field:


### PR DESCRIPTION
…w/ bootstrap utility classes to remove unnecessary text at the smallest breakpoints.

Closes projectblacklight/arclight#804

This is an attempt try to address this wrapping of the controls on smaller screens:
<img width="324" alt="before" src="https://user-images.githubusercontent.com/96776/65192869-9cc43a80-da2d-11e9-8b23-27d834564337.png">

---

After this change:

<img width="323" alt="after" src="https://user-images.githubusercontent.com/96776/65192870-9cc43a80-da2d-11e9-8893-ffeb4b281868.png">

Note: Old keys kept in intentionally for backwards compatibility.