### PR TITLE
Enable new functionality for pagination information on grouped results

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -31,8 +31,11 @@ module Blacklight::CatalogHelperBehavior
 
   ##
   # Override the Kaminari page_entries_info helper with our own, blacklight-aware
-  # implementation.
-  # Displays the "showing X through Y of N" message.
+  # implementation. Why do we have to do this?
+  #  - We need custom counting information for grouped results
+  #  - We need to provide number_with_delimiter strings to i18n keys
+  # If we didn't have to do either one of these, we could get away with removing
+  # this entirely.
   #
   # @param [RSolr::Resource] collection (or other Kaminari-compatible objects)
   # @return [String]

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -46,7 +46,7 @@ module Blacklight::CatalogHelperBehavior
                  elsif collection.respond_to?(:model_name) && !collection.model_name.nil? # AR, Blacklight::PaginationMethods
                    collection.model_name.human.downcase
                  else
-                   t('blacklight.entry_name.default')
+                   collection.entry_name(count: collection.size)
                  end
 
     entry_name = entry_name.pluralize unless collection.total_count == 1

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -36,17 +36,13 @@ module Blacklight::CatalogHelperBehavior
   #
   # @param [RSolr::Resource] collection (or other Kaminari-compatible objects)
   # @return [String]
-  def page_entries_info(collection, options = {})
+  def page_entries_info(collection, entry_name: nil)
     return unless show_pagination? collection
 
-    entry_name = if options[:entry_name]
-                   options[:entry_name]
-                 elsif collection.respond_to? :model  # DataMapper
-                   collection.model.model_name.human.downcase
-                 elsif collection.respond_to?(:model_name) && !collection.model_name.nil? # AR, Blacklight::PaginationMethods
-                   collection.model_name.human.downcase
+    entry_name = if entry_name
+                   entry_name.pluralize(collection.size, I18n.locale)
                  else
-                   collection.entry_name(count: collection.size)
+                   collection.entry_name(count: collection.size).downcase
                  end
 
     entry_name = entry_name.pluralize unless collection.total_count == 1

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -215,5 +215,7 @@ de:
 
     entry_name:
       default: 'Eintrag'
+      grouped:
+        default: 'gruppiertes Ergebnis'
 
     did_you_mean: 'Meinten Sie: %{options}?'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -215,5 +215,7 @@ en:
 
     entry_name:
       default: 'entry'
+      grouped:
+        default: 'grouped result'
 
     did_you_mean: 'Did you mean to type: %{options}?'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -215,5 +215,7 @@ es:
 
     entry_name:
       default: 'entrada'
+      grouped:
+        default: 'resultado agrupado'
 
     did_you_mean: '¿Quiere decir %{options}?'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -219,5 +219,7 @@ fr:
 
     entry_name:
       default: 'résultat'
+      grouped:
+        default: 'résultat groupé'
 
     did_you_mean: 'Essayez peut-être avec : %{options}'

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -208,5 +208,7 @@ hu:
 
     entry_name:
       default: 'bejegyzés'
+      grouped:
+        default: 'csoportosított eredmény'
 
     did_you_mean: 'Arra gondolt, hogy: %{options}?'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -215,5 +215,7 @@ it:
 
     entry_name:
       default: 'termine di ricerca'
+      grouped:
+        default: 'risultato raggruppato'
 
     did_you_mean: 'Intendevi digitare: %{options}?'

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -208,5 +208,7 @@ nl:
 
     entry_name:
       default: 'ingang'
+      grouped:
+        default: 'gegroepeerd resultaat'
 
     did_you_mean: 'Bedoelde u: %{options}?'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -217,5 +217,7 @@ pt-BR:
 
     entry_name:
       default: 'registro'
+      grouped:
+        default: 'resultado agrupado'
 
     did_you_mean: 'Você quis dizer: %{options}?'

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -206,5 +206,7 @@ sq:
 
     entry_name:
       default: 'entry'
+      grouped:
+        default: 'rezultat i grupuar'
 
     did_you_mean: 'A keni menduar: %{options}?'

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -208,5 +208,7 @@ zh:
 
     entry_name:
       default: '条目'
+      grouped:
+        default: '分组结果'
 
     did_you_mean: '你是要输入： %{options} 吗？'

--- a/lib/blacklight/solr/response/group_response.rb
+++ b/lib/blacklight/solr/response/group_response.rb
@@ -39,6 +39,16 @@ class Blacklight::Solr::Response::GroupResponse
     total.zero?
   end
 
+  ##
+  # Overridden from Blacklight::Solr::Response::PaginationMethods to support
+  # grouped key specific i18n keys. `key` is the field being grouped
+  def entry_name(options)
+    I18n.t(
+      "blacklight.entry_name.grouped.#{key}",
+      default: :'blacklight.entry_name.grouped.default'
+    ).pluralize(options[:count])
+  end
+
   def method_missing meth, *args, &block
     if response.respond_to? meth
       response.send(meth, *args, &block)

--- a/lib/blacklight/solr/response/pagination_methods.rb
+++ b/lib/blacklight/solr/response/pagination_methods.rb
@@ -16,6 +16,12 @@ module Blacklight::Solr::Response::PaginationMethods
   end
 
   ##
+  # Should return response documents size, not hash size
+  def size
+    total_count
+  end
+
+  ##
   # Meant to have the same signature as Kaminari::PaginatableArray#entry_name
   def entry_name(options)
     I18n.t('blacklight.entry_name.default').pluralize(options[:count])

--- a/lib/blacklight/solr/response/pagination_methods.rb
+++ b/lib/blacklight/solr/response/pagination_methods.rb
@@ -14,4 +14,10 @@ module Blacklight::Solr::Response::PaginationMethods
   def total_count #:nodoc:
     total
   end
+
+  ##
+  # Meant to have the same signature as Kaminari::PaginatableArray#entry_name
+  def entry_name(options)
+    I18n.t('blacklight.entry_name.default').pluralize(options[:count])
+  end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -62,15 +62,6 @@ RSpec.describe CatalogHelper do
         expect(html).to eq "<strong>1</strong> entry found"
         expect(html).to be_html_safe
       end
-
-      it "uses the model_name from the response" do
-        response = mock_response total: 1
-        allow(response).to receive(:model_name).and_return(double(human: 'thingy'))
-
-        html = page_entries_info(response)
-        expect(html).to eq "<strong>1</strong> thingy found"
-        expect(html).to be_html_safe
-      end
     end
 
     it "with a single page of results" do

--- a/spec/models/blacklight/solr/response/group_response_spec.rb
+++ b/spec/models/blacklight/solr/response/group_response_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe Blacklight::Solr::Response::GroupResponse, api: true do
       expect(group.empty?).to be false
     end
   end
+
+  describe "entry_name" do
+    it "accesses a custom field grouped i18n key" do
+      allow(I18n).to receive(:t).with(
+        'blacklight.entry_name.grouped.result_group_ssi',
+        default: :'blacklight.entry_name.grouped.default'
+      ).and_return('cool group')
+      expect(group.entry_name(count: 2)).to eq 'cool groups'
+    end
+    it "falls back to default group key" do
+      expect(group.entry_name(count: 2)).to eq 'grouped results'
+    end
+  end
 end
 
 def create_response(response, params = {})

--- a/spec/models/blacklight/solr/response_spec.rb
+++ b/spec/models/blacklight/solr/response_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Blacklight::Solr::Response, api: true do
     expect(r.prev_page).to eq(nil)
     expect(r.entry_name(count: 1)).to eq 'entry'
     expect(r.entry_name(count: 2)).to eq 'entries'
+    expect(r.size).to eq 26
     if Kaminari.config.respond_to? :max_pages
       expect(r.max_pages).to be_nil
     end

--- a/spec/models/blacklight/solr/response_spec.rb
+++ b/spec/models/blacklight/solr/response_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe Blacklight::Solr::Response, api: true do
     expect(r.total_count).to eq(r.total)
     expect(r.next_page).to eq(r.current_page + 1)
     expect(r.prev_page).to eq(nil)
+    expect(r.entry_name(count: 1)).to eq 'entry'
+    expect(r.entry_name(count: 2)).to eq 'entries'
     if Kaminari.config.respond_to? :max_pages
       expect(r.max_pages).to be_nil
     end


### PR DESCRIPTION
Enables https://github.com/projectblacklight/arclight/issues/699 and replacing approach in https://github.com/projectblacklight/arclight/pull/775.

A few things about this pull request. At first I aimed to target removal of `page_entries_info` in a Blacklight 8 release by removing our custom i18n keys and just using Kaminari's. This would have worked except for the two remaining Blacklight needs:
 - We need to change the math for grouped results
 - We need to provide delimited number strings

We could accmmodate either one of those I think independently, but together I couldn't figure out a way to successfully push that to the `Blacklight::Solr::Response` in a sane way.

I've hopefully simplified this method a bit so that future Blacklight maintainers have an easier time. 🤞 