### PR TITLE
add aria-labels to section tags, fixes arclight issue 841

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:content) do %>
   <% if content_for? :sidebar %>
-    <section id="content" class="<%= main_content_classes %> order-last">
+    <section id="content" class="<%= main_content_classes %> order-last" aria-label="search results">
       <%= yield %>
     </section>
 
-    <section id="sidebar" class="<%= sidebar_classes %> order-first">
+    <section id="sidebar" class="<%= sidebar_classes %> order-first" aria-label="limit your search">
       <%= content_for(:sidebar) %>
     </section>
   <% else %>


### PR DESCRIPTION
closes projectblacklight/arclight#841

Blacklight is using 'section' tags to define major page areas. On the search results pages, it would be useful for these sections to have aria-labels, to make them more accessible to screen readers. (Landmarks without labels don't show up in landmark lists on at least some SRs.)

> section id="content" add aria-label="search results"
>  section id="sidebar" add aria-label="limit your search"

It's redundant, but gives a more complete picture of the page in the landmarks list.

<a href="https://cl.ly/73d3beef4828" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1w041E2E2H3t442w0m3H/%5Bd41b42487d3fe5e762d2b7d19c001a28%5D_Screen+Shot+2019-09-23+at+10.02.06+AM.png" style="display: block;height: auto;width: 100%;"/></a>