### PR TITLE
add main landmark and translations

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -19,7 +19,7 @@
   <body class="<%= render_body_class %>">
   <%= render partial: 'shared/header_navbar' %>
 
-  <div id="main-container" class="<%= container_classes %>" role="main", aria-label="<%= t('blacklight.main.aria.main_container') %>">
+  <div id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -19,7 +19,7 @@
   <body class="<%= render_body_class %>">
   <%= render partial: 'shared/header_navbar' %>
 
-  <div id="main-container" class="<%= container_classes %>">
+  <div id="main-container" class="<%= container_classes %>" role="main", aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -19,7 +19,7 @@
   <body class="<%= render_body_class %>">
   <%= render partial: 'shared/header_navbar' %>
 
-  <div id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+  <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
@@ -27,7 +27,7 @@
     <div class="row">
       <%= content_for?(:content) ? yield(:content) : yield %>
     </div>
-  </div>
+  </main>
 
   <%= render partial: 'shared/footer' %>
   <%= render partial: 'shared/modal' %>

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -219,3 +219,7 @@ de:
       default: 'Eintrag'
 
     did_you_mean: 'Meinten Sie: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Hauptinhalt'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -219,3 +219,7 @@ en:
       default: 'entry'
 
     did_you_mean: 'Did you mean to type: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Main content'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -219,3 +219,7 @@ es:
       default: 'entrada'
 
     did_you_mean: '¿Quiere decir %{options}?'
+
+    main:
+      aria:
+        main_container: 'Contenido principal'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -223,3 +223,7 @@ fr:
       default: 'résultat'
 
     did_you_mean: 'Essayez peut-être avec : %{options}'
+
+    main:
+      aria:
+        main_container: 'Contenu principal'

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -212,3 +212,7 @@ hu:
       default: 'bejegyzés'
 
     did_you_mean: 'Arra gondolt, hogy: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Központi téma'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -219,3 +219,7 @@ it:
       default: 'termine di ricerca'
 
     did_you_mean: 'Intendevi digitare: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Contenuto principale'

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -212,3 +212,7 @@ nl:
       default: 'ingang'
 
     did_you_mean: 'Bedoelde u: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Belangrijkste inhoud'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -221,3 +221,7 @@ pt-BR:
       default: 'registro'
 
     did_you_mean: 'Você quis dizer: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Conteúdo principal'

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -210,3 +210,7 @@ sq:
       default: 'entry'
 
     did_you_mean: 'A keni menduar: %{options}?'
+
+    main:
+      aria:
+        main_container: 'Përmbajtja kryesore'

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -212,3 +212,7 @@ zh:
       default: '条目'
 
     did_you_mean: '你是要输入： %{options} 吗？'
+
+    main:
+      aria:
+        main_container: '主要内容'


### PR DESCRIPTION
closes projectblacklight/arclight#838

Accessibility ticket:
It's WCAG best practice that pages have a main landmark, and that all content on the page is contained by landmarks.

 Change
> div id="main-container" class="container" 

to

> main id="main-container" class="container" role="main" aria-label="Main content"

<a href="https://cl.ly/82dbdd3b477b" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2o1b3L1c1h3K2d1m1s08/Screen%20Shot%202019-09-24%20at%209.14.32%20AM.png" style="display: block;height: auto;width: 100%;"/></a>

<a href="https://cl.ly/aab8045e203e" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3G1v3q411V2D2X3q1K3a/Screen%20Shot%202019-09-24%20at%209.13.59%20AM.png" style="display: block;height: auto;width: 100%;"/></a>