### PR TITLE
update sidebar breakpoint to large size

### DIFF
--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -22,14 +22,14 @@ module Blacklight
     # Classes used for sizing the main content of a Blacklight page
     # @return [String]
     def main_content_classes
-      'col-md-9'
+      'col-lg-9'
     end
 
     ##
     # Classes used for sizing the sidebar content of a Blacklight page
     # @return [String]
     def sidebar_classes
-      'page-sidebar col-md-3'
+      'page-sidebar col-lg-3'
     end
 
     ##

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -1,6 +1,6 @@
 <% # main container for facets/limits menu -%>
 <% if has_facet_values? facet_field_names(groupname) %>
-<div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-sm">
+<div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md">
 
   <div class="navbar">
     <h2 class="facets-heading">

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Facets" do
 
   it 'is able to expand facets when javascript is enabled', js: true do
     visit root_path
-
+    page.find('.navbar-toggler.navbar-toggler-right').click
     expect(page).to have_css('#facet-format', visible: false)
 
     page.find('h3.facet-field-heading a', text: 'Format').click

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe "Facets" do
   it "is collapsed when not selected", js: true do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
+    page.find('.navbar-toggler.navbar-toggler-right').click
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
     end
@@ -176,6 +177,7 @@ RSpec.describe "Facets" do
   it "expands when the heading is clicked", js: true do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
+    page.find('.navbar-toggler.navbar-toggler-right').click
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
       find(".card-header").click
@@ -185,6 +187,7 @@ RSpec.describe "Facets" do
   it "expands when the anchor is clicked", js: true do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
+    page.find('.navbar-toggler.navbar-toggler-right').click
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
       find(".card-header").click
@@ -194,6 +197,7 @@ RSpec.describe "Facets" do
   it "keeps selected facets expanded on page load", js: true do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
+    page.find('.navbar-toggler.navbar-toggler-right').click
     within(".blacklight-subject_ssim") do
       click_link "Topic"
       expect(page).to have_selector(".panel-collapse", visible: true)

--- a/spec/helpers/blacklight/layout_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/layout_helper_behavior_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe Blacklight::LayoutHelperBehavior do
   describe '#show_content_classes' do
     it 'returns a string of classes' do
       expect(helper.show_content_classes).to be_an String
-      expect(helper.show_content_classes).to eq 'col-md-9 show-document'
+      expect(helper.show_content_classes).to eq 'col-lg-9 show-document'
     end
   end
 
   describe '#show_sidebar_classes' do
     it 'returns a string of classes' do
       expect(helper.show_sidebar_classes).to be_an String
-      expect(helper.show_sidebar_classes).to eq 'page-sidebar col-md-3'
+      expect(helper.show_sidebar_classes).to eq 'page-sidebar col-lg-3'
     end
   end
 
   describe '#main_content_classes' do
     it 'returns a string of classes' do
       expect(helper.main_content_classes).to be_an String
-      expect(helper.main_content_classes).to eq 'col-md-9'
+      expect(helper.main_content_classes).to eq 'col-lg-9'
     end
   end
 
   describe '#sidebar_classes' do
     it 'returns a string of classes' do
       expect(helper.sidebar_classes).to be_an String
-      expect(helper.sidebar_classes).to eq 'page-sidebar col-md-3'
+      expect(helper.sidebar_classes).to eq 'page-sidebar col-lg-3'
     end
   end
 


### PR DESCRIPTION
Closes issue #2133 

### Issue
Change the responsive behavior of the sidebar such that it doesn't go to three columns unless we are in the large or xlarge breakpoints. Make sure the facets collapse at the medium breakpoint

### Discussion
updated some facet and search filters specs to click the collapsed facet menu

### Demos
#### BlackLight sample app Medium
<a href="https://cl.ly/defdc8e6b79f" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3W280q2u1Y2Q1F3B3G2j/Screen%20Shot%202019-09-30%20at%201.34.45%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

#### BlackLight sample app Large
<a href="https://cl.ly/4f6f17e80252" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2P111B0h0L1Q0i0z3q00/Screen%20Shot%202019-09-30%20at%201.34.23%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

#### ArcLight sample app Medium
<a href="https://cl.ly/2ff637af6b89" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/13413u2V462e3F0z201C/Screen%20Shot%202019-09-30%20at%2012.02.15%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

#### ArcLight sample app Large
<a href="https://cl.ly/ff912eb4c748" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1F2d1d0P2W0r173H2s2X/Screen%20Shot%202019-09-30%20at%2012.01.51%20PM.png" style="display: block;height: auto;width: 100%;"/></a>