### PR TITLE
Refresh CSRF tokens when updating resubmittable checkbox

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -156,6 +156,7 @@ Blacklight.onLoad(function () {
         checkbox.prop('checked', state);
         label.toggleClass('checked', state);
 
+        Rails.refreshCSRFTokens();
         if (state) {
           //Set the Rails hidden field that fakes an HTTP verb
           //properly for current state action.

--- a/app/javascript/blacklight/checkbox_submit.js
+++ b/app/javascript/blacklight/checkbox_submit.js
@@ -69,6 +69,7 @@
         function updateStateFor(state) {
             checkbox.prop('checked', state);
             label.toggleClass('checked', state);
+            Rails.refreshCSRFTokens();
             if (state) {
                //Set the Rails hidden field that fakes an HTTP verb
                //properly for current state action.


### PR DESCRIPTION
Co-authored-by: Christina Chortaria <actspatial@gmail.com>

Why does checkbox_submit.js exist when actually the site is using blacklight.js?

Fixes #2002.

Also fixes [Arclight #769](https://github.com/projectblacklight/arclight/issues/769).