### PR TITLE
Handle text input rounding based on the number of search fields.

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
 
     <span class="input-group-append">
       <button type="submit" class="btn btn-primary search-btn" id="search">


### PR DESCRIPTION
Bootstrap should handle this for us, but the markup that the typeahead library injects ends up messing that up.

To be honest, I don't know if this is worth it or not, but the borders have been bugging me.  An alternative would be to put some right margin on the fielded search drop down and have the left of the search input always be rounded and the right always be non-rounded (but that would remove the single-input appearance of the drop-down, text input, button we currently have though)

## Before
<img width="747" alt="single-field-before" src="https://user-images.githubusercontent.com/96776/66155336-3bc36780-e5d4-11e9-9ab1-27e9503ab9b2.png">

---

<img width="746" alt="many-fields-before" src="https://user-images.githubusercontent.com/96776/66155335-3bc36780-e5d4-11e9-982d-6e2e46e7285d.png">


## After
_Note: There is really no change here w/o a fielded search drop-down_
<img width="749" alt="single-field-after" src="https://user-images.githubusercontent.com/96776/66155339-3bc36780-e5d4-11e9-90ce-da033d5d4cca.png">

---

<img width="754" alt="many-fields-after" src="https://user-images.githubusercontent.com/96776/66155340-3c5bfe00-e5d4-11e9-8400-e4ad26cb0c70.png">
