### PR TITLE
Update asset generator

### DIFF
--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -16,7 +16,7 @@ module Blacklight
       return if has_blacklight_assets?
 
       contents = "\n//\n// Required by Blacklight\n"
-      contents += "//= require jquery\n"
+      contents += "//= require jquery3\n"
       contents += "//= require popper\n"
       contents += "// Twitter Typeahead for autocomplete\n"
       contents += "//= require twitter/typeahead\n"

--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -16,7 +16,6 @@ module Blacklight
       return if has_blacklight_assets?
 
       contents = "\n//\n// Required by Blacklight\n"
-      contents += "//= require jquery3\n"
       contents += "//= require popper\n"
       contents += "// Twitter Typeahead for autocomplete\n"
       contents += "//= require twitter/typeahead\n"
@@ -31,6 +30,10 @@ module Blacklight
 
       insert_into_file "app/assets/javascripts/application.js", after: marker do
         contents
+      end
+
+      insert_into_file "app/assets/javascripts/application.js", before: '//= require rails-ujs' do
+        "//= require jquery3\n"
       end
     end
 


### PR DESCRIPTION
Potentially complementary to #2164 

This PR does the following:
 - Updates new applications to use jquery3 by default
 - Modifies the generated location of the jquery require to be before the `rails-ujs` require.

This should (in my testing) resolve #2002.