### PR TITLE
Deprecate render_opensearch_response_metadata

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -50,8 +50,9 @@ module Blacklight::BlacklightHelperBehavior
   # Render OpenSearch headers for this search
   # @return [String]
   def render_opensearch_response_metadata
-    render partial: 'catalog/opensearch_response_metadata'
+    render partial: 'catalog/opensearch_response_metadata', locals: { response: @response }
   end
+  deprecation_deprecate render_opensearch_response_metadata: 'Use `render "catalog/opensearch_response_metadata"\' instead'
 
   ##
   # Render classes for the <body> element

--- a/app/views/catalog/_opensearch_response_metadata.html.erb
+++ b/app/views/catalog/_opensearch_response_metadata.html.erb
@@ -1,3 +1,3 @@
-<%= tag :meta, :name => "totalResults", :content => @response.total %>
-<%= tag :meta, :name => "startIndex", :content => @response.start %>
-<%= tag :meta, :name => "itemsPerPage", :content => @response.limit_value %>
+<%= tag :meta, name: "totalResults", content: response.total %>
+<%= tag :meta, name: "startIndex", content: response.start %>
+<%= tag :meta, name: "itemsPerPage", content: response.limit_value %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,7 +1,7 @@
 <% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
 
 <% content_for(:head) do -%>
-  <%= render_opensearch_response_metadata %>
+  <%= render 'catalog/opensearch_response_metadata', response: @response %>
   <%= rss_feed_link_tag %>
   <%= atom_feed_link_tag %>
   <%= json_api_link_tag %>

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "catalog/index.html.erb" do
       stub_template "catalog/_search_header.html.erb" => "header_content"
       allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
       allow(view).to receive(:render_opensearch_response_metadata).and_return("")
-      assign(:response, instance_double(Blacklight::Solr::Response, empty?: true))
+      @response = instance_double(Blacklight::Solr::Response, empty?: true, total: 11, start: 1, limit_value: 10)
     end
 
     it "renders the search_header partial" do


### PR DESCRIPTION
It's just a simple partial render, so we can just replace it with a `render`