### PR TITLE
Update locales in i18n-tasks report

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,6 +1,6 @@
 # i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
 base_locale: en
-locales: [es, fr, de, it, pt-BR]
+locales: [ar, de, es, fr, hu, it, nl, pt-BR, sq, zh]
 data:
   read:
     - config/locales/%{locale}.yml

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -22,7 +22,7 @@ ar:
   blacklight:
     application_name: 'Blacklight'
     skip_links:
-      main_content:
+      main_content: 'انتقل إلى المحتوى الرئيسي'
       search_field: 'انتقل إلى البحث'
       first_result: 'انتقل إلى النتيجة الأولى'
     header_links:

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -6,6 +6,14 @@ hu:
       previous: '&laquo; Előző'
       next: 'Következő &raquo;'
       truncate: '…'
+      aria:
+        container_label: pagination linkek
+        current_page: Aktuális oldal, %{page} oldal
+        go_to_page: Ugrás a %{page} oldalra
+        go_to_previous_page: Ugrás az előző oldalra
+        go_to_next_page: Ugrás a következő oldalra
+        go_to_first_page: Ugrás az első oldalra
+        go_to_last_page: Ugrás az utolsó oldalra
 
     pagination_compact:
       previous: '&laquo; Előző'

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -6,6 +6,14 @@ nl:
       previous: '&laquo; Vorige'
       next: 'Volgende &raquo;'
       truncate: '…'
+      aria:
+        container_label: paginatielinks
+        current_page: Huidige pagina, Pagina %{page}
+        go_to_page: Ga naar pagina %{page}
+        go_to_previous_page: Ga naar de vorige pagina
+        go_to_next_page: Ga naar de volgende pagina
+        go_to_first_page: Ga naar de eerste pagina
+        go_to_last_page: Ga naar de laatste pagina
 
     pagination_compact:
       previous: '&laquo; Vorige'

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -6,12 +6,21 @@ sq:
       previous: '&laquo; Mbrapa'
       next: 'Tjetra &raquo;'
       truncate: '…'
+      aria:
+        container_label: lidhjet e pagination
+        current_page: Faqja aktuale, Faqja %{page}
+        go_to_page: Shkoni te faqja %{page}
+        go_to_previous_page: Shko te faqja e mëparshme
+        go_to_next_page: Shko te faqja tjetër
+        go_to_first_page: Shko tek faqja e parë
+        go_to_last_page: Shko tek faqja e fundit
 
     pagination_compact:
       previous: '&laquo; Mbrapa'
       next: 'Tjetra &raquo;'
 
   blacklight:
+    application_name: 'Blacklight'
     skip_links:
       main_content: 'Shkoni tek përmbajtja kryesore'
       search_field: 'Shkoni në kërkim'

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -6,6 +6,14 @@ zh:
       previous: '&laquo; 上一页'
       next: '下一页 &raquo;'
       truncate: '…'
+      aria:
+        container_label: 分页链接
+        current_page: 当前页面，页面%{page}
+        go_to_page: 前往页面%{page}
+        go_to_previous_page: 转到上一页
+        go_to_next_page: 转到下一页
+        go_to_first_page: 转到第一页
+        go_to_last_page: 转到最后一页
 
     pagination_compact:
       previous: '&laquo; 上一页'


### PR DESCRIPTION
`i18n-tasks health` only reports on a subset of locales right now. I doubt we're going to run `i18n-tasks normalize` soon, but it would be good to have an accurate understanding of translation drift over time.