### PR TITLE
Make initially expanded collapsible facets have proper aria-expanded

### DIFF
--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,15 +1,15 @@
 <div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
   <h3 class="card-header p-0 facet-field-heading" id="<%= facet_field_id(facet_field) %>-header">
     <button
-      class="btn btn-block p-2 text-left <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle"
+      class="btn btn-block p-2 text-left collapse-toggle"
       data-toggle="collapse"
       data-target="#<%= facet_field_id(facet_field) %>"
-      aria-expanded="false"
+      aria-expanded="<%= should_collapse_facet?(facet_field) ? 'false' : 'true' %>"
     >
       <%= facet_field_label(facet_field.key) %>
     </button>
   </h3>
-  <div id="<%= facet_field_id(facet_field) %>" aria-labelledby="<%= facet_field_id(facet_field) %>-header" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
+  <div id="<%= facet_field_id(facet_field) %>" aria-labelledby="<%= facet_field_id(facet_field) %>-header" class="panel-collapse facet-content collapse <%= "show" unless should_collapse_facet?(facet_field) %>">
     <div  class="card-body">
       <%= yield %>
     </div>

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -27,14 +27,15 @@ RSpec.describe "catalog/facet_layout" do
 
   it "is collapsable" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
-    expect(rendered).to have_selector 'button.collapsed'
+    expect(rendered).to have_selector 'button[data-toggle="collapse"][aria-expanded="false"]'
     expect(rendered).to have_selector '.collapse .card-body'
   end
 
   it "is configured to be open by default" do
     allow(facet_field).to receive_messages(collapse: false)
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
+    expect(rendered).to have_selector 'button[data-toggle="collapse"][aria-expanded="true"]'
     expect(rendered).not_to have_selector '.card-header.collapsed'
-    expect(rendered).to have_selector '.show .card-body'
+    expect(rendered).to have_selector '.collapse.show .card-body'
   end
 end


### PR DESCRIPTION
And otherwise match my reading of instructions at Bootstrap 4 Collapsible. https://getbootstrap.com/docs/4.3/components/collapse/

* No collapse class is needed on the button trigger, whether initially expanded or not.
* Content needs collapse class whether initially expanded or not, but also needs show class if initially expanded.

Manually tested in an app created with quick start, everything seems to work fine.
Closes #2194