### PR TITLE
Use FieldRetriever and FieldPresenter consistently for index + show fields and title fields

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -166,6 +166,7 @@ module Blacklight::ConfigurationHelperBehavior
 
     field
   end
+  deprecation_deprecate document_show_link_field: 'Deprecated without replacement'
 
   ##
   # Default sort field

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -21,10 +21,10 @@ module Blacklight::UrlHelperBehavior
   def link_to_document(doc, field_or_opts = nil, opts = { counter: nil })
     label = case field_or_opts
             when NilClass
-              index_presenter(doc).label document_show_link_field(doc), opts
+              index_presenter(doc).heading
             when Hash
               opts = field_or_opts
-              index_presenter(doc).label document_show_link_field(doc), opts
+              index_presenter(doc).heading
             when Proc, Symbol
               Deprecation.warn(self, "passing a #{field_or_opts.class} to link_to_document is deprecated and will be removed in Blacklight 8")
               Deprecation.silence(Blacklight::IndexPresenter) do

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -14,6 +14,19 @@ module Blacklight
       end
     end
 
+    ##
+    # Get the value of the document's "title" field, or a placeholder
+    # value (if empty)
+    #
+    # @return [String]
+    def heading
+      return field_values(view_config.title_field) if view_config.title_field.is_a? Blacklight::Configuration::Field
+
+      fields = Array.wrap(view_config.title_field) + [configuration.document_model.unique_key]
+      f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| retrieve_values(field_config).any? }
+      field_values(f, except_operations: [Rendering::HelperMethod])
+    end
+
     private
 
     ##

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -29,10 +29,28 @@ module Blacklight
     # the given solr field
     # @param [Blacklight::Configuration::Field] field_config
     # @return [Boolean]
-    def has_value? field_config
-      document.has?(field_config.field) ||
-        (document.has_highlight_field? field_config.field if field_config.highlight) ||
-        field_config.accessor
+    def has_value?(field_config)
+      retrieve_values(field_config).present?
+    end
+
+    ##
+    # Get the value for a document's field, and prepare to render it.
+    # - highlight_field
+    # - accessor
+    # - solr field
+    #
+    # Rendering:
+    #   - helper_method
+    #   - link_to_facet
+    # @param [Blacklight::Configuration::Field] field_config solr field configuration
+    # @param [Hash] options additional options to pass to the rendering helpers
+    def field_values(field_config, options = {})
+      options[:values] ||= retrieve_values(field_config) unless options.key? :value
+      FieldPresenter.new(view_context, document, field_config, options).render
+    end
+
+    def retrieve_values(field_config)
+      FieldRetriever.new(document, field_config).fetch
     end
   end
 end

--- a/app/presenters/blacklight/field_presenter.rb
+++ b/app/presenters/blacklight/field_presenter.rb
@@ -7,29 +7,40 @@ module Blacklight
     # @param document [SolrDocument] the document
     # @param field_config [Blacklight::Configuration::Field] the field's configuration
     # @param options [Hash]
-    # @option options [Object] :value when this is provided, we don't want the pipeline to deal with helper methods.
-    #                                 this happens when drawing the label for the document
-    def initialize(controller, document, field_config, options)
+    # @option options [Object] :values
+    # @option options [Array] :except_operations
+    # @option options [Object] :value
+    # @option options [Array] :steps
+    def initialize(controller, document, field_config, options = {})
       @controller = controller
       @document = document
       @field_config = field_config
       @options = options
+
+      @values = if options.key?(:value)
+                  Array.wrap(options[:value])
+                else
+                  options[:values]
+                end
+
+      @except_operations = options[:except_operations] || []
+      # Implicitly prevent helper methods from drawing when drawing the label for the document
+      @except_operations += [Rendering::HelperMethod] if options.key? :value
     end
 
-    attr_reader :controller, :document, :field_config, :options
+    attr_reader :controller, :document, :field_config, :values, :except_operations, :options
 
     def render
-      return Rendering::Pipeline.render(retrieve_values, field_config, document, controller, options) unless options[:value]
-
-      values = Array.wrap(options[:value])
-      # Prevents helper methods from drawing.
-      steps = Rendering::Pipeline.operations - [Rendering::HelperMethod]
-      Rendering::Pipeline.new(values, field_config, document, controller, steps, options).render
+      Rendering::Pipeline.new(values || retrieve_values, field_config, document, controller, pipeline_steps, options).render
     end
 
     private
 
-    def retrieve_values
+    def pipeline_steps
+      (options[:steps] || Rendering::Pipeline.operations) - except_operations
+    end
+
+    def retrieve_values(field_config)
       FieldRetriever.new(document, field_config).fetch
     end
   end

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -28,7 +28,7 @@ module Blacklight
       value = case field_or_string_or_proc
                 when Symbol
                   config = field_config(field_or_string_or_proc)
-                  document[field_or_string_or_proc]
+                  retrieve_values(config)
                 when Proc
                   Deprecation.warn(self, "calling IndexPresenter.label with a Proc is deprecated. " \
                                          "First argument must be a symbol. This will be removed in Blacklight 8")
@@ -39,7 +39,7 @@ module Blacklight
                   field_or_string_or_proc
               end
 
-      value ||= document.id
+      value = document.id if value.blank?
       field_values(config, values: Array.wrap(value), except_operations: [Rendering::HelperMethod])
     end
 

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -40,7 +40,7 @@ module Blacklight
               end
 
       value ||= document.id
-      field_values(config, value: value)
+      field_values(config, values: Array.wrap(value), except_operations: [Rendering::HelperMethod])
     end
 
     ##
@@ -64,21 +64,6 @@ module Blacklight
     # @return [Hash<String,Configuration::Field>] all the fields for this index view
     def fields
       configuration.index_fields_for(document)
-    end
-
-    ##
-    # Get the value for a document's field, and prepare to render it.
-    # - highlight_field
-    # - accessor
-    # - solr field
-    #
-    # Rendering:
-    #   - helper_method
-    #   - link_to_facet
-    # @param [Blacklight::Configuration::Field] field_config solr field configuration
-    # @param [Hash] options additional options to pass to the rendering helpers
-    def field_values(field_config, options = {})
-      FieldPresenter.new(view_context, document, field_config, options).render
     end
 
     def field_config(field)

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -22,7 +22,6 @@ module Blacklight
     #
     # @param [Symbol, Proc, String] field_or_string_or_proc Render the given field or evaluate the proc or render the given string
     # @param [Hash] opts
-    # TODO: the default field should be `document_show_link_field(doc)'
     def label(field_or_string_or_proc, opts = {})
       config = Configuration::NullField.new
       value = case field_or_string_or_proc
@@ -42,6 +41,8 @@ module Blacklight
       value = document.id if value.blank?
       field_values(config, values: Array.wrap(value), except_operations: [Rendering::HelperMethod])
     end
+
+    deprecation_deprecate label: 'Use #heading'
 
     ##
     # Render the index field label for a document

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -30,10 +30,9 @@ module Blacklight
     # @return [String]
     def html_title
       if view_config.html_title_field
-        fields = Array.wrap(view_config.html_title_field)
-        f = fields.detect { |field| document.has? field }
-        f ||= configuration.document_model.unique_key
-        field_values(field_config(f))
+        fields = Array.wrap(view_config.html_title_field) + [configuration.document_model.unique_key]
+        f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| retrieve_values(field_config).any? }
+        field_values(f)
       else
         heading
       end
@@ -45,10 +44,9 @@ module Blacklight
     #
     # @return [String]
     def heading
-      fields = Array.wrap(view_config.title_field)
-      f = fields.detect { |field| document.has? field }
-      f ||= configuration.document_model.unique_key
-      field_values(field_config(f), except_operations: [Rendering::HelperMethod])
+      fields = Array.wrap(view_config.title_field) + [configuration.document_model.unique_key]
+      f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| retrieve_values(field_config).any? }
+      field_values(f, except_operations: [Rendering::HelperMethod])
     end
 
     ##

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -32,7 +32,7 @@ module Blacklight
       if view_config.html_title_field
         fields = Array.wrap(view_config.html_title_field)
         f = fields.detect { |field| document.has? field }
-        f ||= 'id'
+        f ||= configuration.document_model.unique_key
         field_values(field_config(f))
       else
         heading
@@ -48,7 +48,7 @@ module Blacklight
       fields = Array.wrap(view_config.title_field)
       f = fields.detect { |field| document.has? field }
       f ||= configuration.document_model.unique_key
-      field_values(field_config(f), value: document[f])
+      field_values(field_config(f), except_operations: [Rendering::HelperMethod])
     end
 
     ##
@@ -68,21 +68,6 @@ module Blacklight
     # @return [Hash<String,Configuration::Field>]
     def fields
       configuration.show_fields_for(document)
-    end
-
-    ##
-    # Get the value for a document's field, and prepare to render it.
-    # - highlight_field
-    # - accessor
-    # - solr field
-    #
-    # Rendering:
-    #   - helper_method
-    #   - link_to_facet
-    # @param [Blacklight::Configuration::Field] field_config solr field configuration
-    # @param [Hash] options additional options to pass to the rendering helpers
-    def field_values(field_config, options = {})
-      FieldPresenter.new(view_context, document, field_config, options).render
     end
 
     def view_config

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -29,6 +29,8 @@ module Blacklight
     # @see #document_heading
     # @return [String]
     def html_title
+      return field_values(view_config.html_title_field) if view_config.html_title_field.is_a? Blacklight::Configuration::Field
+
       if view_config.html_title_field
         fields = Array.wrap(view_config.html_title_field) + [configuration.document_model.unique_key]
         f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| retrieve_values(field_config).any? }
@@ -44,6 +46,8 @@ module Blacklight
     #
     # @return [String]
     def heading
+      return field_values(view_config.title_field) if view_config.title_field.is_a? Blacklight::Configuration::Field
+
       fields = Array.wrap(view_config.title_field) + [configuration.document_model.unique_key]
       f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| retrieve_values(field_config).any? }
       field_values(f, except_operations: [Rendering::HelperMethod])

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -41,19 +41,6 @@ module Blacklight
     end
 
     ##
-    # Get the value of the document's "title" field, or a placeholder
-    # value (if empty)
-    #
-    # @return [String]
-    def heading
-      return field_values(view_config.title_field) if view_config.title_field.is_a? Blacklight::Configuration::Field
-
-      fields = Array.wrap(view_config.title_field) + [configuration.document_model.unique_key]
-      f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| retrieve_values(field_config).any? }
-      field_values(f, except_operations: [Rendering::HelperMethod])
-    end
-
-    ##
     # Render the show field value for a document
     #
     # Allow an extention point where information in the document

--- a/app/services/blacklight/field_retriever.rb
+++ b/app/services/blacklight/field_retriever.rb
@@ -19,7 +19,9 @@ module Blacklight
           retrieve_highlight
         elsif field_config.accessor
           retieve_using_accessor
-        elsif field_config
+        elsif field_config.values
+          retrieve_values
+        else
           retrieve_simple
         end
       )
@@ -54,6 +56,10 @@ module Blacklight
     def retrieve_highlight
       # retrieve the document value from the highlighting response
       document.highlight_field(field_config.field).map(&:html_safe) if document.has_highlight_field? field_config.field
+    end
+
+    def retrieve_values
+      field_config.values.call(field_config, document)
     end
   end
 end

--- a/app/views/catalog/_document.atom.builder
+++ b/app/views/catalog/_document.atom.builder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 xml.entry do
-  xml.title index_presenter(document).label(document_show_link_field(document))
+  xml.title index_presenter(document).heading
 
   # updated is required, for now we'll just set it to now, sorry
   xml.updated Time.current.iso8601

--- a/app/views/catalog/_document.rss.builder
+++ b/app/views/catalog/_document.rss.builder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-xml.item do  
-  xml.title(index_presenter(document).label(document_show_link_field(document)) || (document.to_semantic_values[:title].first if document.to_semantic_values.key?(:title)))
+xml.item do
+  xml.title(index_presenter(document).heading || (document.to_semantic_values[:title].first if document.to_semantic_values.key?(:title)))
   xml.link(polymorphic_url(url_for_document(document)))
   xml.author( document.to_semantic_values[:author].first ) if document.to_semantic_values.key? :author
 end

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
   describe "#document_show_link_field" do
     let(:document) { SolrDocument.new id: 123, a: 1, b: 2, c: 3 }
 
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
     it "allows single values" do
       blacklight_config.index.title_field = :a
       f = helper.document_show_link_field document

--- a/spec/helpers/blacklight/url_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/url_helper_behavior_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "consists of the document title wrapped in a <a>" do
-      expect(Deprecation).to receive(:warn)
+      allow(Deprecation).to receive(:warn)
       expect(helper.link_to_document(document, :title_tsim)).to have_selector("a", text: '654321', count: 1)
     end
 
@@ -215,7 +215,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "accepts and returns a Proc" do
-      expect(Deprecation).to receive(:warn).twice
+      allow(Deprecation).to receive(:warn)
       expect(helper.link_to_document(document, proc { |doc, _opts| doc[:id] + ": " + doc.first(:title_tsim) })).to have_selector("a", text: '123456: 654321', count: 1)
     end
 
@@ -223,12 +223,12 @@ RSpec.describe Blacklight::UrlHelperBehavior do
       let(:data) { { 'id' => id } }
 
       it "returns id" do
-        expect(Deprecation).to receive(:warn)
+        allow(Deprecation).to receive(:warn)
         expect(helper.link_to_document(document, :title_tsim)).to have_selector("a", text: '123456', count: 1)
       end
 
       it "is html safe" do
-        expect(Deprecation).to receive(:warn)
+        allow(Deprecation).to receive(:warn)
         expect(helper.link_to_document(document, :title_tsim)).to be_html_safe
       end
 
@@ -250,7 +250,7 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     end
 
     it "converts the counter parameter into a data- attribute" do
-      expect(Deprecation).to receive(:warn)
+      allow(Deprecation).to receive(:warn)
       expect(helper.link_to_document(document, :title_tsim, counter: 5)).to include 'data-context-href="tracking url"'
       expect(helper.main_app).to have_received(:track_test_path).with(hash_including(id: have_attributes(id: '123456'), counter: 5))
     end

--- a/spec/presenters/blacklight/document_presenter_spec.rb
+++ b/spec/presenters/blacklight/document_presenter_spec.rb
@@ -52,10 +52,11 @@ RSpec.describe Blacklight::DocumentPresenter do
     subject { presenter.send(:has_value?, field_config) }
 
     context 'when the document has the field value' do
-      let(:field_config) { double(field: 'asdf') }
+      let(:field_config) { double(field: 'asdf', highlight: false, accessor: nil, default: nil) }
 
       before do
         allow(doc).to receive(:has?).with('asdf').and_return(true)
+        allow(doc).to receive(:fetch).with('asdf', nil).and_return(['value'])
       end
 
       it { is_expected.to be true }
@@ -66,18 +67,17 @@ RSpec.describe Blacklight::DocumentPresenter do
 
       before do
         allow(doc).to receive(:has_highlight_field?).with('asdf').and_return(true)
-        allow(doc).to receive(:has?).with('asdf').and_return(true)
+        allow(doc).to receive(:highlight_field).with('asdf').and_return(['value'])
       end
 
       it { is_expected.to be true }
     end
 
     context 'when the field is a model accessor' do
-      let(:field_config) { double(field: 'asdf', highlight: true, accessor: true) }
+      let(:field_config) { double(field: 'asdf', highlight: false, accessor: true) }
 
       before do
-        allow(doc).to receive(:has_highlight_field?).with('asdf').and_return(true)
-        allow(doc).to receive(:has?).with('asdf').and_return(true)
+        allow(doc).to receive(:send).with('asdf').and_return(['value'])
       end
 
       it { is_expected.to be true }

--- a/spec/presenters/blacklight/document_presenter_spec.rb
+++ b/spec/presenters/blacklight/document_presenter_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Blacklight::DocumentPresenter do
       let(:field_config) { double(field: 'asdf', highlight: false, accessor: nil, default: nil) }
 
       before do
-        allow(doc).to receive(:has?).with('asdf').and_return(true)
         allow(doc).to receive(:fetch).with('asdf', nil).and_return(['value'])
       end
 

--- a/spec/presenters/blacklight/document_presenter_spec.rb
+++ b/spec/presenters/blacklight/document_presenter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Blacklight::DocumentPresenter do
     subject { presenter.send(:has_value?, field_config) }
 
     context 'when the document has the field value' do
-      let(:field_config) { double(field: 'asdf', highlight: false, accessor: nil, default: nil) }
+      let(:field_config) { double(field: 'asdf', highlight: false, accessor: nil, default: nil, values: nil) }
 
       before do
         allow(doc).to receive(:fetch).with('asdf', nil).and_return(['value'])

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -277,8 +277,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
 
     it "returns the first present value" do
       config.show.title_field = [:x, :y]
-      allow(document).to receive(:has?).with(:x).and_return(false)
-      allow(document).to receive(:has?).with(:y).and_return(true)
+      allow(document).to receive(:fetch).with(:x, nil).and_return(nil)
       allow(document).to receive(:fetch).with(:y, nil).and_return("value")
       expect(subject.heading).to eq "value"
     end
@@ -299,8 +298,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
 
     it "returns the first present value" do
       config.show.html_title_field = [:x, :y]
-      allow(document).to receive(:has?).with(:x).and_return(false)
-      allow(document).to receive(:has?).with(:y).and_return(true)
+      allow(document).to receive(:fetch).with(:x, nil).and_return(nil)
       allow(document).to receive(:fetch).with(:y, nil).and_return("value")
       expect(subject.html_title).to eq "value"
     end

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
     it "returns the value of the field" do
       config.show.title_field = :x
       allow(document).to receive(:has?).with(:x).and_return(true)
-      allow(document).to receive(:[]).with(:x).and_return("value")
+      allow(document).to receive(:fetch).with(:x, nil).and_return("value")
       expect(subject.heading).to eq "value"
     end
 
@@ -279,7 +279,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
       config.show.title_field = [:x, :y]
       allow(document).to receive(:has?).with(:x).and_return(false)
       allow(document).to receive(:has?).with(:y).and_return(true)
-      allow(document).to receive(:[]).with(:y).and_return("value")
+      allow(document).to receive(:fetch).with(:y, nil).and_return("value")
       expect(subject.heading).to eq "value"
     end
   end

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
         config.add_show_field 'solr_doc_accessor', accessor: true
         config.add_show_field 'explicit_accessor', accessor: :solr_doc_accessor
         config.add_show_field 'explicit_array_accessor', accessor: [:solr_doc_accessor, :some_method]
+        config.add_show_field 'explicit_values', values: ->(_config, _doc) { ['some-value'] }
       end
     end
 
@@ -246,6 +247,14 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
         allow(document).to receive_message_chain(:solr_doc_accessor, some_method: "123")
 
         expect(subject).to eq '123'
+      end
+    end
+
+    context 'when the values lambda is provided' do
+      let(:field_name) { 'explicit_values' }
+
+      it 'calls the accessors on the return of the preceeding' do
+        expect(subject).to eq 'some-value'
       end
     end
   end

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -290,6 +290,11 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
       allow(document).to receive(:fetch).with(:y, nil).and_return("value")
       expect(subject.heading).to eq "value"
     end
+
+    it "can use explicit field configuration" do
+      config.show.title_field = Blacklight::Configuration::Field.new(field: 'x', values: ->(*_) { 'hardcoded' })
+      expect(subject.heading).to eq 'hardcoded'
+    end
   end
 
   describe "#html_title" do
@@ -310,6 +315,11 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
       allow(document).to receive(:fetch).with(:x, nil).and_return(nil)
       allow(document).to receive(:fetch).with(:y, nil).and_return("value")
       expect(subject.html_title).to eq "value"
+    end
+
+    it "can use explicit field configuration" do
+      config.show.html_title_field = Blacklight::Configuration::Field.new(field: 'x', values: ->(*_) { 'hardcoded' })
+      expect(subject.html_title).to eq 'hardcoded'
     end
   end
 


### PR DESCRIPTION
Also, refactor the way titles are displayed by pulling up a consistent `#header` method (from ShowPresenter) and use it with the IndexPresenter as well. Finally, add some additional logic to the fields configuration to allow explicit configuration of the field rendering including calculating values in a lambda context (where it could, say, pull out the first field with data) as an alternative to a list of fields to try.
