### PR TITLE
Use the FieldRetriever or presenter methods for accessing data in a document

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -134,8 +134,7 @@ module Blacklight::CatalogHelperBehavior
   #
   # @return [String]
   def render_document_class(document = @document)
-    types = document[blacklight_config.view_config(document_index_view_type).display_type_field]
-
+    types = presenter(document).display_type
     return if types.blank?
 
     Array(types).compact.map do |t|

--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -55,7 +55,7 @@ module Blacklight::ConfigurationHelperBehavior
   ##
   # Look up the label for the index field
   def index_field_label document, field
-    field_config = blacklight_config.index_fields_for(document)[field]
+    field_config = blacklight_config.index_fields_for(index_presenter(document).display_type)[field]
     field_config ||= Blacklight::Configuration::NullField.new(key: field)
 
     field_config.display_label('index')
@@ -64,7 +64,7 @@ module Blacklight::ConfigurationHelperBehavior
   ##
   # Look up the label for the show field
   def document_show_field_label document, field
-    field_config = blacklight_config.show_fields_for(document)[field]
+    field_config = blacklight_config.show_fields_for(show_presenter(document).display_type)[field]
     field_config ||= Blacklight::Configuration::NullField.new(key: field)
 
     field_config.display_label('show')

--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -115,15 +115,7 @@ module Blacklight::RenderPartialsHelperBehavior
   # @param [Symbol] base_name base name for the partial
   # @return [String]
   def document_partial_name(document, base_name = nil)
-    view_config = blacklight_config.view_config(:show)
-
-    display_type = if base_name && view_config.key?(:"#{base_name}_display_type_field")
-                     document[view_config[:"#{base_name}_display_type_field"]]
-                   end
-
-    display_type ||= document[view_config.display_type_field]
-
-    display_type ||= 'default'
+    display_type = show_presenter(document).display_type(base_name, default: 'default')
 
     type_field_to_partial_name(document, display_type)
   end

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -27,6 +27,17 @@ module Blacklight
       field_values(f, except_operations: [Rendering::HelperMethod])
     end
 
+    def display_type(base_name = nil, default: nil)
+      fields = []
+      fields += Array.wrap(view_config[:"#{base_name}_display_type_field"]) if base_name && view_config.key?(:"#{base_name}_display_type_field")
+      fields += Array.wrap(view_config.display_type_field)
+
+      display_type = fields.lazy.map { |field| retrieve_values(field_config(field)) }.detect(&:any?)
+      display_type ||= Array(default) if default
+
+      display_type
+    end
+
     private
 
     ##

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -64,7 +64,7 @@ module Blacklight
 
     # @return [Hash<String,Configuration::Field>] all the fields for this index view
     def fields
-      configuration.index_fields_for(document)
+      configuration.index_fields_for(display_type)
     end
 
     def field_config(field)

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -56,7 +56,7 @@ module Blacklight
 
     # @return [Hash<String,Configuration::Field>]
     def fields
-      configuration.show_fields_for(document)
+      configuration.show_fields_for(display_type)
     end
 
     def view_config

--- a/app/presenters/blacklight/thumbnail_presenter.rb
+++ b/app/presenters/blacklight/thumbnail_presenter.rb
@@ -20,7 +20,7 @@ module Blacklight
     # @return [Boolean]
     def exists?
       thumbnail_method.present? ||
-        (thumbnail_field && thumbnail_value_from_document(document).present?) ||
+        (thumbnail_field && thumbnail_value_from_document.present?) ||
         default_thumbnail.present?
     end
 
@@ -47,7 +47,7 @@ module Blacklight
       value = if thumbnail_method
                 view_context.send(thumbnail_method, document, image_options)
               elsif thumbnail_field
-                image_url = thumbnail_value_from_document(document)
+                image_url = thumbnail_value_from_document
                 view_context.image_tag image_url, image_options if image_url.present?
               end
 
@@ -67,8 +67,18 @@ module Blacklight
       end
     end
 
-    def thumbnail_value_from_document(document)
-      Array(thumbnail_field).lazy.map { |field| document.first(field) }.reject(&:blank?).first
+    def thumbnail_value_from_document
+      Array(thumbnail_field).lazy.map { |field| retrieve_values(field_config(field)).first }.reject(&:blank?).first
+    end
+
+    def retrieve_values(field_config)
+      FieldRetriever.new(document, field_config).fetch
+    end
+
+    def field_config(field)
+      return field if field.is_a? Blacklight::Configuration::Field
+
+      Configuration::NullField.new(field)
     end
   end
 end

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -12,12 +12,11 @@ end
 
 json.data do
   json.array! @presenter.documents do |document|
+    doc_presenter = index_presenter(document)
     document_url = polymorphic_url(url_for_document(document))
     json.id document.id
-    json.type document[blacklight_config.view_config(:index).display_type_field]
+    json.type doc_presenter.display_type.first
     json.attributes do
-      doc_presenter = index_presenter(document)
-
       doc_presenter.fields_to_render.each do |field_name, field|
         json.partial! 'field', field: field,
                                field_name: field_name,

--- a/app/views/catalog/show.json.jbuilder
+++ b/app/views/catalog/show.json.jbuilder
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 document_url = polymorphic_url(@document)
+doc_presenter = show_presenter(@document)
+
 json.links do
   json.self document_url
 end
 
 json.data do
   json.id @document.id
-  json.type @document[blacklight_config.view_config(:show).display_type_field]
+  json.type doc_presenter.display_type.first
   json.attributes do
-    doc_presenter = show_presenter(@document)
-
     doc_presenter.fields_to_render.each do |field_name, field|
       json.partial! 'field', field: field,
                              field_name: field_name,

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -357,16 +357,28 @@ module Blacklight
     ##
     # Return a list of fields for the index display that should be used for the
     # provided document.  This respects any configuration made using for_display_type
-    def index_fields_for(document)
-      display_type = document.first(index.display_type_field)
+    def index_fields_for(document_or_display_type)
+      display_type = if document_or_display_type.is_a? Blacklight::Document
+                       Deprecation.warn self, "Calling index_fields_for with a #{document_or_display_type.class} is deprecated and will be removed in Blacklight 8. Pass the display type instead."
+                       document_or_display_type.first(index.display_type_field)
+                     else
+                       document_or_display_type
+                     end
+
       for_display_type(display_type).index_fields.merge(index_fields)
     end
 
     ##
     # Return a list of fields for the show page that should be used for the
     # provided document.  This respects any configuration made using for_display_type
-    def show_fields_for(document)
-      display_type = document.first(show.display_type_field)
+    def show_fields_for(document_or_display_type)
+      display_type = if document_or_display_type.is_a? Blacklight::Document
+                       Deprecation.warn self, "Calling show_fields_for with a #{document_or_display_type.class} is deprecated and will be removed in Blacklight 8. Pass the display type instead."
+                       document_or_display_type.first(show.display_type_field)
+                     else
+                       document_or_display_type
+                     end
+
       for_display_type(display_type).show_fields.merge(show_fields)
     end
 

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -87,16 +87,38 @@ RSpec.describe "Blacklight::Configuration", api: true do
     let(:image) { SolrDocument.new(format: 'Image') }
     let(:sound) { SolrDocument.new(format: 'Sound') }
 
+    context 'with deprecated behavior' do
+      before do
+        allow(Deprecation).to receive(:warn)
+      end
+
+      it 'accepts documents as an argument to index_fields_for' do
+        config.for_display_type "Image" do |c|
+          c.add_index_field :dimensions
+        end
+        config.add_index_field :title
+        expect(config.index_fields_for(image)).to have_key 'dimensions'
+      end
+
+      it 'accepts documents as an argument to show_fields_for' do
+        config.for_display_type "Image" do |c|
+          c.add_show_field :dimensions
+        end
+        config.add_show_field :title
+        expect(config.show_fields_for(image)).to have_key 'dimensions'
+      end
+    end
+
     it "adds index fields just for a certain type" do
       config.for_display_type "Image" do |c|
         c.add_index_field :dimensions
       end
       config.add_index_field :title
 
-      expect(config.index_fields_for(image)).to have_key 'dimensions'
-      expect(config.index_fields_for(image)).to have_key 'title'
-      expect(config.index_fields_for(sound)).not_to have_key 'dimensions'
-      expect(config.index_fields_for(image)).to have_key 'title'
+      expect(config.index_fields_for('Image')).to have_key 'dimensions'
+      expect(config.index_fields_for('Image')).to have_key 'title'
+      expect(config.index_fields_for('Sound')).not_to have_key 'dimensions'
+      expect(config.index_fields_for('Image')).to have_key 'title'
       expect(config.index_fields).not_to have_key 'dimensions'
     end
 
@@ -106,10 +128,10 @@ RSpec.describe "Blacklight::Configuration", api: true do
       end
       config.add_show_field :title
 
-      expect(config.show_fields_for(image)).to have_key 'dimensions'
-      expect(config.show_fields_for(image)).to have_key 'title'
-      expect(config.show_fields_for(sound)).not_to have_key 'dimensions'
-      expect(config.show_fields_for(image)).to have_key 'title'
+      expect(config.show_fields_for('Image')).to have_key 'dimensions'
+      expect(config.show_fields_for('Image')).to have_key 'title'
+      expect(config.show_fields_for('Sound')).not_to have_key 'dimensions'
+      expect(config.show_fields_for('Image')).to have_key 'title'
       expect(config.show_fields).not_to have_key 'dimensions'
     end
 
@@ -121,8 +143,8 @@ RSpec.describe "Blacklight::Configuration", api: true do
         c.add_show_field :photographer
       end
 
-      expect(config.show_fields_for(image)).to have_key 'dimensions'
-      expect(config.show_fields_for(image)).to have_key 'photographer'
+      expect(config.show_fields_for('Image')).to have_key 'dimensions'
+      expect(config.show_fields_for('Image')).to have_key 'photographer'
     end
   end
 

--- a/spec/presenters/thumbnail_presenter_spec.rb
+++ b/spec/presenters/thumbnail_presenter_spec.rb
@@ -105,14 +105,13 @@ RSpec.describe Blacklight::ThumbnailPresenter do
       end
 
       it "creates an image tag from the given field" do
-        allow(document).to receive(:first).with(:xyz).and_return("http://example.com/some.jpg")
+        allow(document).to receive(:fetch).with(:xyz, nil).and_return("http://example.com/some.jpg")
         allow(view_context).to receive(:image_tag).with("http://example.com/some.jpg", {}).and_return('<img src="image.jpg">')
         expect(view_context).to receive(:link_to_document).with(document, '<img src="image.jpg">', {})
         subject
       end
 
       it "returns nil if no thumbnail is in the document" do
-        allow(document).to receive(:first).with(:xyz).and_return(nil)
         expect(subject).to be_nil
       end
     end


### PR DESCRIPTION
This PR finishes migrating the remaining direct data access methods by pushing them through the presenters (that use `FieldRetriever` internally). This also involved a little refactoring to try to make that hand-off as sensible as possible.