### PR TITLE
Use the I18n.locale for the html @lang attribute instead of hard-coding 'en'

### DIFF
--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -12,6 +12,13 @@ module Blacklight
     end
 
     ##
+    # Attributes to add to the <html> tag (e.g. lang and dir)
+    # @return [Hash]
+    def html_tag_attributes
+      { lang: I18n.locale }
+    end
+
+    ##
     # Classes added to a document's sidebar div
     # @return [String]
     def show_sidebar_classes

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -37,4 +37,4 @@
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>
   </body>
-</html>
+<% end %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "Search Page" do
+  it 'declares the page language in the html lang attribute' do
+    visit root_path
+    expect(page).to have_selector('html[lang=en]')
+  end
+
   it "shows welcome" do
     visit root_path
     expect(page).to have_selector("input#q")

--- a/spec/helpers/blacklight/layout_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/layout_helper_behavior_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe Blacklight::LayoutHelperBehavior do
       expect(helper.container_classes).to eq 'container'
     end
   end
+
+  describe '#html_tag_attributes' do
+    before do
+      allow(I18n).to receive(:locale).and_return('x')
+    end
+
+    it 'returns the current locale as the lang' do
+      expect(helper.html_tag_attributes).to include lang: 'x'
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2202