### PR TITLE
Re-add the collapsed class on the facet button (removed in #2196)

### DIFF
--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,7 +1,7 @@
 <div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
   <h3 class="card-header p-0 facet-field-heading" id="<%= facet_field_id(facet_field) %>-header">
     <button
-      class="btn btn-block p-2 text-left collapse-toggle"
+      class="btn btn-block p-2 text-left collapse-toggle <%= "collapsed" if should_collapse_facet?(facet_field) %>"
       data-toggle="collapse"
       data-target="#<%= facet_field_id(facet_field) %>"
       aria-expanded="<%= should_collapse_facet?(facet_field) ? 'false' : 'true' %>"
@@ -10,7 +10,7 @@
     </button>
   </h3>
   <div id="<%= facet_field_id(facet_field) %>" aria-labelledby="<%= facet_field_id(facet_field) %>-header" class="panel-collapse facet-content collapse <%= "show" unless should_collapse_facet?(facet_field) %>">
-    <div  class="card-body">
+    <div class="card-body">
       <%= yield %>
     </div>
   </div>

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "catalog/facet_layout" do
 
   it "is collapsable" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
-    expect(rendered).to have_selector 'button[data-toggle="collapse"][aria-expanded="false"]'
+    expect(rendered).to have_selector 'button.collapsed[data-toggle="collapse"][aria-expanded="false"]'
     expect(rendered).to have_selector '.collapse .card-body'
   end
 


### PR DESCRIPTION
It is used for CSS styling