### PR TITLE
Presenter#display_type should always return an array

### DIFF
--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -47,7 +47,7 @@ module Blacklight
       display_type = fields.lazy.map { |field| retrieve_values(field_config(field)) }.detect(&:any?)
       display_type ||= Array(default) if default
 
-      display_type
+      display_type || []
     end
 
     ##

--- a/spec/presenters/blacklight/index_presenter_spec.rb
+++ b/spec/presenters/blacklight/index_presenter_spec.rb
@@ -183,4 +183,32 @@ RSpec.describe Blacklight::IndexPresenter, api: true do
 
     it { is_expected.to be_instance_of Blacklight::ThumbnailPresenter }
   end
+
+  describe '#display_type' do
+    context 'with no configuration' do
+      it 'returns an empty array' do
+        expect(presenter.display_type).to be_empty
+      end
+    end
+
+    context 'with a default value' do
+      it 'returns the default' do
+        expect(presenter.display_type(default: 'default')).to eq ['default']
+      end
+    end
+
+    context 'with field configuration' do
+      let(:document) do
+        SolrDocument.new(id: 1, xyz: 'abc')
+      end
+
+      before do
+        config.index.display_type_field = :xyz
+      end
+
+      it 'returns the value from the field' do
+        expect(presenter.display_type).to eq ['abc']
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/earthworks/issues/576 (broken JSON views)

> ActionView::Template::Error: undefined method `first' for nil:NilClass