### PR TITLE
Add role menuitem to per page dropdown

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -7,7 +7,7 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>
-      <li><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
+      <li role="menuitem"><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
     <%- end -%>
   </ul>
 </div>


### PR DESCRIPTION
Part of #2220. Related 6.x change in #2219 

See more about `role=menu` and `role=menuitem` in:
- [WAI-ARIA Authoring Practices: menu button](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties-14)
- [WAI-ARIA Navigation Menu Button Example](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html)