### PR TITLE
Add menuitem role to sort and per page dropdowns

### DIFF
--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -6,7 +6,7 @@
   </button>
   <div class="dropdown-menu dropdown-menu-right" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>
-      <%= link_to(label, url_for(search_state.params_for_search(per_page: count)), class: 'dropdown-item') %>
+      <%= link_to(label, url_for(search_state.params_for_search(per_page: count)), class: 'dropdown-item', role: 'menuitem') %>
     <%- end -%>
   </div>
 </div>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -6,7 +6,7 @@
 
   <div class="dropdown-menu" role="menu">
     <%- active_sort_fields.each do |sort_key, field_config| %>
-      <%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key)), class: 'dropdown-item') %>
+      <%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key)), class: 'dropdown-item', role: 'menuitem') %>
     <%- end -%>
   </div>
 </div>


### PR DESCRIPTION
Closes #2220. Related 6.x changes in #2219 and #2221 

Hat tip to @sensei100 for filing 👏

See more about `role=menu` and `role=menuitem` in:
- [WAI-ARIA Authoring Practices: menu button](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties-14)
- [WAI-ARIA Navigation Menu Button Example](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html)