### PR TITLE
Use a custom class for the facet header section; fixes #2217

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -36,6 +36,13 @@
   }
 }
 
+.facets-header {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
 .facets-heading {
   @extend .h4;
   line-height: inherit;

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -2,7 +2,7 @@
 <% if has_facet_values? facet_field_names(groupname), @response %>
 <div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md">
 
-  <div class="navbar">
+  <div class="facets-header">
     <h2 class="facets-heading">
       <%= groupname.blank? ? t('blacklight.search.facets.title') : t("blacklight.search.facets-#{groupname}.title") %>
     </h2>

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Facets" do
 
     expect(page).to have_css('#facet-format', visible: false)
 
-    within('#facets .navbar') do
+    within('#facets .facets-header') do
       page.find('button.navbar-toggler').click
     end
 

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "Facets" do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
 
-    within('#facets .navbar') do
+    within('#facets .facets-header') do
       page.find('button.navbar-toggler').click
     end
 
@@ -182,7 +182,7 @@ RSpec.describe "Facets" do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
 
-    within('#facets .navbar') do
+    within('#facets .facets-header') do
       page.find('button.navbar-toggler').click
     end
 
@@ -196,7 +196,7 @@ RSpec.describe "Facets" do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
 
-    within('#facets .navbar') do
+    within('#facets .facets-header') do
       page.find('button.navbar-toggler').click
     end
 
@@ -210,7 +210,7 @@ RSpec.describe "Facets" do
     skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
 
-    within('#facets .navbar') do
+    within('#facets .facets-header') do
       page.find('button.navbar-toggler').click
     end
 


### PR DESCRIPTION
Before:
<img width="318" alt="Screen Shot 2019-12-13 at 13 18 34" src="https://user-images.githubusercontent.com/111218/70832873-12307480-1dab-11ea-942f-c18b2825d8f7.png">

After:
<img width="295" alt="Screen Shot 2019-12-13 at 13 18 41" src="https://user-images.githubusercontent.com/111218/70832879-15c3fb80-1dab-11ea-9824-1ed9eb8d0d3e.png">
