### PR TITLE
Bug fix: raise RecordNotFound for exportable actions with invalid doc ids

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -217,7 +217,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 210
+  Max: 212
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -114,7 +114,10 @@ module Blacklight::Catalog
   # @return [Array] first value is a Blacklight::Solr::Response and the second
   #                 is a list of documents
   def action_documents
-    search_service.fetch(Array(params[:id]))
+    deprecated_response, @documents = search_service.fetch(Array(params[:id]))
+    raise Blacklight::Exceptions::RecordNotFound if @documents.blank?
+
+    [deprecated_response, @documents]
   end
 
   def action_success_redirect_path


### PR DESCRIPTION
This PR raises an Blacklight::Exceptions::RecordNotFound error if exportable methods returns zero results. This change fixes issues present in Blacklight and GeoBlacklight, documented below.

Fixes https://github.com/projectblacklight/blacklight/issues/2232
Fixes https://github.com/geoblacklight/geoblacklight/issues/859