### PR TITLE
Fixes an issue where role definition "image" was incorrect and we wer…

### DIFF
--- a/app/models/blacklight/icon.rb
+++ b/app/models/blacklight/icon.rb
@@ -10,7 +10,7 @@ module Blacklight
     # @param [Boolean] aria_hidden include aria_hidden attribute
     # @param [Boolean] label include <title> and aria-label as part of svg
     # @param [String] role role attribute to be included in svg
-    def initialize(icon_name, classes: '', aria_hidden: false, label: true, role: 'image')
+    def initialize(icon_name, classes: '', aria_hidden: false, label: true, role: 'img')
       @icon_name = icon_name
       @classes = classes
       @aria_hidden = aria_hidden
@@ -24,7 +24,7 @@ module Blacklight
     def svg
       svg = ng_xml.at_xpath('svg')
       svg['role'] = role
-      svg['aria-labelled-by'] = unique_id if label
+      svg['aria-labelledby'] = unique_id if label
       svg.add_child("<title id='#{unique_id}'>#{icon_label}</title>") if label
       ng_xml.to_xml
     end

--- a/spec/models/blacklight/icon_spec.rb
+++ b/spec/models/blacklight/icon_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe Blacklight::Icon do
       expect(Capybara.string(subject.svg))
         .to have_css 'svg[width="24"]'
     end
-    it 'adds role="image"' do
+    it 'adds role="img"' do
       expect(Capybara.string(subject.svg))
-        .to have_css 'svg[role="image"]'
+        .to have_css 'svg[role="img"]'
     end
     it 'adds title' do
       expect(Capybara.string(subject.svg))
         .to have_css 'title[id^="bl-icon-search-"]', text: 'search icon'
     end
-    it 'adds aria-labelled-by' do
+    it 'adds aria-labelledby' do
       expect(Capybara.string(subject.svg))
-        .to have_css 'svg[aria-labelled-by^="bl-icon-search-"]'
+        .to have_css 'svg[aria-labelledby^="bl-icon-search-"]'
     end
     context 'when label is false' do
       subject { described_class.new(:search, classes: 'awesome', aria_hidden: true, label: false) }
@@ -30,9 +30,9 @@ RSpec.describe Blacklight::Icon do
         expect(Capybara.string(subject.svg))
           .not_to have_css 'title', text: 'search icon'
       end
-      it 'does not add aria-labelled-by' do
+      it 'does not add aria-labelledby' do
         expect(Capybara.string(subject.svg))
-          .not_to have_css 'svg[aria-labelled-by^="bl-icon-search-"]'
+          .not_to have_css 'svg[aria-labelledby^="bl-icon-search-"]'
       end
     end
   end


### PR DESCRIPTION
…e using the wrong aria-labelledby attribute

Fixes https://github.com/sul-dlss/exhibits/issues/1571

Source: https://www.w3.org/TR/wai-aria/#roles_categorization

While this changes default behavior, the default behavior was incorrect and broke screen readers. I consider this a useful bug fix