### PR TITLE
Remove unnecessary guard clause from page_entries_info

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -40,8 +40,6 @@ module Blacklight::CatalogHelperBehavior
   # @param [RSolr::Resource] collection (or other Kaminari-compatible objects)
   # @return [String]
   def page_entries_info(collection, entry_name: nil)
-    return unless show_pagination? collection
-
     entry_name = if entry_name
                    entry_name.pluralize(collection.size, I18n.locale)
                  else

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -39,13 +39,6 @@ RSpec.describe CatalogHelper do
       expect(html).to be_html_safe
     end
 
-    it "with an empty page of results" do
-      @response = double(limit_value: -1)
-
-      html = page_entries_info(@response)
-      expect(html).to be_blank
-    end
-
     context "when response.entry_name is nil" do
       it "does not raise an error" do
         collection = mock_response total: 10


### PR DESCRIPTION
this is enforced by the calling partials.