### PR TITLE
Conditionally render next/previous controls so that extra borders are…

### DIFF
--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,6 +1,6 @@
-<% # Using the Bootstrap Pagination class  -%>
-<div class='pagination-search-widgets'>
-  <% if @search_context[:prev] || @search_context[:next] %>
+<% if @search_context[:prev] || @search_context[:next] %>
+  <div class='pagination-search-widgets'>
+  
     <div class="page-links">
       <%= link_to_previous_document @search_context[:prev] %> |
 
@@ -8,5 +8,5 @@
 
       <%= link_to_next_document @search_context[:next] %>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/spec/views/catalog/_previous_next_doc.html.erb_spec.rb
+++ b/spec/views/catalog/_previous_next_doc.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe "catalog/_previous_next_doc.html.erb" do
+  it "without next or previous does not render content" do
+    assign(:search_context, {})
+    render
+    expect(rendered).not_to have_selector ".pagination-search-widgets"
+  end
+
+  it "with next or previous does render content" do
+    assign(:search_context, next: 'foo', prev: 'bar')
+    allow(view).to receive(:link_to_previous_document).and_return('')
+    allow(view).to receive(:item_page_entry_info).and_return('')
+    allow(view).to receive(:link_to_next_document).and_return('')
+    render
+    expect(rendered).to have_selector ".pagination-search-widgets"
+  end
+end


### PR DESCRIPTION
… not present

An extra border will be present when a search session is not present and a user navigates to that page. This resolves that issue.

Fixes https://github.com/sul-dlss/exhibits/issues/1651