### PR TITLE
label_for_search_field should be empty if no search field is specified

### DIFF
--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -91,10 +91,11 @@ module Blacklight::ConfigurationHelperBehavior
   end
 
   # Shortcut for commonly needed operation, look up display
-  # label for the key specified. Returns "Keyword" if a label
-  # can't be found.
+  # label for the key specified.
   def label_for_search_field(key)
     field_config = blacklight_config.search_fields[key]
+    return if key.nil? && field_config.nil?
+
     field_config ||= Blacklight::Configuration::NullField.new(key: key)
 
     field_config.display_label('search')

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -274,6 +274,9 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
       it 'handles a missing key' do
         expect(helper.label_for_search_field('not-found')).to eq 'Not Found'
       end
+      it 'handles a missing field' do
+        expect(helper.label_for_search_field(nil)).to eq nil
+      end
     end
 
     describe '#sort_field_label' do


### PR DESCRIPTION
If you're on the happy path for i18n field labeling, this can result in raw i18n hashes leaking  into the UI if the search field parameter isn't specified (although it happens to be, in the Blacklight-provided search form.)

Fixes https://github.com/sul-dlss/exhibits/issues/1797.



