### PR TITLE
Provide an icon label context into Blacklight::Icon

### DIFF
--- a/app/models/blacklight/icon.rb
+++ b/app/models/blacklight/icon.rb
@@ -2,7 +2,7 @@
 
 module Blacklight
   class Icon
-    attr_reader :icon_name, :aria_hidden, :label, :role
+    attr_reader :icon_name, :aria_hidden, :label, :role, :additional_options
     ##
     # @param [String, Symbol] icon_name
     # @param [Hash] options
@@ -10,12 +10,14 @@ module Blacklight
     # @param [Boolean] aria_hidden include aria_hidden attribute
     # @param [Boolean] label include <title> and aria-label as part of svg
     # @param [String] role role attribute to be included in svg
-    def initialize(icon_name, classes: '', aria_hidden: false, label: true, role: 'img')
+    # @param [Hash] additional_options the way forward instead of named arguments
+    def initialize(icon_name, classes: '', aria_hidden: false, label: true, role: 'img', additional_options: {})
       @icon_name = icon_name
       @classes = classes
       @aria_hidden = aria_hidden
       @label = label
       @role = role
+      @additional_options = additional_options
     end
 
     ##
@@ -30,11 +32,11 @@ module Blacklight
     end
 
     def icon_label
-      I18n.translate("blacklight.icon.#{icon_name}", default: "#{icon_name} icon")
+      I18n.translate("blacklight.icon.#{icon_name_context}", default: "#{icon_name} icon")
     end
 
     def unique_id
-      @unique_id ||= "bl-icon-#{icon_name}-#{SecureRandom.hex(8)}"
+      @unique_id ||= "bl-icon-#{icon_name_context}-#{SecureRandom.hex(8)}"
     end
 
     ##
@@ -65,6 +67,10 @@ module Blacklight
     end
 
     private
+
+    def icon_name_context
+      [icon_name, additional_options[:label_context]].compact.join('_')
+    end
 
     def file
       # Rails.application.assets is `nil` in production mode (where compile assets is enabled).

--- a/spec/models/blacklight/icon_spec.rb
+++ b/spec/models/blacklight/icon_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe Blacklight::Icon do
           .not_to have_css 'svg[aria-labelledby^="bl-icon-search-"]'
       end
     end
+
+    context ' with a label context' do
+      subject { described_class.new(:search, classes: 'awesome', aria_hidden: true, additional_options: { label_context: 'foo' }) }
+
+      it 'adds title' do
+        expect(Capybara.string(subject.svg))
+          .to have_css 'title[id^="bl-icon-search_foo-"]', text: 'search icon'
+      end
+    end
   end
 
   describe '#options' do


### PR DESCRIPTION
Fixes #2248. This allows someone to more surgically change the i18n
labels for icon usage in different places throughout a Blacklight
application.

Inspired by need in https://github.com/sul-dlss/exhibits/issues/1774

Additionally, `blacklight_icon` takes an `options` argument which is used as a cache key. This could be useful for someone trying to generate different title/id attributes used by icons in multiple places.