### PR TITLE
Revert "Test using Docker based Solr rather than solr_wrapper"

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,0 +1,12 @@
+# Place configuration for solr_wrapper here
+#
+# Specify the port to run solr on
+# port: 8983
+#
+# Specify a version of Solr to download
+# version: 7.3.1
+#
+# Create a collection when starting solr
+collection:
+  dir: lib/generators/blacklight/templates/solr/conf/
+  name: blacklight-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
   fast_finish: true
 
 before_install:
-  - docker pull solr:7
-  - docker run -d -p 8983:8983 -v $PWD/lib/generators/blacklight/templates/solr/conf:/myconfig solr:7 solr-create -c blacklight-core -d /myconfig
-  - docker ps -a
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
 notifications:

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rsolr", ">= 1.0.6", "< 3"  # Library for interacting with rSolr.
   s.add_development_dependency "rspec-rails", "~> 4.0.0.beta2"
+  s.add_development_dependency "solr_wrapper"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency "capybara", '~> 3'

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'solr_wrapper'
 require 'engine_cart/rake_task'
 
 require 'rspec/core/rake_task'
@@ -12,10 +13,14 @@ RuboCop::RakeTask.new(:rubocop)
 
 desc "Run test suite"
 task ci: ['blacklight:generate'] do
-  within_test_app do
-    system "RAILS_ENV=test rake blacklight:index:seed"
+  SolrWrapper.wrap do |solr|
+    solr.with_collection do
+      within_test_app do
+        system "RAILS_ENV=test rake blacklight:index:seed"
+      end
+      Rake::Task['blacklight:coverage'].invoke
+    end
   end
-  Rake::Task['blacklight:coverage'].invoke
 end
 
 namespace :blacklight do


### PR DESCRIPTION
This reverts commit 0759cd50042f7fa4ea91302f9f2b658aa376e7c2.

Solr_wrapper was never fully removed and the docker based solr solution
was never documented. This PR restores the solr_wrapper approach for CI.

While I acknowledge that this maybe in fact controversial, I would like to propose this move forward since we didn't seem to have documentation and local ci traction with the other approach. I'm also open to solutions that resolve the documentation and local development gaps.

Fixes #2195
Fixes #2183
Fixes #2231