### PR TITLE
Adds a margin to fix pagination spacing

### DIFF
--- a/app/assets/stylesheets/blacklight/_pagination.scss
+++ b/app/assets/stylesheets/blacklight/_pagination.scss
@@ -5,6 +5,10 @@
   padding-left: 0;
 }
 
+.record-padding {
+  margin-top: $spacer / 2;
+}
+
 .pagination {
   @media (max-width: breakpoint-max(sm)) {
     flex-wrap: wrap;


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/1833

This seems like a Bootstrap 4 /Blacklight 7 regression.

## Before
<img width="546" alt="Screen Shot 2020-03-09 at 11 21 10 AM" src="https://user-images.githubusercontent.com/1656824/76244933-4378df00-61f8-11ea-8950-1dfa8713fdb7.png">

## After
<img width="568" alt="Screen Shot 2020-03-09 at 11 21 00 AM" src="https://user-images.githubusercontent.com/1656824/76244934-44aa0c00-61f8-11ea-8533-863b357cd84e.png">
