### PR TITLE
Adds probot/stale configuration to repository for stale issues.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,52 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - planned
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+pulls:
+  markComment: |-
+    This pull request has been marked 'stale' due to lack of recent activity. If there is no further activity, the PR will be closed in another 30 days. Thank you for your contribution!
+
+  unmarkComment: >-
+    This pull request is no longer marked for closure.
+
+  closeComment: >-
+    This pull request has been closed due to inactivity. If you feel this is in error, please reopen the pull request or file a new PR with the relevant details.
+
+issues:
+  markComment: |-
+    This issue has been marked 'stale' due to lack of recent activity. If there is no further activity, the issue will be closed in another 30 days. Thank you for your contribution!
+
+  unmarkComment: >-
+    This issue is no longer marked for closure.
+
+  closeComment: >-
+    This issue has been closed due to inactivity. If you feel this is in error, please reopen the issue or file a new issue with the relevant details.


### PR DESCRIPTION
I will not be disappointed if this is rejected/not merged (not sure it should really!), but, I noticed stalebot messages in a repo I use ([more on that here](https://www.jeffgeerling.com/blog/2020/enabling-stale-issue-bot-on-my-github-repositories)) and thought about how it might be useful for blacklight. With stalebot stale issues are automatically closed after a period of inactivity. Just something to consider maybe.  https://probot.github.io/apps/stale/

If there is interest, I do think it might be worth adding a bit more to the explanation messaging