### PR TITLE
Use docker-compose to run Solr in CI

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,12 +1,26 @@
-FROM ruby:2.6
-RUN \
-      wget -qO- https://deb.nodesource.com/setup_9.x | bash - && \
-      wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-      echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-      apt-get update -qq && \
-      apt-get install -y --force-yes --no-install-recommends && \
-      nodejs yarn build-essential libpq-dev \
-      && apt-get clean
-RUN gem install bundler
+ARG ALPINE_RUBY_VERSION
+
+FROM ruby:${ALPINE_RUBY_VERSION}-alpine
+
+RUN apk add --update --no-cache \
+  bash \
+  build-base \
+  git \
+  libxml2-dev \
+  libxslt-dev \
+  nodejs \
+  sqlite-dev \
+  tzdata
+
 RUN mkdir /app
 WORKDIR /app
+
+RUN gem update --system && \
+  gem install bundler && \
+  bundle config build.nokogiri --use-system-libraries
+
+COPY . .
+
+EXPOSE 3000
+
+CMD [".docker/app/entrypoint.sh"]

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+rm -f /app/.internal_test_app/tmp/pids/server.pid
+bundle install
+exec bundle exec rake blacklight:server["-p 3000 -b 0.0.0.0"]

--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+ALPINE_RUBY_VERSION=2.6.5
+RAILS_VERSION=5.2.4.1
+SOLR_PORT=8983
+SOLR_URL=http://solr:8983/solr/blacklight-core
+SOLR_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 dist: bionic
+
 addons:
   chrome: stable
-language: ruby
 
-notifications:
-  email: false
+language: ruby
 
 matrix:
   include:
@@ -25,26 +24,19 @@ matrix:
   fast_finish: true
 
 before_install:
-  - docker pull solr:7
-  - docker run -d -p 8983:8983 -v $PWD/lib/generators/blacklight/templates/solr/conf:/myconfig solr:7 solr-create -c blacklight-core -d /myconfig
-  - docker ps -a
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
-notifications:
-  irc: "irc.freenode.org#blacklight"
-  email:
-      - blacklight-commits@googlegroups.com
-
-global_env:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  - ENGINE_CART_RAILS_OPTIONS='--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
-  - CC_TEST_REPORTER_ID=5042c7358c96b0b926088a4cda3e132fffe7a66ce8047cdb1dc6f0b4b6676b79
-
-jdk: openjdk11
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - ENGINE_CART_RAILS_OPTIONS='--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+    - CC_TEST_REPORTER_ID=5042c7358c96b0b926088a4cda3e132fffe7a66ce8047cdb1dc6f0b4b6676b79
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - docker-compose build app || travis_terminate 1 # validates application Dockerfile

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-rm .internal_test_app/tmp/pids/server.pid 2> /dev/null
-bundle install
-bundle exec rake blacklight:server["-p 3000 -b '0.0.0.0'"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: .
       dockerfile: .docker/app/Dockerfile
-    stdin_open: true
-    tty: true
+      args:
+        - ALPINE_RUBY_VERSION
     volumes:
       - .:/app
     depends_on:
@@ -14,17 +14,18 @@ services:
     ports:
       - "3000:3000"
     environment:
-      SOLR_URL: "http://solr:8983/solr/blacklight-core"
-      DEVELOPMENT_ENVIRONMENT: "docker"
-    entrypoint:
-      - /app/bin/start.sh
+      - SOLR_URL # Set via environment variable or use default defined in .env file
+      - RAILS_VERSION # Set via environment variable or use default defined in .env file
 
   solr:
-    image: solr:7
+    environment:
+      - SOLR_PORT # Set via environment variable or use default defined in .env file
+      - SOLR_VERSION # Set via environment variable or use default defined in .env file
+    image: "solr:${SOLR_VERSION}"
     volumes:
       - $PWD/lib/generators/blacklight/templates/solr/conf:/opt/solr/conf
     ports:
-      - "8983:8983"
+      - "${SOLR_PORT}:8983"
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate


### PR DESCRIPTION
Fixes #2195
Fixes #2231 
Closes #2256 

# Summary

In this way, we are using docker-compose for development and testing of the Blacklight gem itself, not for downstream purposes such as generation of new Blacklight applications, which will continue to use solr_wrapper. Also includes: using a lighter base image for the app.

This supersedes #2256.

# Open Question (Now Closed)

I put the documentation here: https://github.com/projectblacklight/blacklight/wiki/Testing-and-Developing-Blacklight

~~It is not clear to me where information like this is currently documented. The README is short and sweet, and for this reason I suspect it is not a good place for such internal development documentation to live. Other options include `CONTRIBUTING.md`, but that is more focused on higher-level contribution process than particular technical steps.~~

~~Note, I also don't think the Quickstart is the right place, so this ticket has nothing to do with #2183, which I think we should either close as a `wontfix` per [my comment](https://github.com/projectblacklight/blacklight/issues/2183#issuecomment-598779218) or discuss what the right way to move forward is particularly w/r/t how much we continue to generate for downstream BL apps: *i.e.*, if we don't give them a working SolrWrapper, do we generate/ship a working docker-compose configuration? Or do we get out of that business entirely? This is beyond the scope of this PR.~~

~~For this reason, perhaps the best place is somewhere on the [project wiki](https://github.com/projectblacklight/blacklight/wiki). Happy to take suggestions on this.~~

# Webpack(er) Broken (But Not Related)

I believe this may be solved by https://github.com/projectblacklight/blacklight/pull/2266. Thanks, @mejackreed!

~~Note that this PR changes the `blacklight:server` rake task to use `docker-compose` for Solr but I was unable to see this working---with Ruby 2.6 and Rails 6, but other combinations will yield different results---because when Blacklight uses EngineCart to generate the test app, there's a problem with webpack(er). If you generate without the `--skip-webpack-install` flag being passed to the `rails new` command, the Rails webpack generator runs and fails because the dependency is not declared. If you skip webpack installation, Rails generates an app that still contains `webpacker` in its Gemfile, and it's a multi-step process to strip out webpack(er) and use Sprockets in its stead ([1](http://mitrev.net/ruby/2019/12/27/rails-6-without-webpack/), [2](https://www.reddit.com/r/rails/comments/b0goct/webpacker_for_non_js_people/eih2930/), [3](https://stackoverflow.com/a/58518795)). That said, I did not alter this behavior or attempt to fix the underlying problem since it is orthogonal to how we spin up Solr for CI/testing of Blacklight.~~ 
