### PR TITLE
Generate Rails 6 applications with Sprockets 4-style assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rvm: 2.7.0
       env: "RAILS_VERSION=6.0.2.1"
     - rvm: 2.6.5
-      env: "RAILS_VERSION=6.0.2.1 ENGINE_CART_RAILS_OPTIONS=\"--skip-webpack-install\""
+      env: "RAILS_VERSION=6.0.2.1"
     - rvm: 2.6.5
       env: "RAILS_VERSION=5.2.4.1"
     - rvm: 2.5.7

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,10 @@ else
   end
 
   case ENV['RAILS_VERSION']
-  when /^5.[12]/, /^6.0/
+  when /^6.0/
+    gem 'sass-rails', '>= 6'
+    gem 'webpacker', '~> 4.0'
+  when /^5.[12]/
     gem 'sass-rails', '~> 5.0'
   when /^4.2/
     gem 'responders', '~> 2.0'

--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -22,6 +22,16 @@ module Blacklight
       end
     end
 
+    ##
+    # Remove the empty generated app/assets/images directory. Without doing this,
+    # the default Sprockets 4 manifest will raise an exception.
+    def appease_sprockets4
+      return if !defined?(Sprockets::VERSION) || Sprockets::VERSION < '4'
+
+      append_to_file 'app/assets/config/manifest.js', "\n//= link application.js"
+      empty_directory 'app/assets/images'
+    end
+
     def assets
       copy_file "blacklight.scss", "app/assets/stylesheets/blacklight.scss"
 

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -40,7 +40,7 @@ namespace :blacklight do
   end
 
   namespace :internal do
-    desc 'Index seed data in test ap'
+    desc 'Index seed data in test app'
     task seed: ['engine_cart:generate'] do
       within_test_app do
         system "bin/rake blacklight:index:seed"
@@ -49,16 +49,8 @@ namespace :blacklight do
   end
 
   desc 'Run Solr and Blacklight for interactive development'
-  task :server, [:rails_server_args] do |_t, args|
+  task :server, [:rails_server_args] => ['engine_cart:generate'] do |_t, args|
     with_solr do
-      if File.exist? EngineCart.destination
-        within_test_app do
-          system "bundle update"
-        end
-      else
-        Rake::Task['engine_cart:generate'].invoke
-      end
-
       Rake::Task['blacklight:internal:seed'].invoke
 
       within_test_app do


### PR DESCRIPTION
Blacklight is currently generating Rails 6 applications with Sprockets 3-style assets. With this change, the `blacklight:server` task spins up a working server (with Sprockets 4-style assets) instead of screaming about webpacker.

Related to #2266, discovered in #2263.
