### PR TITLE
Safe navigate when iterating over the documents ivar

### DIFF
--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -5,7 +5,7 @@
   </button>
 </div>
 <div class="modal-body">
-  <% @documents.each do |document| %>
+  <% @documents&.each do |document| %>
     <h1 class="modal-title"><%= document_heading(document) %></h1>
 
     <% if document.respond_to?(:export_as_mla_citation_txt) %>

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <% @documents.each do |doc| %>
+    <% @documents&.each do |doc| %>
       <%=hidden_field_tag "id[]", doc.id %>
     <% end %>
     <%- if params[:sort] -%>

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -22,7 +22,7 @@
       </div>
 
     </div>
-    <% @documents.each do |doc| %>
+    <% @documents&.each do |doc| %>
        <%=hidden_field_tag "id[]", doc.id %>
     <% end %>
 </div>


### PR DESCRIPTION
While we guard against no documents, the meta-programmed action definition + rails allowing undefined actions when a view is present makes this view/partial routable and throw an error.

This is likely an edge case, but we've noticed this triggering errors (primarily caused by bots/crawlers) on sites where we've removed the citation tool.