### PR TITLE
Remove unneeded auto-loader config

### DIFF
--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -9,12 +9,6 @@ module Blacklight
       ActionView::Base.send :include, BlacklightHelper
     end
 
-    config.autoload_paths += %W(
-      #{config.root}/app/presenters
-      #{config.root}/app/controllers/concerns
-      #{config.root}/app/models/concerns
-    )
-
     # This makes our rake tasks visible.
     rake_tasks do
       Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..'))) do


### PR DESCRIPTION
I believe this config should be unnecessary, and possibly could cause a problem with the new Rails6 zeitwerk auto-loader. May not cause a bug, but the code that isn't even in your codebase is the code that can't possibly cause problems!

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#autoloading

app/presenters, along with all sub-dirs of `./app`, should be automatically put in load path by Rails.
Similary, we are usingly the ./concerns subdirs in a standard Rails way, which Rails should handle by default.

I suspect this config is left over from long ago versions of Rails before it was fully default behavior.

Note `config.root` in this config is Blacklight engine root, not app root.
