### PR TITLE
Style bookmark actions as buttons, closes #2272

### DIFF
--- a/app/components/blacklight/document/action_component.html.erb
+++ b/app/components/blacklight/document/action_component.html.erb
@@ -2,7 +2,7 @@
   <%= link_to label,
               url,
               id: @id,
-              class: 'nav-link',
+              class: @link_classes,
               data: {}.merge(({ blacklight_modal: "trigger" } if @action.modal != false) || {}) %>
 <% else %>
   <%= @view_context.render(partial: @action.partial || @action.name.to_s, locals: { document: @document, document_action_config: @action }.merge(@options)) %>

--- a/app/components/blacklight/document/action_component.rb
+++ b/app/components/blacklight/document/action_component.rb
@@ -7,12 +7,13 @@ module Blacklight
       with_collection_parameter :action
 
       # @param [Blacklight::Document] document
-      def initialize(document:, action:, options: {}, url_opts: {}, id: nil)
+      def initialize(document:, action:, options: {}, url_opts: {}, id: nil, link_classes: 'nav-link')
         @document = document
         @action = action
         @options = options
         @url_opts = url_opts
         @id = id || @action.fetch(:id, "#{@action.name}Link")
+        @link_classes = link_classes
       end
 
       def using_default_document_action?

--- a/app/components/blacklight/document/actions_component.html.erb
+++ b/app/components/blacklight/document/actions_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag @tag, class: @classes do %>
   <% @actions.each do |action| %>
-    <% result = capture { @view_context.render((action.component || Blacklight::Document::ActionComponent).new(action: action, document: @document, options: @options, url_opts: @url_opts)) } %>
+    <% result = capture { @view_context.render((action.component || Blacklight::Document::ActionComponent).new(action: action, document: @document, options: @options, url_opts: @url_opts, link_classes: @link_classes)) } %>
 
     <% if @wrapping_tag %>
       <%= content_tag(@wrapping_tag, class: Array(@wrapping_classes) + [action.key]) do %>

--- a/app/components/blacklight/document/actions_component.rb
+++ b/app/components/blacklight/document/actions_component.rb
@@ -6,7 +6,7 @@ module Blacklight
     class ActionsComponent < ::ViewComponent::Base
       # @param [Blacklight::Document] document
       # rubocop:disable Metrics/ParameterLists
-      def initialize(document: nil, actions: [], options: {}, url_opts: nil, tag: :div, classes: 'index-document-functions', wrapping_tag: nil, wrapping_classes: nil)
+      def initialize(document: nil, actions: [], options: {}, url_opts: nil, tag: :div, classes: 'index-document-functions', wrapping_tag: nil, wrapping_classes: nil, link_classes: 'nav-link')
         @document = document
         @actions = actions
         @tag = tag
@@ -15,6 +15,7 @@ module Blacklight
         @url_opts = url_opts
         @wrapping_tag = wrapping_tag
         @wrapping_classes = wrapping_classes
+        @link_classes = link_classes
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/app/views/bookmarks/_tools.html.erb
+++ b/app/views/bookmarks/_tools.html.erb
@@ -1,5 +1,5 @@
 <% if render_show_doc_actions_method_from_blacklight? %>
-  <%= render(Blacklight::Document::ActionsComponent.new(document: nil, tag: 'ul', classes: "#{controller_name}Tools nav nav-pills", wrapping_tag: 'li', wrapping_classes: 'nav-item', actions: document_actions(document_list, options: { document: nil }), options: { document_list: @response.documents }, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h))) %>
+  <%= render(Blacklight::Document::ActionsComponent.new(document: nil, tag: 'div', classes: "#{controller_name}Tools", wrapping_tag: 'span', wrapping_classes: 'btn btn-outline-primary', link_classes: '', actions: document_actions(document_list, options: { document: nil }), options: { document_list: @response.documents }, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h))) %>
 <% else %>
   <% Deprecation.warn(self, '#render_show_doc_actions is deprecated; use ActionComponents instead') %>
   <ul class="<%= controller_name %>Tools nav nav-pills">


### PR DESCRIPTION
Since these represent actions that a user would take on their bookmarked
items, let's style them as buttons rather than nav-pills.

These actions are still wrapped in a .bookmarksTools class, just in case
anybody was using this to style their app.