### PR TITLE
Moves comment

### DIFF
--- a/app/models/concerns/blacklight/document/extensions.rb
+++ b/app/models/concerns/blacklight/document/extensions.rb
@@ -32,6 +32,9 @@ module Blacklight::Document::Extensions
   module ClassMethods
     attr_writer :registered_extensions
 
+    # Returns array of hashes of registered extensions. Each hash
+    # has a :module_obj key and a :condition_proc key. Usually this
+    # method is only used internally in #apply_extensions, but if you
     # want to zero out all previously registered extensions you can call:
     # SolrDocument.registered_extensions = nil
     def registered_extensions

--- a/app/models/concerns/blacklight/document/semantic_fields.rb
+++ b/app/models/concerns/blacklight/document/semantic_fields.rb
@@ -4,10 +4,6 @@ module Blacklight::Document
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Returns array of hashes of registered extensions. Each hash
-      # has a :module_obj key and a :condition_proc key. Usually this
-      # method is only used internally in #apply_extensions, but if you
-
       # Class-level method for accessing/setting semantic mappings
       # for solr stored fields. Can be set by local app, key is
       # a symbol for a semantic, value is a solr _stored_ field.


### PR DESCRIPTION
This looks to me like a description for a method that was removed. Is it? Not sure what this could be referring to that returns an array of hashes with these special symbols because I only see the one method in this module that does not do that. If it is meant to be here, it does kinda end in a cliff hanger :)