### PR TITLE
Removes unnecessary autoloads

### DIFF
--- a/app/models/concerns/blacklight/document.rb
+++ b/app/models/concerns/blacklight/document.rb
@@ -16,16 +16,6 @@ require 'globalid'
 # transformation formats.
 #
 module Blacklight::Document
-  autoload :ActiveModelShim, 'blacklight/document/active_model_shim'
-  autoload :SchemaOrg, 'blacklight/document/schema_org'
-  autoload :CacheKey, 'blacklight/document/cache_key'
-  autoload :DublinCore, 'blacklight/document/dublin_core'
-  autoload :Email, 'blacklight/document/email'
-  autoload :SemanticFields, 'blacklight/document/semantic_fields'
-  autoload :Sms, 'blacklight/document/sms'
-  autoload :Extensions, 'blacklight/document/extensions'
-  autoload :Export, 'blacklight/document/export'
-
   extend ActiveSupport::Concern
   include Blacklight::Document::SchemaOrg
   include Blacklight::Document::SemanticFields


### PR DESCRIPTION
I've been attempting an upgrade to Rails 6.0 for our catalog Blacklight-based application (I figured that since blacklight works on Rails 6 it should be ok) and have been wrestling with issues related to zeitwerk, especially with the blacklight marc engine. See https://github.com/projectblacklight/blacklight-marc/issues/85 and note that the quick start guide is not working for Rails 6.

Once I was able to get blacklight marc to find the constant for Marc and MarcExport I started seeing errors like `Blacklight::Document::SchemaOrg` being an uninitialized constant. Looking at the directory setup I noticed that these things I've removed don't seem to need to be specifically `autoload`ed because they are in the directory that Rails and zeitwerk will find. And apparently specifying autoload can cause a problem (?). After I removed them librarian view started display marc.

But maybe there's a reason these are being autoloaded here and removing them is a bad idea, just not sure because of all the activity in this namespace across 2 engines and my application and the context that I'm probably missing.