### PR TITLE
Only show search context controls if the current context matches the …

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -215,7 +215,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 14
 
-# Offense count: 60
+# Offense count: 61
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.
 Metrics/MethodLength:
   Max: 30
@@ -223,7 +223,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 212
+  Max: 213
 
 # Offense count: 3
 # Configuration parameters: CountKeywordArgs.

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -67,6 +67,7 @@ module Blacklight::Catalog
     search_session['counter'] = params[:counter]
     search_session['id'] = params[:search_id]
     search_session['per_page'] = params[:per_page]
+    search_session['document_id'] = params[:document_id]
 
     if params[:redirect] && (params[:redirect].starts_with?('/') || params[:redirect] =~ URI::DEFAULT_PARSER.make_regexp)
       uri = URI.parse(params[:redirect])

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -68,7 +68,7 @@ module Blacklight::UrlHelperBehavior
   #   session_tracking_params(SolrDocument.new(id: 123), 7)
   #   => { data: { :'context-href' => '/catalog/123/track?counter=7&search_id=999' } }
   def session_tracking_params document, counter
-    path = session_tracking_path(document, per_page: params.fetch(:per_page, search_session['per_page']), counter: counter, search_id: current_search_session.try(:id))
+    path = session_tracking_path(document, per_page: params.fetch(:per_page, search_session['per_page']), counter: counter, search_id: current_search_session.try(:id), document_id: document.id)
 
     if path.nil?
       return {}

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -68,7 +68,7 @@ module Blacklight::UrlHelperBehavior
   #   session_tracking_params(SolrDocument.new(id: 123), 7)
   #   => { data: { :'context-href' => '/catalog/123/track?counter=7&search_id=999' } }
   def session_tracking_params document, counter
-    path = session_tracking_path(document, per_page: params.fetch(:per_page, search_session['per_page']), counter: counter, search_id: current_search_session.try(:id), document_id: document.id)
+    path = session_tracking_path(document, per_page: params.fetch(:per_page, search_session['per_page']), counter: counter, search_id: current_search_session.try(:id), document_id: document&.id)
 
     if path.nil?
       return {}

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,4 +1,4 @@
-<%= render 'previous_next_doc' if @search_context %>
+<%= render 'previous_next_doc' if @search_context && @search_context['document_id'] == @document.id %>
 
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,4 +1,4 @@
-<%= render 'previous_next_doc' if @search_context && @search_context['document_id'] == @document.id %>
+<%= render 'previous_next_doc' if @search_context && search_session['document_id'] == @document.id %>
 
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,4 +1,4 @@
-<% if current_search_session %>
+<% if current_search_session && current_search_session['document_id'] == @document.id %>
   <div id="appliedParams" class="clearfix constraints-container">
     <%= render 'start_over' %>
     <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,4 +1,4 @@
-<% if current_search_session && current_search_session['document_id'] == @document.id %>
+<% if current_search_session %>
   <div id="appliedParams" class="clearfix constraints-container">
     <%= render 'start_over' %>
     <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -240,6 +240,11 @@ RSpec.describe CatalogController, api: true do
       expect(session[:search]['per_page']).to eq "15"
     end
 
+    it "records the document id being viewed" do
+      put :track, params: { id: doc_id, counter: 3, document_id: 1234 }
+      expect(session[:search]['document_id']).to eq "1234"
+    end
+
     it "redirects to show action for doc id" do
       put :track, params: { id: doc_id, counter: 3 }
       assert_redirected_to(solr_document_path(doc_id))

--- a/spec/features/search_context_spec.rb
+++ b/spec/features/search_context_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Search Results context", js: true do
     click_on 'Pluvial nectar of blessings'
     expect(page).to have_content "« Previous | 10 of 30 | Next »"
     prev = page.find(".pagination-search-widgets .previous")
-    expect(prev['data-context-href']).to eq "/catalog/2003546302/track?counter=9&search_id=#{search_id}"
+    expect(prev['data-context-href']).to eq "/catalog/2003546302/track?counter=9&document_id=2003546302&search_id=#{search_id}"
 
     click_on "« Previous"
 
     prev = page.find(".pagination-search-widgets .previous")
-    expect(prev['data-context-href']).to eq "/catalog/2004310986/track?counter=8&search_id=#{search_id}"
+    expect(prev['data-context-href']).to eq "/catalog/2004310986/track?counter=8&document_id=2004310986&search_id=#{search_id}"
   end
 
   it "redirects context urls to the original url" do

--- a/spec/features/search_context_spec.rb
+++ b/spec/features/search_context_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe "Search Results context", js: true do
     end
   end
 
+  it "does not display stale previous and next links for direct item views" do
+    search_for ''
+    click_on 'Pluvial nectar of blessings'
+
+    # Go to the number 9 result separately
+    visit '/catalog/2003546302'
+    expect(page).not_to have_selector '.page-links'
+    expect(page).not_to have_content "« Previous | 10 of 30 | Next »"
+  end
+
   context "navigating between search results using context pagination" do
     it "updates the back to search link with the current search pagination context" do
       search_for ''


### PR DESCRIPTION
…current document

Maybe helps address or obscure the problems from #2295?