### PR TITLE
Inform the IndexPresenter about the search offset

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -124,8 +124,8 @@ module Blacklight::BlacklightHelperBehavior
 
   ##
   # Returns a document presenter for the given document
-  def document_presenter(document)
-    document_presenter_class(document).new(document, self)
+  def document_presenter(document, counter: nil)
+    document_presenter_class(document).new(document, self, counter: counter)
   end
 
   ##

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -75,7 +75,8 @@ module Blacklight::CatalogHelperBehavior
   end
 
   ##
-  # Get the offset counter for a document
+  # Get the offset counter for a document.
+  # This should only be called on the index action because it depends on @response
   #
   # @param [Integer] idx document index
   # @param [Integer] offset additional offset to incremenet the counter by

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -11,10 +11,12 @@ module Blacklight
     # @param [SolrDocument] document
     # @param [ActionView::Base] view_context scope for linking and generating urls
     # @param [Blacklight::Configuration] configuration
-    def initialize(document, view_context, configuration = view_context.blacklight_config)
+    # @param [Integer] counter what offset in the search result is this record (used for tracking)
+    def initialize(document, view_context, configuration = view_context.blacklight_config, counter: nil)
       @document = document
       @view_context = view_context
       @configuration = configuration
+      @counter = counter
     end
 
     # @return [Hash<String,Configuration::Field>]  all the fields for this index view that should be rendered
@@ -102,7 +104,7 @@ module Blacklight
     end
 
     def thumbnail
-      @thumbnail ||= thumbnail_presenter_class.new(document, view_context, view_config)
+      @thumbnail ||= thumbnail_presenter_class.new(document, view_context, view_config, counter: @counter)
     end
 
     ##

--- a/app/presenters/blacklight/thumbnail_presenter.rb
+++ b/app/presenters/blacklight/thumbnail_presenter.rb
@@ -8,10 +8,12 @@ module Blacklight
     # @param [ActionView::Base] view_context scope for linking and generating urls
     #                                        as well as for invoking "thumbnail_method"
     # @param [Blacklight::Configuration::ViewConfig] view_config
-    def initialize(document, view_context, view_config)
+    # @param [Integer] counter what offset in the search result is this record (used for tracking)
+    def initialize(document, view_context, view_config, counter: nil)
       @document = document
       @view_context = view_context
       @view_config = view_config
+      @counter = counter
     end
 
     def render(image_options = {})
@@ -39,6 +41,7 @@ module Blacklight
       value = thumbnail_value(image_options)
       return value if value.nil? || url_options[:suppress_link]
 
+      url_options[:counter] = @counter if @counter
       view_context.link_to_document document, value, url_options
     end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,6 +1,7 @@
 <% # container for a single doc -%>
 <% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type) %>
-<%= render view_config.document_component.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
+<% counter = document_counter_with_offset(document_counter) %>
+<%= render view_config.document_component.new(presenter: document_presenter(document, counter: counter), counter: counter) do |component| %>
   <% view_config.partials.each do |partial| %>
     <% component.partial do %>
       <%= render_document_partial document, partial, component: component, document_counter: document_counter %>


### PR DESCRIPTION
This means our document partials don't have to access instance variables, which means that
we are able to call the thumbnail partial in a show context without getting a deprecation warning about accessing the deprecated @response ivar.

Fixes #2303 