### PR TITLE
Avoid passing kwargs as the last argument

### DIFF
--- a/app/helpers/blacklight/icon_helper_behavior.rb
+++ b/app/helpers/blacklight/icon_helper_behavior.rb
@@ -11,7 +11,7 @@ module Blacklight::IconHelperBehavior
   # @return [String]
   def blacklight_icon(icon_name, options = {})
     Rails.cache.fetch([:blacklight_icons, icon_name, options]) do
-      icon = Blacklight::Icon.new(icon_name, options)
+      icon = Blacklight::Icon.new(icon_name, **options)
       content_tag(:span, icon.svg.html_safe, icon.options)
     end
   end


### PR DESCRIPTION
This is deprecated and without adding the **, a warning is emitted