### PR TITLE
Move search_service_class to Searchable

### DIFF
--- a/app/controllers/concerns/blacklight/controller.rb
+++ b/app/controllers/concerns/blacklight/controller.rb
@@ -30,12 +30,6 @@ module Blacklight::Controller
     # TODO: move to Searchable
     class_attribute :search_state_class
     self.search_state_class = Blacklight::SearchState
-
-    # Which class to use for the search service. You can subclass SearchService if you
-    # want to override any of the methods (e.g. SearchService#fetch)
-    # TODO: move to Searchable
-    class_attribute :search_service_class
-    self.search_service_class = Blacklight::SearchService
   end
 
   # @private

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -11,6 +11,15 @@
 # further context to the SearchService. For example you could override this to provide the
 # currently signed in user.
 module Blacklight::Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    # Which class to use for the search service. You can subclass SearchService if you
+    # want to override any of the methods (e.g. SearchService#fetch)
+    class_attribute :search_service_class
+    self.search_service_class = Blacklight::SearchService
+  end
+
   # @return [Blacklight::SearchService]
   def search_service
     search_service_class.new(config: blacklight_config, search_state: search_state, user_params: search_state.to_h, **search_service_context)

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -5,7 +5,6 @@
 # would be provided by Blacklight::Controller
 #  1. search_state
 #  2. blacklight_config
-#  3. search_service_class
 #
 # Additionally, the including class may override the search_service_context method to provide
 # further context to the SearchService. For example you could override this to provide the


### PR DESCRIPTION
Anything that uses Searchable should be able to configure a search_service_class, this does not have anything to do with a Controller.  This keeps the concept of the search service encapsulated in the Searchable module.