### PR TITLE
Remove Rails 4 from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,13 +39,6 @@ else
     gem 'webpacker', '~> 4.0'
   when /^5.[12]/
     gem 'sass-rails', '~> 5.0'
-  when /^4.2/
-    gem 'responders', '~> 2.0'
-    gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
-    gem 'json', '~> 1.8'
-  when /^4.[01]/
-    gem 'sass-rails', '< 5.0'
   end
 end
 # END ENGINE_CART BLOCK


### PR DESCRIPTION
Fixes warnings about the json gem being out of date.