### PR TITLE
Update spelling of Spanish translation

### DIFF
--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -169,8 +169,8 @@ es:
       pagination:
         title: 'Resultados de navegación'
       pagination_info:
-        no_items_found: 'No %{entry_name} encontrado'
-        single_item_found: '<strong>1</strong> %{entry_name} encontrado'
+        no_items_found: 'No %{entry_name} encontrada'
+        single_item_found: '<strong>1</strong> %{entry_name} encontrada'
         pages:
           one: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong> de <strong>%{total_num}</strong>'
           other: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong> de <strong>%{total_num}</strong>'


### PR DESCRIPTION
We received a report from a native Spanish speaker that the Spanish translation of "1 entry found" is incorrect. Instead of "entrada encontrado" it should be "entrada encontrada". This PR updates the spelling of "encontrado" to "encontrada" in the two similar contexts (1 item found and No items found). 

<img width="492" alt="Screen Shot 2020-08-12 at 9 39 12 AM" src="https://user-images.githubusercontent.com/101482/90043026-58164300-dc80-11ea-9a7f-7cba7b441fdb.png">

My Spanish is too limited to know if this is correct, so if anyone reviewing this knows better, definitely speak up. But between the native Spanish speaker reporting this and the fact that Google Translate gives me the same spelling, I assume it's correct and the original was perhaps a typo (or both are technically okay but "encontrada" is more appropriate in this context or something).

<img width="652" alt="Screen Shot 2020-08-12 at 9 41 24 AM" src="https://user-images.githubusercontent.com/101482/90043233-b2af9f00-dc80-11ea-85b3-5c376cc0e9e1.png">
