### PR TITLE
Do not mutate search_state when mutating search_state.to_h

### DIFF
--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -47,7 +47,7 @@ module Blacklight
     end
 
     def to_hash
-      @params
+      @params.dup
     end
     alias to_h to_hash
 

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe Blacklight::SearchState do
         expect(search_state.to_h).to include f: { field: %w[first second] }
       end
     end
+
+    context 'deleting item from to_h' do
+      let(:params) { { q: 'foo', q_1: 'bar' } }
+
+      it 'does not mutate search_state to mutate search_state.to_h' do
+        params = search_state.to_h
+        params.delete(:q_1)
+
+        expect(search_state.to_h).to eq('q' => 'foo', 'q_1' => 'bar')
+        expect(params).to eq('q' => 'foo')
+      end
+    end
   end
 
   describe 'interface compatibility with params' do


### PR DESCRIPTION
`Blacklight::SearchState#to_h` needs to return a dupe of it's internal
state @params not a reference to it.  Otherwise whatever mutation you do
to the reference gets reflected in the `Blacklight::SearchState` instance.

It's unexpected behavior for the `to_h` method to expose the
`Blacklight::SearchState` instance's copy of `@params` and it can lead
to very confusing bugs.