### PR TITLE
Do not mutate search_state internal params on .to_h

### DIFF
--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -47,7 +47,7 @@ module Blacklight
     end
 
     def to_hash
-      @params.dup
+      @params.deep_dup
     end
     alias to_h to_hash
 

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Blacklight::SearchState do
         expect(params).to eq('q' => 'foo')
       end
     end
+
+    context 'deleting deep item from to_h' do
+      let(:params) { { foo: { bar: [] } } }
+
+      it 'does not mutate search_state to deep mutate search_state.to_h' do
+        params = search_state.to_h
+        params[:foo][:bar] << 'buzz'
+
+        expect(search_state.to_h).to eq('foo' => { 'bar' => [] })
+        expect(params).to eq('foo' => { 'bar' => ['buzz'] })
+      end
+    end
   end
 
   describe 'interface compatibility with params' do


### PR DESCRIPTION
Unfortunately the solution for protecting our search_state
instance's internal state is still incomplete.  In the case where we
mutate a deep object within `params` that change causes the search_state
`@params` to also mutate.

For example:`
`search_state.to_h[:f] << 'foo'` will mutate search_sate
too.

This commit fixes that issue by using Rails `.deep_dup` method instead of
the ruby core `.dup` method.