### PR TITLE
remove stopImmediatePropagation from handleSearchContextMethod

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -488,7 +488,6 @@ Blacklight.handleSearchContextMethod = function (event) {
   form.querySelector('[type="submit"]').click();
   event.preventDefault();
   event.stopPropagation();
-  event.stopImmediatePropagation();
 };
 
 Blacklight.onLoad(function () {

--- a/app/javascript/blacklight/search_context.js
+++ b/app/javascript/blacklight/search_context.js
@@ -59,7 +59,6 @@ Blacklight.handleSearchContextMethod = function(event) {
 
   event.preventDefault()
   event.stopPropagation()
-  event.stopImmediatePropagation()
 };
 
 Blacklight.onLoad(function() {


### PR DESCRIPTION
Removes call to `stopImmediatePropagation` in `Blacklight.handleSearchContextMethod`.

`stopImmediatePropagation` is overly restrictive, as it prevents downstream apps/gems from executing additional event handlers on search result links.

In Blacklight 6.*, this was `return false`, which can be similarly accomplished with just:
```
event.preventDefault()
event.stopPropagation()
```
In my case, I want to add Google Analytics event tracking to search result links. This was possible in 6.* , but the addition of `stopImmediatePropagation` in 7.* prevents this functionality.