### PR TITLE
Return of the solr wrapper

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,0 +1,5 @@
+# Place any default configuration for solr_wrapper here
+# port: 8983
+collection:
+  dir: lib/generators/blacklight/templates/solr/conf
+  name: blacklight-core

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop-rails", '~> 2.6'
   s.add_development_dependency "rubocop-rspec", '~> 1.43'
   s.add_development_dependency "i18n-tasks"
+  s.add_development_dependency "solr_wrapper"
 end

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -43,12 +43,7 @@ end
 desc "Run test suite"
 task :ci do
   with_solr do
-    Rake::Task['engine_cart:generate'].invoke
-
-    within_test_app do
-      system "RAILS_ENV=test bin/rake blacklight:index:seed"
-    end
-
+    Rake::Task['blacklight:internal:seed'].invoke
     Rake::Task['blacklight:coverage'].invoke
   end
 end

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -10,13 +10,22 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
+require 'open3'
+
+def system_with_error_handling(*args)
+  Open3.popen3(*args) do |stdout, stderr, status, _thread|
+    puts stdout.read
+    raise "Unable to run #{args.inspect}: #{stderr.read}" unless status.success?
+  end
+end
+
 def with_solr
-  puts "Starting Solr"
-  system "docker-compose up -d solr"
-  yield
-ensure
-  puts "Stopping Solr"
-  system "docker-compose stop solr"
+    puts "Starting Solr"
+    system_with_error_handling "docker-compose up -d solr"
+    yield
+  ensure
+    puts "Stopping Solr"
+    system_with_error_handling "docker-compose stop solr"
 end
 
 # rubocop:disable Rails/RakeEnvironment


### PR DESCRIPTION
Have the rake task:

- complain if `docker-compose` doesn't work
- fall back on solr_wrapper if docker isn't available