### PR TITLE
Allow the atom feed's summary to be customized

### DIFF
--- a/app/views/catalog/_document.atom.builder
+++ b/app/views/catalog/_document.atom.builder
@@ -19,9 +19,9 @@ xml.entry do
 
   with_format(:html) do
     xml.summary "type" => "html" do
-      xml.text! render_document_partial(document,
-                                        :index,
-                                        document_counter: document_counter)
+      xml.text! render_document_partials(document,
+                                         blacklight_config.view_config(:atom).summary_partials,
+                                         document_counter: document_counter)
     end
   end
 

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -66,7 +66,7 @@ module Blacklight
             # document presenter class used by helpers and views
             document_presenter_class: nil,
             # component class used to render a document; defaults to Blacklight::DocumentComponent,
-            #   but can be set explicitly to avoid any legacy behavior   
+            #   but can be set explicitly to avoid any legacy behavior
             document_component: nil,
             # solr field to use to render a document title
             title_field: nil,
@@ -100,7 +100,8 @@ module Blacklight
                                                    list: {},
                                                    atom: {
                                                      if: false, # by default, atom should not show up as an alternative view
-                                                     partials: [:document]
+                                                     partials: [:document],
+                                                     summary_partials: [:index]
                                                    },
                                                    rss: {
                                                      if: false, # by default, rss should not show up as an alternative view

--- a/spec/views/catalog/index.atom.builder_spec.rb
+++ b/spec/views/catalog/index.atom.builder_spec.rb
@@ -12,20 +12,23 @@ RSpec.describe "catalog/index" do
     end
   end
 
+  let(:blacklight_config) { CatalogController.blacklight_config }
+
   before do
     @response = Blacklight::Solr::Response.new({ response: { numFound: 30 } }, start: 10, rows: 10)
     allow(@response).to receive(:documents).and_return(document_list)
     params['content_format'] = 'some_format'
     allow(view).to receive(:action_name).and_return('index')
-    allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     allow(view).to receive(:search_field_options_for_select).and_return([])
-    render template: 'catalog/index', formats: [:atom]
   end
 
   # We need to use rexml to test certain things that have_tag wont' test
   let(:response_xml) { REXML::Document.new(rendered) }
 
   it "has contextual information" do
+    render template: 'catalog/index', formats: [:atom]
+
     expect(rendered).to have_selector("link[rel=self]")
     expect(rendered).to have_selector("link[rel=next]")
     expect(rendered).to have_selector("link[rel=previous]")
@@ -36,6 +39,8 @@ RSpec.describe "catalog/index" do
   end
 
   it "gets paging data correctly from response" do
+    render template: 'catalog/index', formats: [:atom]
+
     # Can't use have_tag for namespaced elements, sorry.
     expect(response_xml.elements["/feed/opensearch:totalResults"].text).to eq "30"
     expect(response_xml.elements["/feed/opensearch:startIndex"].text).to eq "10"
@@ -43,6 +48,8 @@ RSpec.describe "catalog/index" do
   end
 
   it "includes an opensearch Query role=request" do
+    render template: 'catalog/index', formats: [:atom]
+
     expect(response_xml.elements.to_a("/feed/opensearch:itemsPerPage")).to have(1).item
     query_el = response_xml.elements["/feed/opensearch:Query"]
     expect(query_el).not_to be_nil
@@ -52,34 +59,55 @@ RSpec.describe "catalog/index" do
   end
 
   it "has ten entries" do
+    render template: 'catalog/index', formats: [:atom]
+
     expect(rendered).to have_selector("entry", count: 10)
   end
 
   describe "entries" do
     it "has a title" do
+      render template: 'catalog/index', formats: [:atom]
       expect(rendered).to have_selector("entry > title")
     end
 
     it "has an updated" do
+      render template: 'catalog/index', formats: [:atom]
       expect(rendered).to have_selector("entry > updated")
     end
 
     it "has html link" do
+      render template: 'catalog/index', formats: [:atom]
       expect(rendered).to have_selector("entry > link[rel=alternate][type='text/html']")
     end
 
     it "has an id" do
+      render template: 'catalog/index', formats: [:atom]
       expect(rendered).to have_selector("entry > id")
     end
 
     it "has a summary" do
-      expect(rendered).to have_selector("entry > summary")
+      stub_template "catalog/_index.html.erb" => "partial content"
+      render template: 'catalog/index', formats: [:atom]
+      expect(rendered).to have_selector("entry > summary", text: 'partial content')
+    end
+
+    context 'with a custom HTML partial' do
+      before do
+        blacklight_config.view.atom.summary_partials = ['whatever']
+        stub_template 'catalog/_whatever_default.html.erb' => 'whatever content'
+      end
+
+      it "has the customized summary" do
+        render template: 'catalog/index', formats: [:atom]
+        expect(rendered).to have_selector("entry > summary", text: 'whatever content')
+      end
     end
 
     describe "with an author" do
       let(:entry) { response_xml.elements.to_a("/feed/entry")[0] }
 
       it "has author tag" do
+        render template: 'catalog/index', formats: [:atom]
         expect(entry.elements["author/name"].text).to eq 'xyz'
       end
     end
@@ -88,6 +116,7 @@ RSpec.describe "catalog/index" do
       let(:entry) { response_xml.elements.to_a("/feed/entry")[1] }
 
       it "does not have an author tag" do
+        render template: 'catalog/index', formats: [:atom]
         expect(entry.elements["author/name"]).to be_nil
       end
     end
@@ -98,10 +127,12 @@ RSpec.describe "catalog/index" do
       let(:entry) { response_xml.elements.to_a("/feed/entry")[1].to_s }
 
       it "includes a link rel tag" do
+        render template: 'catalog/index', formats: [:atom]
         expect(entry).to have_selector("link[rel=alternate][type='application/some-format']")
       end
 
       it "has content embedded" do
+        render template: 'catalog/index', formats: [:atom]
         expect(entry).to have_selector("content")
       end
     end
@@ -110,6 +141,7 @@ RSpec.describe "catalog/index" do
       let(:entry) { response_xml.elements.to_a("/feed/entry")[5].to_s }
 
       it "does not have content embedded" do
+        render template: 'catalog/index', formats: [:atom]
         expect(entry).not_to have_selector("content[type='application/some-format']")
       end
     end


### PR DESCRIPTION
 using the `blacklight_config.view.atom.summary_partials` configuration:

```ruby
blacklight_config.view.atom.summary_partials = ['whatever']
# will render e.g. catalog/_whatever_default.html.erb instead of catalog/_index.html.erb into the <summary> tag.
```