### PR TITLE
Fix two minor view component migration regressions

### DIFF
--- a/app/components/blacklight/response/sort_component.html.erb
+++ b/app/components/blacklight/response/sort_component.html.erb
@@ -1,4 +1,4 @@
-<%= render(Blacklight::System::DropdownComponent.new(
+<%= @view_context.render(Blacklight::System::DropdownComponent.new(
       param: @param,
       choices: @choices,
       id: @id,

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <label for="<%= @prefix %>q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, @q, placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{@search_fields.length > 1 ? '0' : 'left'}", id: "#{@prefix}q", autocomplete: @autocomplete_path.present? ? "off" : "", autofocus: @autofocus, data: { autocomplete_enabled: @autocomplete_path.present?, autocomplete_path: @autocomplete_path }  %>
+    <%= text_field_tag :q, @q, placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{@search_fields.length > 1 ? '0' : 'left'}", id: "#{@prefix}q", autocomplete: autocomplete_path.present? ? "off" : "", autofocus: @autofocus, data: { autocomplete_enabled: autocomplete_path.present?, autocomplete_path: autocomplete_path }  %>
 
     <%= content %>
 

--- a/app/components/blacklight/system/dropdown_component.html.erb
+++ b/app/components/blacklight/system/dropdown_component.html.erb
@@ -6,7 +6,7 @@
   <div class="dropdown-menu" role="menu">
     <%- @choices.each do |option| %>
       <% text, value = option_text_and_value(option) %>
-      <%= link_to(text, url_for(@search_state.params_for_search(@param => value)), class: 'dropdown-item', role: 'menuitem') %>
+      <%= link_to(text, @view_context.url_for(@search_state.params_for_search(@param => value)), class: 'dropdown-item', role: 'menuitem') %>
     <%- end -%>
   </div>
 <% end %>


### PR DESCRIPTION
1) the view component search bar always added the autocomplete bar if a route was available
2) cross-engine routing gets weird 