### PR TITLE
Keep subclassing ActionMailer::Base for RecordMailer for backwards co…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Naming/PredicateName:
 Rails:
   Enabled: true
 
+Rails/ApplicationMailer:
+  Enabled: false
+
 # https://github.com/rubocop-hq/rubocop/issues/6439
 Style/AccessModifierDeclarations:
   Enabled: false

--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # Only works for documents with a #to_marc right now.
-class RecordMailer < ApplicationMailer
+class RecordMailer < ActionMailer::Base
   def email_record(documents, details, url_gen_params)
     title = begin
               documents.first.to_semantic_values[:title]


### PR DESCRIPTION
…mpatibility

Introduced in https://github.com/projectblacklight/blacklight/commit/2a881c1af03a5db595da93b383edcd1505073eec because of Rubocop. This may make sense more in an application, but for backwards compatibility lets keep the `ActionMailer::Base` subclass.