### PR TITLE
Updates sort field config in catalog controller template

### DIFF
--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -184,10 +184,11 @@ class <%= controller_name.classify %>Controller < ApplicationController
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the Solr field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
-    # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
-    config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
-    config.add_sort_field 'author_si asc, title_si asc', label: 'author'
+    # except in the relevancy case). Add the sort: option to configure a
+    # custom Blacklight url parameter value separate from the Solr sort fields.
+    config.add_sort_field 'relevance', sort: 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
+    config.add_sort_field 'year-desc', sort: 'pub_date_si desc, title_si asc', label: 'year'
+    config.add_sort_field 'author', sort: 'author_si asc, title_si asc', label: 'author'
     config.add_sort_field 'title_si asc, pub_date_si desc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you

--- a/spec/models/blacklight/search_builder_spec.rb
+++ b/spec/models/blacklight/search_builder_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Blacklight::SearchBuilder, api: true do
       end
     end
 
-    context "when the user provides an sort parameter" do
+    context "when the user provides a sort parameter" do
       subject(:sort) { builder_with_param.send(:sort) }
 
       let(:builder_with_param) { builder.with(sort: 'x') }

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -331,6 +331,14 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
         end
       end
 
+      context "when the user provides a valid customized sort parmeter" do
+        let(:user_params) { { sort: 'year-desc' } }
+
+        it "passes solr sort paramters through" do
+          expect(subject[:sort]).to eq 'pub_date_si desc, title_si asc'
+        end
+      end
+
       context "when the user provides an invalid sort parameter" do
         let(:user_params) { { sort: 'bad' } }
 


### PR DESCRIPTION
This PR adds the `sort` config option in the Catalog Controller template file to demonstrate that Blacklight applications can use a configured sort url parameter rather than inserting the Solr sort params directly in the url ([example](http://demo.projectblacklight.org/?q=&search_field=all_fields&sort=title_si+asc%2C+pub_date_si+desc))