### PR TITLE
Unify document presenters to a single document_presenter helper

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -100,13 +100,7 @@ module Blacklight
     end
 
     def presenter
-      @presenter ||= begin
-        if show?
-          @view_context.presenter(@document)
-        else
-          @view_context.index_presenter(@document)
-        end
-      end
+      @presenter ||= @view_context.document_presenter(@document)
     end
 
     def show?

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -48,7 +48,7 @@ module Blacklight::BlacklightHelperBehavior
   def render_link_rel_alternates(document = @document, options = {})
     return if document.nil?
 
-    presenter(document).link_rel_alternates(options)
+    document_presenter(document).link_rel_alternates(options)
   end
 
   ##
@@ -208,7 +208,7 @@ module Blacklight::BlacklightHelperBehavior
   # @return [String]
   def document_heading document = nil
     document ||= @document
-    presenter(document).heading
+    document_presenter(document).heading
   end
 
   ##
@@ -221,7 +221,7 @@ module Blacklight::BlacklightHelperBehavior
   def document_show_html_title document = nil
     document ||= @document
 
-    presenter(document).html_title
+    document_presenter(document).html_title
   end
 
   ##
@@ -240,7 +240,7 @@ module Blacklight::BlacklightHelperBehavior
     tag = options.fetch(:tag, :h4)
     document ||= @document
 
-    content_tag(tag, presenter(document).heading, itemprop: "name")
+    content_tag(tag, document_presenter(document).heading, itemprop: "name")
   end
 
   ##
@@ -293,13 +293,15 @@ module Blacklight::BlacklightHelperBehavior
   # TODO: Move this to the controller. It can just pass a presenter or set of presenters.
   # @return [Blacklight::DocumentPresenter]
   def presenter(document)
+    Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#presenter is deprecated; use #document_presenter instead')
+
     # As long as the presenter methods haven't been overridden, we can use the new behavior
     if method(:show_presenter).owner == Blacklight::BlacklightHelperBehavior &&
        method(:index_presenter).owner == Blacklight::BlacklightHelperBehavior
       return document_presenter_class(document).new(document, self)
     end
 
-    Deprecation.warn(self, '#show_presenter and/or #index_presenter have been overridden; please override #document_presenter instead')
+    Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#show_presenter and/or #index_presenter have been overridden; please override #document_presenter instead')
 
     Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
       case action_name
@@ -310,7 +312,6 @@ module Blacklight::BlacklightHelperBehavior
       end
     end
   end
-  deprecation_deprecate presenter: 'Use #document_presenter instead'
 
   ##
   # Returns a document presenter for the given document
@@ -322,27 +323,29 @@ module Blacklight::BlacklightHelperBehavior
 
   # @return [Blacklight::ShowPresenter]
   def show_presenter(document)
+    Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#show_presenter is deprecated; use #document_presenter instead')
+
     if method(:show_presenter_class).owner != Blacklight::BlacklightHelperBehavior
-      Deprecation.warn(self, '#show_presenter_class has been overridden; please override #document_presenter_class instead')
+      Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#show_presenter_class has been overridden; please override #document_presenter_class instead')
     end
 
     Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
       show_presenter_class(document).new(document, self)
     end
   end
-  deprecation_deprecate show_presenter: 'Use #document_presenter instead'
 
   # @return [Blacklight::IndexPresenter]
   def index_presenter(document)
+    Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter is deprecated; use #document_presenter instead')
+
     if method(:index_presenter_class).owner != Blacklight::BlacklightHelperBehavior
-      Deprecation.warn(self, '#index_presenter_class has been overridden; please override #document_presenter_class instead')
+      Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter_class has been overridden; please override #document_presenter_class instead')
     end
 
     Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
       index_presenter_class(document).new(document, self)
     end
   end
-  deprecation_deprecate index_presenter: 'Use #document_presenter instead'
 
   ##
   # Override this method if you want to use a differnet presenter for your documents
@@ -361,15 +364,17 @@ module Blacklight::BlacklightHelperBehavior
   # Override this method if you want to use a different presenter class
   # @return [Class]
   def show_presenter_class(_document)
+    Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#show_presenter_class is deprecated; use #document_presenter_class instead')
+
     blacklight_config.show.document_presenter_class
   end
-  deprecation_deprecate show_presenter_class: 'Use #document_presenter_class intead'
 
   # @return [Class]
   def index_presenter_class(_document)
+    Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter_class is deprecated; use #document_presenter_class instead')
+
     blacklight_config.index.document_presenter_class
   end
-  deprecation_deprecate index_presenter_class: 'Use #document_presenter_class intead'
 
   # @return [Class]
   def search_bar_presenter_class

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -373,7 +373,8 @@ module Blacklight::BlacklightHelperBehavior
   def index_presenter_class(_document)
     Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter_class is deprecated; use #document_presenter_class instead')
 
-    blacklight_config.index.document_presenter_class
+    (blacklight_config.view.key?(document_index_view_type) && blacklight_config.dig(:view, document_index_view_type, :document_presenter_class)) ||
+      blacklight_config.index.document_presenter_class
   end
 
   # @return [Class]

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -140,7 +140,7 @@ module Blacklight::CatalogHelperBehavior
   # @param [Blacklight::Document] document
   # @return [String]
   def render_document_class(document = @document)
-    types = presenter(document).display_type
+    types = document_presenter(document).display_type
     return if types.blank?
 
     Array(types).compact.map do |t|
@@ -219,7 +219,7 @@ module Blacklight::CatalogHelperBehavior
   # @param [SolrDocument] document
   # @return [Boolean]
   def has_thumbnail? document
-    index_presenter(document).thumbnail.exists?
+    document_presenter(document).thumbnail.exists?
   end
   deprecation_deprecate has_thumbnail?: "use IndexPresenter#thumbnail.exists?"
 
@@ -233,7 +233,7 @@ module Blacklight::CatalogHelperBehavior
   # @param [Hash] url_options to pass to #link_to_document
   # @return [String]
   def render_thumbnail_tag document, image_options = {}, url_options = {}
-    index_presenter(document).thumbnail.thumbnail_tag(image_options, url_options)
+    document_presenter(document).thumbnail.thumbnail_tag(image_options, url_options)
   end
   deprecation_deprecate render_thumbnail_tag: "Use IndexPresenter#thumbnail.thumbnail_tag"
 

--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -65,7 +65,7 @@ module Blacklight::ConfigurationHelperBehavior
   # @deprecated
   # @return [String]
   def index_field_label document, field
-    field_config = blacklight_config.index_fields_for(index_presenter(document).display_type)[field]
+    field_config = blacklight_config.index_fields_for(document_presenter(document).display_type)[field]
     field_config ||= Blacklight::Configuration::NullField.new(key: field)
 
     field_config.display_label('index')
@@ -77,7 +77,7 @@ module Blacklight::ConfigurationHelperBehavior
   # @deprecated
   # @return [String]
   def document_show_field_label document, field
-    field_config = blacklight_config.show_fields_for(show_presenter(document).display_type)[field]
+    field_config = blacklight_config.show_fields_for(document_presenter(document).display_type)[field]
     field_config ||= Blacklight::Configuration::NullField.new(key: field)
 
     field_config.display_label('show')

--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -115,7 +115,7 @@ module Blacklight::RenderPartialsHelperBehavior
   # @param [Symbol] base_name base name for the partial
   # @return [String]
   def document_partial_name(document, base_name = nil)
-    display_type = show_presenter(document).display_type(base_name, default: 'default')
+    display_type = document_presenter(document).display_type(base_name, default: 'default')
 
     type_field_to_partial_name(document, display_type)
   end

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -21,10 +21,10 @@ module Blacklight::UrlHelperBehavior
   def link_to_document(doc, field_or_opts = nil, opts = { counter: nil })
     label = case field_or_opts
             when NilClass
-              index_presenter(doc).heading
+              document_presenter(doc).heading
             when Hash
               opts = field_or_opts
-              index_presenter(doc).heading
+              document_presenter(doc).heading
             when Proc, Symbol
               Deprecation.warn(self, "passing a #{field_or_opts.class} to link_to_document is deprecated and will be removed in Blacklight 8")
               Deprecation.silence(Blacklight::IndexPresenter) do

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -49,6 +49,24 @@ module Blacklight
       f ? field_value(f, except_operations: [Rendering::HelperMethod]) : ""
     end
 
+    ##
+    # Get the document's "title" to display in the <title> element.
+    # (by default, use the #document_heading)
+    #
+    # @see #document_heading
+    # @return [String]
+    def html_title
+      return field_value(view_config.html_title_field) if view_config.html_title_field.is_a? Blacklight::Configuration::Field
+
+      if view_config.html_title_field
+        fields = Array.wrap(view_config.html_title_field) + [configuration.document_model.unique_key]
+        f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| field_presenter(field_config).any? }
+        field_value(f)
+      else
+        heading
+      end
+    end
+
     def display_type(base_name = nil, default: nil)
       fields = []
       fields += Array.wrap(view_config[:"#{base_name}_display_type_field"]) if base_name && view_config.key?(:"#{base_name}_display_type_field")
@@ -74,6 +92,18 @@ module Blacklight
 
     def thumbnail
       @thumbnail ||= thumbnail_presenter.new(document, view_context, view_config)
+    end
+
+    ##
+    # Create <link rel="alternate"> links from a documents dynamically
+    # provided export formats. Returns empty string if no links available.
+    #
+    # @param [Hash] options
+    # @option options [Boolean] :unique ensures only one link is output for every
+    #     content type, e.g. as required by atom
+    # @option options [Array<String>] :exclude array of format shortnames to not include in the output
+    def link_rel_alternates(options = {})
+      LinkAlternatePresenter.new(view_context, document, options).render
     end
 
     private

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -72,6 +72,13 @@ module Blacklight
       fields += Array.wrap(view_config[:"#{base_name}_display_type_field"]) if base_name && view_config.key?(:"#{base_name}_display_type_field")
       fields += Array.wrap(view_config.display_type_field)
 
+      if fields.empty?
+        fields += Array.wrap(configuration.show[:"#{base_name}_display_type_field"]) if base_name && configuration.show.key?(:"#{base_name}_display_type_field")
+        fields += Array.wrap(configuration.show.display_type_field)
+      end
+
+      fields += ['format'] if fields.empty? # backwards compatibility with the old default value for display_type_field
+
       display_type = fields.lazy.map { |field| field_presenter(field_config(field)) }.detect(&:any?)&.values
       display_type ||= Array(default) if default
 

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -130,7 +130,11 @@ module Blacklight
 
     def field_presenter(field_config, options = {})
       presenter_class = field_config.presenter || Blacklight::FieldPresenter
-      presenter_class.new(view_context, document, field_config, options)
+      presenter_class.new(view_context, document, field_config, options.merge(field_presenter_options))
+    end
+
+    def field_presenter_options
+      {}
     end
   end
 end

--- a/app/presenters/blacklight/field_presenter.rb
+++ b/app/presenters/blacklight/field_presenter.rb
@@ -44,8 +44,8 @@ module Blacklight
 
     # @param [String] context
     # @return [String]
-    def label(context = 'index', **options)
-      field_config.display_label(context, count: retrieve_values.count, **options)
+    def label(context = nil, **options)
+      field_config.display_label(context || options.fetch(:context, 'index'), count: retrieve_values.count, **options)
     end
 
     ##

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -15,5 +15,9 @@ module Blacklight
     def field_config(field)
       configuration.show_fields.fetch(field) { Configuration::NullField.new(field) }
     end
+
+    def field_presenter_options
+      { context: 'show' }
+    end
   end
 end

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -1,36 +1,6 @@
 # frozen_string_literal: true
 module Blacklight
   class ShowPresenter < DocumentPresenter
-    ##
-    # Create <link rel="alternate"> links from a documents dynamically
-    # provided export formats. Returns empty string if no links available.
-    #
-    # @param [Hash] options
-    # @option options [Boolean] :unique ensures only one link is output for every
-    #     content type, e.g. as required by atom
-    # @option options [Array<String>] :exclude array of format shortnames to not include in the output
-    def link_rel_alternates(options = {})
-      LinkAlternatePresenter.new(view_context, document, options).render
-    end
-
-    ##
-    # Get the document's "title" to display in the <title> element.
-    # (by default, use the #document_heading)
-    #
-    # @see #document_heading
-    # @return [String]
-    def html_title
-      return field_value(view_config.html_title_field) if view_config.html_title_field.is_a? Blacklight::Configuration::Field
-
-      if view_config.html_title_field
-        fields = Array.wrap(view_config.html_title_field) + [configuration.document_model.unique_key]
-        f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| field_presenter(field_config).any? }
-        field_value(f)
-      else
-        heading
-      end
-    end
-
     private
 
     # @return [Hash<String,Configuration::Field>]

--- a/app/views/catalog/_document.atom.builder
+++ b/app/views/catalog/_document.atom.builder
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+presenter = document_presenter(document)
 xml.entry do
-  xml.title index_presenter(document).heading
+  xml.title presenter.heading
 
   # updated is required, for now we'll just set it to now, sorry
   xml.updated Time.current.iso8601
@@ -9,7 +10,7 @@ xml.entry do
   xml.link    "rel" => "alternate", "type" => "text/html", "href" => polymorphic_url(url_for_document(document))
   # add other doc-specific formats, atom only lets us have one per
   # content type, so the first one in the list wins.
-  xml << show_presenter(document).link_rel_alternates(unique: true)
+  xml << presenter.link_rel_alternates(unique: true)
 
   xml.id polymorphic_url(url_for_document(document))
 

--- a/app/views/catalog/_document.rss.builder
+++ b/app/views/catalog/_document.rss.builder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 xml.item do
-  xml.title(index_presenter(document).heading || (document.to_semantic_values[:title].first if document.to_semantic_values.key?(:title)))
+  xml.title(document_presenter(document).heading || (document.to_semantic_values[:title].first if document.to_semantic_values.key?(:title)))
   xml.link(polymorphic_url(url_for_document(document)))
   xml.author( document.to_semantic_values[:author].first ) if document.to_semantic_values.key? :author
 end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,1 +1,1 @@
-<%= render(Blacklight::DocumentMetadataComponent.new(fields: index_presenter(document).field_presenters)) %>
+<%= render(Blacklight::DocumentMetadataComponent.new(fields: document_presenter(document).field_presenters)) %>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,6 +1,6 @@
 <%= render(
   Blacklight::DocumentMetadataComponent.new(
-    fields: show_presenter(document).field_presenters,
+    fields: document_presenter(document).field_presenters,
     show: true
   )
 ) %>

--- a/app/views/catalog/_thumbnail.html.erb
+++ b/app/views/catalog/_thumbnail.html.erb
@@ -1,4 +1,4 @@
-<% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({ alt: '' }, 'aria-hidden': true, tabindex: -1, counter: document_counter_with_offset(document_counter)) %>
+<% if document_presenter(document).thumbnail.exists? && tn = document_presenter(document).thumbnail.thumbnail_tag({ alt: '' }, 'aria-hidden': true, tabindex: -1, counter: document_counter_with_offset(document_counter)) %>
 <div class="document-thumbnail">
   <%= tn %>
 </div>

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -12,7 +12,7 @@ end
 
 json.data do
   json.array! @presenter.documents do |document|
-    doc_presenter = index_presenter(document)
+    doc_presenter = document_presenter(document)
     document_url = polymorphic_url(url_for_document(document))
     json.id document.id
     json.type doc_presenter.display_type.first

--- a/app/views/catalog/show.json.jbuilder
+++ b/app/views/catalog/show.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 document_url = polymorphic_url(@document)
-doc_presenter = show_presenter(@document)
+doc_presenter = document_presenter(@document)
 
 json.links do
   json.self document_url

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -71,7 +71,7 @@ module Blacklight
             # solr field to use to render a document title
             title_field: nil,
             # solr field to use to render format-specific partials
-            display_type_field: 'format',
+            display_type_field: nil,
             # partials to render for each document(see #render_document_partials)
             partials: [:index_header, :thumbnail, :index],
             document_actions: NestedOpenStructWithHashAccess.new(ToolConfig),
@@ -86,7 +86,7 @@ module Blacklight
             # document presenter class used by helpers and views
             document_presenter_class: nil,
             document_component: nil,
-            display_type_field: 'format',
+            display_type_field: nil,
             # Default route parameters for 'show' requests.
             # Set this to a hash with additional arguments to merge into the route,
             # or set `controller: :current` to route to the current controller.
@@ -360,7 +360,7 @@ module Blacklight
     def index_fields_for(document_or_display_types)
       display_types = if document_or_display_types.is_a? Blacklight::Document
                         Deprecation.warn self, "Calling index_fields_for with a #{document_or_display_types.class} is deprecated and will be removed in Blacklight 8. Pass the display type instead."
-                        document_or_display_types[index.display_type_field]
+                        document_or_display_types[index.display_type_field || 'format']
                       else
                         document_or_display_types
                       end
@@ -380,7 +380,7 @@ module Blacklight
     def show_fields_for(document_or_display_types)
       display_types = if document_or_display_types.is_a? Blacklight::Document
                         Deprecation.warn self, "Calling show_fields_for with a #{document_or_display_types.class} is deprecated and will be removed in Blacklight 8. Pass the display type instead."
-                        document_or_display_types[show.display_type_field]
+                        document_or_display_types[show.display_type_field || 'format']
                       else
                         document_or_display_types
                       end

--- a/spec/components/blacklight/facet_item_pivot_component_spec.rb
+++ b/spec/components/blacklight/facet_item_pivot_component_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
   end
 
   it 'has the facet hierarchy' do
-    puts render
     expect(rendered).to have_selector 'li ul.pivot-facet'
     expect(rendered).to have_link 'x:1', href: /f%5Bz%5D%5B%5D=x%3A1/
   end

--- a/spec/helpers/blacklight/render_partials_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/render_partials_helper_behavior_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Blacklight::RenderPartialsHelperBehavior do
     let(:blacklight_config) { Blacklight::Configuration.new }
 
     before do
-      allow(helper).to receive_messages(blacklight_config: blacklight_config)
+      allow(helper).to receive_messages(blacklight_config: blacklight_config, action_name: 'show')
     end
 
     context "with a solr document with empty fields" do

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe CatalogHelper do
 
   describe "should_autofocus_on_search_box?" do
     before do
-      expect(Deprecation).to receive(:warn)
+      allow(Deprecation).to receive(:warn)
     end
 
     it "is focused if we're on a catalog-like index page without query or facet parameters" do
@@ -192,7 +192,7 @@ RSpec.describe CatalogHelper do
 
   describe "has_thumbnail?" do
     before do
-      expect(Deprecation).to receive(:warn)
+      allow(Deprecation).to receive(:warn)
     end
 
     let(:document) { SolrDocument.new(data) }
@@ -231,7 +231,7 @@ RSpec.describe CatalogHelper do
     let(:thumbnail_presenter) { instance_double(Blacklight::ThumbnailPresenter) }
 
     before do
-      expect(Deprecation).to receive(:warn)
+      allow(Deprecation).to receive(:warn)
       allow(helper).to receive(:index_presenter).with(document).and_return(index_presenter)
     end
 
@@ -250,7 +250,7 @@ RSpec.describe CatalogHelper do
 
   describe "thumbnail_url" do
     before do
-      expect(Deprecation).to receive(:warn)
+      allow(Deprecation).to receive(:warn)
     end
 
     it "pulls the configured thumbnail field out of the document" do

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -334,10 +334,6 @@ RSpec.describe Blacklight::SearchService, api: true do
     it 'has the expected value in the id field' do
       expect(@document.id).to eq doc_id
     end
-
-    it 'has non-nil values for required fields set in initializer' do
-      expect(@document.fetch(blacklight_config.view_config(:show).display_type_field)).not_to be_nil
-    end
   end
 
   describe 'Get multiple documents By Id', integration: true do

--- a/spec/views/catalog/show.json.jbuilder_spec.rb
+++ b/spec/views/catalog/show.json.jbuilder_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "catalog/show.json" do
 
   before do
     allow(view).to receive(:blacklight_config).and_return(config)
+    allow(view).to receive(:action_name).and_return('show')
     assign :document, document
   end
 


### PR DESCRIPTION
This PR:

- tries to eliminate the differences between index + show presenters (and succeeds, except for deprecated methods)
- streamlines the `presenter` helper (renamed to `document_presenter` for clarity... and to make it easier to search for..)
- provides a `document_presenter_class` to replace `show_presenter_class` and `index_presenter_class`
- tries to provide useful deprecation warnings if downstream apps have overridden `presenter`, `show_presenter`, `index_presenter`, `index_presenter_class` or `show_presenter_class`
