### PR TITLE
Integrate parts of "advanced" search

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -1,0 +1,46 @@
+<% if constraints.present? %>
+  <div class="constraints well search_history">
+    <h4><%= t 'blacklight.advanced_search.form.search_context' %></h4>
+    <%= constraints %>
+  </div>
+<% end %>
+
+<%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(@params) %>
+
+  <div class="input-criteria">
+    <div class="query-criteria">
+      <h2 class="query-criteria-heading">
+        <%= t('blacklight.advanced_search.form.query_criteria_heading_html', select_menu: default_operator_menu) %>
+      </h2>
+
+      <div id="advanced_search">
+        <%= search_field_controls %>
+      </div>
+    </div>
+
+    <div class="limit-criteria">
+      <h2 class="limit-criteria-heading"><%= t('blacklight.advanced_search.form.limit_criteria_heading_html')%></h2>
+
+      <div id="advanced_search_facets" class="limit_input">
+        <div class="advanced-facet-limits panel-group">
+          <%= search_filter_controls %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%= content_tag :h2, t('blacklight.advanced_search.form.sort_label') %>
+  <div class="form-group row">
+    <div class="col-sm-offset-3 col-sm-4">
+      <%= sort_fields_select %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div class="submit-buttons col-sm-offset-3 col-sm-9">
+      <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
+      <%= button_tag t('blacklight.advanced_search.form.start_over_html'), type: 'reset', class: 'btn btn-link advanced-search-start-over' %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class AdvancedSearchFormComponent < SearchBarComponent
+    with_content_areas :constraints, :search_field_controls, :search_filter_controls
+
+    def initialize(response:, **options)
+      super(**options)
+      @response = response
+    end
+
+    def default_operator_menu
+      options_with_labels = [:must, :should].index_by { |op| t(op, scope: 'blacklight.advanced_search.op') }
+      select_tag(:op, options_for_select(options_with_labels, params[:op]), class: 'input-small')
+    end
+
+    # Rubocop is just wrong here, so...:
+    # rubocop:disable Rails/ContentTag
+    def search_field_controls
+      @search_field_controls || safe_join(search_fields.values.map.with_index do |field, i|
+        fields_for('clause[]', i, include_id: false) do |f|
+          content_tag(:div, class: 'form-group advanced-search-field row') do
+            f.label(:query, field.display_label('search'), class: "col-sm-3 col-form-label") +
+            content_tag(:div, class: 'col-sm-9') do
+              f.hidden_field(:field, value: field.key) +
+              f.text_field(:query, value: query_for_search_clause(field.key), class: 'form-control')
+            end
+          end
+        end
+      end, "\n")
+    end
+    # rubocop:enable Rails/ContentTag
+
+    def query_for_search_clause(key)
+      field = (@params[:clause] || {}).values.find { |value| value['field'].to_s == key.to_s }
+
+      field&.dig('query')
+    end
+
+    def search_filter_controls
+      return @search_filter_controls if @search_filter_controls
+
+      fields = blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+
+      safe_join(fields.map do |_k, config|
+        display_facet = @response.aggregations[config.field]
+
+        presenter = (config.presenter || Blacklight::FacetFieldPresenter).new(config, display_facet, @view_context)
+        component = config.advanced_search_component || Blacklight::FacetFieldCheckboxesComponent
+        @view_context.render(component.new(facet_field: presenter))
+      end, "\n")
+    end
+
+    def constraints
+      params = @view_context.search_state.params_for_search.except :page, :f_inclusive, :q, :search_field, :op, :index, :sort
+
+      params.except!(*search_fields.map { |_key, field_def| field_def[:key] })
+
+      @view_context.render_search_to_s(params)
+    end
+
+    def sort_fields_select
+      options = sort_fields.values.map { |field_config| [@view_context.sort_field_label(field_config.key), field_config.key] }
+      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-control sort-select")
+    end
+
+    def search_fields
+      blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+    end
+
+    def sort_fields
+      blacklight_config.sort_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+    end
+  end
+end

--- a/app/components/blacklight/constraint_component.html.erb
+++ b/app/components/blacklight/constraint_component.html.erb
@@ -1,5 +1,5 @@
 <%= render(@layout.new(
-      classes: (Array(@classes) + ["filter-#{@facet_item_presenter.facet_config.key.parameterize}"]).join(' '),
+      classes: (Array(@classes) + ["filter-#{@facet_item_presenter.key.parameterize}"]).join(' '),
       label: @facet_item_presenter.field_label,
       value: @facet_item_presenter.label,
       remove_path: @facet_item_presenter.remove_href)) %>

--- a/app/components/blacklight/facet_field_checkboxes_component.html.erb
+++ b/app/components/blacklight/facet_field_checkboxes_component.html.erb
@@ -1,0 +1,23 @@
+<%= render(@layout.new(facet_field: @facet_field)) do |component| %>
+  <% component.with(:label) do %>
+    <%= @facet_field.label %>
+  <% end %>
+
+  <% component.with(:body) do %>
+    <ul class="facet-values list-unstyled blacklight-facet-checkboxes">
+      <% presenters.each_with_index do |presenter, idx| -%>
+        <li>
+          <span class="facet-checkbox">
+            <%= check_box_tag "f_inclusive[#{@facet_field.key}][]", presenter.value, presenter.selected?, id: "f_inclusive_#{@facet_field.key}_#{idx}"%>
+          </span>
+
+          <span class="label-and-count">
+            <%= label_tag "f_inclusive_#{@facet_field.key}_#{idx}" do %>
+              <%= presenter.label %>
+            <% end %>
+          <span>
+        </li>
+      <% end -%>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/components/blacklight/facet_field_checkboxes_component.rb
+++ b/app/components/blacklight/facet_field_checkboxes_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class FacetFieldCheckboxesComponent < ::ViewComponent::Base
+    def initialize(facet_field:, layout: nil)
+      @facet_field = facet_field
+      @layout = layout == false ? FacetFieldNoLayoutComponent : Blacklight::FacetFieldComponent
+    end
+
+    def render?
+      presenters.any?
+    end
+
+    def presenters
+      return [] unless @facet_field.paginator
+
+      return to_enum(:presenters) unless block_given?
+
+      @facet_field.paginator.items.each do |item|
+        yield Blacklight::FacetItemPresenter.new(item, @facet_field.facet_field, @view_context, @facet_field.key, @facet_field.search_state)
+      end
+    end
+  end
+end

--- a/app/components/blacklight/facet_field_inclusive_constraint_component.html.erb
+++ b/app/components/blacklight/facet_field_inclusive_constraint_component.html.erb
@@ -1,0 +1,6 @@
+<div class="inclusive_or card card-body bg-light mb-3">
+  <h5><%= t('blacklight.advanced_search.any_of') %></h5>
+  <ul class="list-unstyled facet-values">
+    <%= @view_context.render(Blacklight::FacetItemComponent.with_collection(presenters.to_a)) %>
+  </ul>
+</div>

--- a/app/components/blacklight/facet_field_inclusive_constraint_component.rb
+++ b/app/components/blacklight/facet_field_inclusive_constraint_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class FacetFieldInclusiveConstraintComponent < ::ViewComponent::Base
+    with_collection_parameter :facet_field
+
+    def initialize(facet_field:, values: nil)
+      @facet_field = facet_field
+      @values = values
+    end
+
+    def values
+      @values ||= @facet_field.values.find { |v| v.is_a? Array }
+      @values || []
+    end
+
+    def render?
+      values.present?
+    end
+
+    def presenters
+      return to_enum(:presenters) unless block_given?
+
+      values.each do |item|
+        yield Blacklight::FacetGroupedItemPresenter.new(values, item, @facet_field.facet_field, @view_context, @facet_field.key, @facet_field.search_state)
+      end
+    end
+  end
+end

--- a/app/components/blacklight/facet_field_list_component.html.erb
+++ b/app/components/blacklight/facet_field_list_component.html.erb
@@ -3,6 +3,7 @@
     <%= @facet_field.label %>
   <% end %>
   <% component.with(:body) do %>
+    <%= @view_context.render(Blacklight::FacetFieldInclusiveConstraintComponent.new(facet_field: @facet_field)) %>
     <ul class="facet-values list-unstyled">
       <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
     </ul>

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -103,6 +103,8 @@ module Blacklight
     def render_facet_count(options = {})
       return @view_context.render_facet_count(@hits, options) unless @view_context.method(:render_facet_count).owner == Blacklight::FacetsHelperBehavior || explicit_component_configuration?
 
+      return '' if @hits.blank?
+
       classes = (options[:classes] || []) << "facet-count"
       tag.span(t('blacklight.search.facets.count', number: number_with_delimiter(@hits)), class: classes)
     end

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -29,3 +29,7 @@
     </span>
   </div>
 <% end %>
+
+<% if presenter.advanced_search_enabled? %>
+  <%= link_to t('blacklight.advanced_search.more_options'), @advanced_search_url, class: 'advanced_search btn btn-secondary'%>
+<% end %>

--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -6,12 +6,14 @@ module Blacklight
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(
-      url:, params:, classes: ['search-query-form'], presenter: nil,
-      prefix: '', method: 'GET', q: nil, query_param: :q,
+      url:, advanced_search_url: nil, params:,
+      classes: ['search-query-form'], presenter: nil, prefix: '',
+      method: 'GET', q: nil, query_param: :q,
       search_field: nil, search_fields: [], autocomplete_path: nil,
       autofocus: nil, i18n: { scope: 'blacklight.search.form' }
     )
       @url = url
+      @advanced_search_url = advanced_search_url
       @q = q || params[:q]
       @query_param = query_param
       @search_field = search_field || params[:search_field]

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -56,6 +56,12 @@ module Blacklight::Catalog
     end
   end
 
+  def advanced_search
+    empty_service = search_service_class.new(config: blacklight_config, user_params: {}, **search_service_context)
+
+    (@response, _deprecated_document_list) = empty_service.search_results
+  end
+
   # get a single document from the index
   def raw
     raise(ActionController::RoutingError, 'Not Found') unless blacklight_config.raw_endpoint.enabled

--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -88,8 +88,8 @@ module Blacklight::RenderConstraintsHelperBehavior
       return "".html_safe if search_state.filter_params.blank?
 
       Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) do
-        safe_join(search_state.filter_params.each_pair.map do |facet, values|
-          render_filter_element(facet, values, search_state)
+        safe_join(search_state.filters.map do |field|
+          render_filter_element(field.key, field.values, search_state)
         end, "\n")
       end
     end

--- a/app/presenters/blacklight/clause_presenter.rb
+++ b/app/presenters/blacklight/clause_presenter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class ClausePresenter
+    attr_reader :key, :user_parameters, :field_config, :view_context, :search_state
+
+    def initialize(key, user_parameters, field_config, view_context, search_state = view_context.search_state)
+      @key = key
+      @user_parameters = user_parameters
+      @field_config = field_config
+      @view_context = view_context
+      @search_state = search_state
+    end
+
+    def field_label
+      field_config.display_label('search')
+    end
+
+    ##
+    # Get the displayable version of a facet's value
+    #
+    # @return [String]
+    def label
+      user_parameters[:query]
+    end
+
+    def remove_href(path = search_state)
+      view_context.search_action_path(path.reset_search(clause: path.clause_params.except(key)))
+    end
+
+    private
+
+    def facet_field_presenter
+      @facet_field_presenter ||= view_context.facet_field_presenter(facet_config, {})
+    end
+  end
+end

--- a/app/presenters/blacklight/facet_field_presenter.rb
+++ b/app/presenters/blacklight/facet_field_presenter.rb
@@ -40,6 +40,10 @@ module Blacklight
       view_context.facet_field_label(key)
     end
 
+    def values
+      search_state&.filter(facet_field)&.values || []
+    end
+
     # @private
     # @deprecated
     def html_id

--- a/app/presenters/blacklight/facet_grouped_item_presenter.rb
+++ b/app/presenters/blacklight/facet_grouped_item_presenter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class FacetGroupedItemPresenter < Blacklight::FacetItemPresenter
+    attr_reader :group
+
+    delegate :key, to: :facet_config
+
+    def initialize(group, facet_item, facet_config, view_context, facet_field, search_state = view_context.search_state)
+      @group = group
+      @facet_item = facet_item
+      @facet_config = facet_config
+      @view_context = view_context
+      @facet_field = facet_field
+      @search_state = search_state
+    end
+
+    ##
+    # Check if the query parameters have the given facet field with the
+    # given value.
+    def selected?
+      group.include?(facet_item)
+    end
+
+    # @private
+    def remove_href(path = search_state)
+      new_state = path.filter(facet_config).remove(group)
+      new_state = new_state.filter(facet_config).add(group - [facet_item])
+
+      view_context.search_action_path(new_state)
+    end
+
+    # @private
+    def add_href(_path_options = {})
+      if facet_config.url_method
+        return view_context.public_send(facet_config.url_method, facet_config.key, facet_item)
+      end
+
+      new_state = search_state.filter(facet_config).remove(@group)
+      new_state = new_state.filter(facet_config).add(@group + [facet_item])
+
+      view_context.search_action_path(new_state)
+    end
+  end
+end

--- a/app/presenters/blacklight/facet_item_presenter.rb
+++ b/app/presenters/blacklight/facet_item_presenter.rb
@@ -4,7 +4,7 @@ module Blacklight
   class FacetItemPresenter
     attr_reader :facet_item, :facet_config, :view_context, :search_state, :facet_field
 
-    delegate :hits, :items, to: :facet_item
+    delegate :key, to: :facet_config
 
     def initialize(facet_item, facet_config, view_context, facet_field, search_state = view_context.search_state)
       @facet_item = facet_item
@@ -14,12 +14,24 @@ module Blacklight
       @search_state = search_state
     end
 
+    def hits
+      return unless @facet_item.respond_to? :hits
+
+      @facet_item.hits
+    end
+
+    def items
+      return unless @facet_item.respond_to? :items
+
+      @facet_item.items
+    end
+
     ##
     # Check if the query parameters have the given facet field with the
     # given value.
     def selected?
       Deprecation.silence(Blacklight::SearchState) do
-        search_state.has_facet? facet_config, value: facet_value
+        search_state.has_facet? facet_config, value: value
       end
     end
 
@@ -34,21 +46,29 @@ module Blacklight
     def label
       return @view_context.facet_display_value(@facet_field, @facet_item) unless @view_context.method(:facet_display_value).owner == Blacklight::FacetsHelperBehavior
 
-      value = if facet_item.respond_to? :label
-                facet_item.label
-              else
-                facet_value
-              end
+      label_value = if facet_item.respond_to? :label
+                      facet_item.label
+                    else
+                      value
+                    end
 
       if facet_config.helper_method
-        view_context.public_send(facet_config.helper_method, value)
-      elsif facet_config.query && facet_config.query[value]
-        facet_config.query[value][:label]
+        view_context.public_send(facet_config.helper_method, label_value)
+      elsif facet_config.query && facet_config.query[label_value]
+        facet_config.query[label_value][:label]
       elsif facet_config.date
         localization_options = facet_config.date == true ? {} : facet_config.date
-        I18n.l(Time.zone.parse(value), **localization_options)
+        I18n.l(Time.zone.parse(label_value), **localization_options)
       else
-        value
+        label_value
+      end
+    end
+
+    def value
+      if facet_item.respond_to? :value
+        facet_item.value
+      else
+        facet_item
       end
     end
 
@@ -77,14 +97,6 @@ module Blacklight
     end
 
     private
-
-    def facet_value
-      if facet_item.respond_to? :value
-        facet_item.value
-      else
-        facet_item
-      end
-    end
 
     def facet_field_presenter
       @facet_field_presenter ||= view_context.facet_field_presenter(facet_config, {})

--- a/app/presenters/blacklight/inclusive_facet_item_presenter.rb
+++ b/app/presenters/blacklight/inclusive_facet_item_presenter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class InclusiveFacetItemPresenter < Blacklight::FacetItemPresenter
+    ##
+    # Get the displayable version of a facet's value
+    #
+    # @return [String]
+    def label
+      view_context.safe_join(
+        Array(facet_item).map { |value| Blacklight::FacetGroupedItemPresenter.new(facet_item, value, facet_config, view_context, facet_field, search_state).label },
+        view_context.t('blacklight.advanced_search.or_html')
+      )
+    end
+  end
+end

--- a/app/presenters/blacklight/search_bar_presenter.rb
+++ b/app/presenters/blacklight/search_bar_presenter.rb
@@ -37,5 +37,9 @@ module Blacklight
         controller.action_name == "index" &&
         !controller.has_search_parameters?
     end
+
+    def advanced_search_enabled?
+      configuration.advanced_search.enabled
+    end
   end
 end

--- a/app/views/catalog/_advanced_search_form.html.erb
+++ b/app/views/catalog/_advanced_search_form.html.erb
@@ -1,0 +1,7 @@
+<%= render(Blacklight::AdvancedSearchFormComponent.new(
+      url: search_action_url,
+      classes: ['advanced', 'form-horizontal'],
+      params: search_state.params_for_search.except(:qt),
+      search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
+      response: @response
+    )) %>

--- a/app/views/catalog/_advanced_search_help.html.erb
+++ b/app/views/catalog/_advanced_search_help.html.erb
@@ -1,0 +1,24 @@
+<div class='card card-default'>
+  <div class="card-body">
+    <h4 class="card-title">Search tips</h4>
+    <ul class="advanced-help">
+     <li>Select "match all" to require all fields.
+     </li>
+
+     <li>Select "match any" to find at least one field.
+     </li>
+
+     <li>Combine keywords and attributes to find specific items.
+     </li>
+
+     <li>Use quotation marks to search as a phrase.
+
+     <li>Use "+" before a term to make it required. (Otherwise results matching only some of your terms may be included).</li>
+
+     <li>Use "-" before a word or phrase to exclude.
+
+     <li>Use "OR", "AND", and "NOT" to create complex boolean logic. You can use parentheses in your complex expressions. </li>
+     <li>Truncation and wildcards are not supported - word-stemming is done automatically.</li>
+   </ul>
+  </div>
+</div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,5 +1,6 @@
 <%= render(Blacklight::SearchBarComponent.new(
       url: search_action_url,
+      advanced_search_url: search_action_url(action: 'advanced_search'),
       params: search_state.params_for_search.except(:qt),
       search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
       presenter: presenter,

--- a/app/views/catalog/advanced_search.html.erb
+++ b/app/views/catalog/advanced_search.html.erb
@@ -1,0 +1,17 @@
+<% @page_title = t('blacklight.advanced_search.page_title', application_name: application_name) %>
+
+<div class="advanced-search-form col-sm-12">
+  <h1 class="advanced page-header">
+      <%= t('blacklight.advanced_search.form.title') %>
+  </h1>
+
+  <div class="row">
+    <div class="col-md-8">
+        <%= render 'advanced_search_form' %>
+    </div>
+
+    <div class="col-md-4">
+        <%= render "advanced_search_help" %>
+    </div>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -18,3 +18,4 @@ search:
 
 ignore_missing:
   - 'button_label_html'
+  - 'blacklight.advanced_search.*'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -239,3 +239,6 @@ en:
     main:
       aria:
         main_container: 'Main content'
+
+    advanced_search:
+      or_html: ' OR '

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -242,3 +242,17 @@ en:
 
     advanced_search:
       or_html: ' OR '
+      more_options: More options
+      any_of: 'Any of:'
+      op:
+        must: all
+        should: any
+      page_title: Advanced search - %{application_name}
+      form:
+        title: Advanced search
+        search_context: Within search
+        limit_criteria_heading_html: "<strong>AND</strong> have these attributes"
+        query_criteria_heading_html: "Match %{select_menu} of the fields below"
+        sort_label: "Sort results by"
+        start_over_html: "Start over"
+        search_btn_html: 'Search'

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -132,7 +132,8 @@ module Blacklight
           crawler_detector: nil,
           autocomplete_suggester: 'mySuggester',
           raw_endpoint: OpenStructWithHashAccess.new(enabled: false),
-          track_search_session: true
+          track_search_session: true,
+          advanced_search: OpenStruct.new(enabled: false)
           }
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/blacklight/routes/searchable.rb
+++ b/lib/blacklight/routes/searchable.rb
@@ -8,6 +8,7 @@ module Blacklight
 
       def call(mapper, _options = {})
         mapper.match '/', action: 'index', as: 'search', via: [:get, :post]
+        mapper.get '/advanced', action: 'advanced_search', as: 'advanced_search'
 
         mapper.post ":id/track", action: 'track', as: 'track'
         mapper.get ":id/raw", action: 'raw', as: 'raw', defaults: { format: 'json' }

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -28,6 +28,7 @@ module Blacklight
 
       @blacklight_params = {}
       @search_state = Blacklight::SearchState.new(@blacklight_params, @scope&.blacklight_config, @scope)
+      @additional_filters = {}
       @merged_params = {}
       @reverse_merged_params = {}
     end
@@ -47,6 +48,7 @@ module Blacklight
       params_will_change!
       @search_state = @search_state.reset(@search_state.params.merge(q: conditions))
       @blacklight_params = @search_state.params.dup
+      @additional_filters = conditions
       self
     end
 

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -82,12 +82,16 @@ module Blacklight
 
     def has_constraints?
       Deprecation.silence(Blacklight::SearchState) do
-        !(query_param.blank? && filter_params.blank? && filters.blank?)
+        !(query_param.blank? && filter_params.blank? && filters.blank? && clause_params.blank?)
       end
     end
 
     def query_param
       params[:q]
+    end
+
+    def clause_params
+      params[:clause] || {}
     end
 
     def filter_params

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -8,7 +8,8 @@ module Blacklight::Solr
         :default_solr_parameters, :add_query_to_solr, :add_facet_fq_to_solr,
         :add_facetting_to_solr, :add_solr_fields_to_query, :add_paging_to_solr,
         :add_sorting_to_solr, :add_group_config_to_solr,
-        :add_facet_paging_to_solr
+        :add_facet_paging_to_solr, :add_adv_search_clauses,
+        :add_additional_filters
       ]
     end
 
@@ -61,10 +62,60 @@ module Blacklight::Solr
       elsif search_field&.solr_local_parameters.present?
         add_search_field_with_local_parameters(solr_parameters)
       elsif search_state.query_param.is_a? Hash
-        add_multifield_search_query(solr_parameters)
-      elsif blacklight_params[:q]
+        add_additional_filters(solr_parameters, search_state.query_param)
+      elsif search_state.query_param
         solr_parameters[:q] = search_state.query_param
       end
+    end
+
+    def add_additional_filters(solr_parameters, additional_filters = nil)
+      q = additional_filters || @additional_filters
+
+      return if q.blank?
+
+      solr_parameters[:q] = if q.values.any?(&:blank?)
+                              # if any field parameters are empty, exclude _all_ results
+                              "{!lucene}NOT *:*"
+                            else
+                              "{!lucene}" + q.map do |field, values|
+                                "#{field}:(#{Array(values).map { |x| solr_param_quote(x) }.join(' OR ')})"
+                              end.join(" AND ")
+                            end
+
+      solr_parameters[:defType] = 'lucene'
+      solr_parameters[:spellcheck] = 'false'
+    end
+
+    # Transform "clause" parameters into the Solr JSON Query DSL
+    def add_adv_search_clauses(solr_parameters)
+      return if search_state.clause_params.blank?
+
+      defaults = { must: [], must_not: [], should: [] }
+      bool_query = (solr_parameters.dig(:json, :query, :bool) || {}).reverse_merge(defaults)
+
+      default_op = blacklight_params[:op]&.to_sym || :must
+
+      search_state.clause_params.each_value do |clause|
+        op, query = adv_search_clause(clause, default_op)
+        bool_query[op] << query if defaults.key?(op) && query
+      end
+
+      return if bool_query.values.all?(&:blank?)
+
+      solr_parameters[:mm] = 1 if default_op == :should
+      solr_parameters[:json] ||= { query: { bool: {} } }
+      solr_parameters[:json][:query] ||= { bool: {} }
+      solr_parameters[:json][:query][:bool] = bool_query.reject { |_k, v| v.blank? }
+    end
+
+    # @return [Array] the first element is the query operator and the second is the value to add
+    def adv_search_clause(clause, default_op)
+      op = clause[:op]&.to_sym || default_op
+      field = (blacklight_config.search_fields || {})[clause[:field]] if clause[:field]
+
+      return unless field&.clause_params && clause[:query].present?
+
+      [op, field.clause_params.transform_values { |v| v.merge(query: clause[:query]) }]
     end
 
     ##
@@ -349,21 +400,6 @@ module Blacklight::Solr
       # our local params, otherwise it'll try and spellcheck the local
       # params!
       solr_parameters["spellcheck.q"] ||= search_state.query_param
-    end
-
-    def add_multifield_search_query(solr_parameters)
-      q = search_state.query_param
-      solr_parameters[:q] = if q.values.any?(&:blank?)
-                              # if any field parameters are empty, exclude _all_ results
-                              "{!lucene}NOT *:*"
-                            else
-                              "{!lucene}" + q.map do |field, values|
-                                "#{field}:(#{Array(values).map { |x| solr_param_quote(x) }.join(' OR ')})"
-                              end.join(" AND ")
-                            end
-
-      solr_parameters[:defType] = 'lucene'
-      solr_parameters[:spellcheck] = 'false'
     end
   end
 end

--- a/spec/components/blacklight/advanced_search_form_component_spec.rb
+++ b/spec/components/blacklight/advanced_search_form_component_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::AdvancedSearchFormComponent, type: :component do
+  subject(:render) do
+    component.render_in(view_context)
+  end
+
+  let(:component) { described_class.new(url: '/whatever', response: response, params: params) }
+  let(:response) { Blacklight::Solr::Response.new({ facet_counts: { facet_fields: { format: { 'Book' => 10, 'CD' => 5 } } } }.with_indifferent_access, {}) }
+  let(:params) { {} }
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:view_context) { controller.view_context }
+
+  before do
+    allow(view_context).to receive(:facet_limit_for).and_return(nil)
+  end
+
+  context 'with additional parameters' do
+    let(:params) { { some: :parameter, an_array: [1, 2] } }
+
+    it 'adds additional parameters as hidden fields' do
+      expect(rendered).to have_field 'some', with: 'parameter', type: :hidden
+      expect(rendered).to have_field 'an_array[]', with: '1', type: :hidden
+      expect(rendered).to have_field 'an_array[]', with: '2', type: :hidden
+    end
+  end
+
+  it 'has text fields for each search field' do
+    expect(rendered).to have_selector '.advanced-search-field', count: 4
+    expect(rendered).to have_field 'clause_0_field', with: 'all_fields', type: :hidden
+    expect(rendered).to have_field 'clause_1_field', with: 'title', type: :hidden
+    expect(rendered).to have_field 'clause_2_field', with: 'author', type: :hidden
+    expect(rendered).to have_field 'clause_3_field', with: 'subject', type: :hidden
+  end
+
+  it 'has filters' do
+    expect(rendered).to have_selector '.blacklight-format'
+    expect(rendered).to have_field 'f_inclusive[format][]', with: 'Book'
+    expect(rendered).to have_field 'f_inclusive[format][]', with: 'CD'
+  end
+
+  it 'has a sort field' do
+    expect(rendered).to have_select 'sort', options: %w[relevance year author title]
+  end
+end

--- a/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
+  subject(:render) do
+    render_inline(described_class.new(facet_field: facet_field))
+  end
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:facet_field) do
+    instance_double(
+      Blacklight::FacetFieldPresenter,
+      facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+      paginator: paginator,
+      key: 'field',
+      label: 'Field',
+      active?: false,
+      collapsed?: false,
+      modal_path: nil,
+      html_id: 'facet-field',
+      search_state: search_state
+    )
+  end
+
+  let(:paginator) do
+    instance_double(Blacklight::FacetPaginator, items: [
+                      double(label: 'a', hits: 10, value: 'a'),
+                      double(label: 'b', hits: 33, value: 'b'),
+                      double(label: 'c', hits: 3, value: 'c')
+                    ])
+  end
+
+  let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, Blacklight::Configuration.new) }
+  let(:params) { { f: { field: ['a'] } } }
+
+  it 'renders a collapsible card' do
+    expect(rendered).to have_selector '.card'
+    expect(rendered).to have_button 'Field'
+    expect(rendered).to have_selector 'button[data-target="#facet-field"]'
+    expect(rendered).to have_selector '#facet-field.collapse.show'
+  end
+
+  it 'renders the facet items' do
+    expect(rendered).to have_selector 'ul.facet-values'
+    expect(rendered).to have_selector 'li', count: 3
+
+    expect(rendered).to have_field 'f_inclusive[field][]', with: 'a'
+    expect(rendered).to have_field 'f_inclusive[field][]', with: 'b'
+    expect(rendered).to have_field 'f_inclusive[field][]', with: 'c'
+  end
+end

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       active?: false,
       collapsed?: false,
       modal_path: nil,
-      html_id: 'facet-field'
+      html_id: 'facet-field',
+      values: []
     )
   end
 
@@ -53,7 +54,8 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
         active?: true,
         collapsed?: false,
         modal_path: nil,
-        html_id: 'facet-field'
+        html_id: 'facet-field',
+        values: []
       )
     end
 
@@ -72,7 +74,8 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
         active?: false,
         collapsed?: true,
         modal_path: nil,
-        html_id: 'facet-field'
+        html_id: 'facet-field',
+        values: []
       )
     end
 
@@ -97,12 +100,44 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
         active?: false,
         collapsed?: false,
         modal_path: '/catalog/facet/modal',
-        html_id: 'facet-field'
+        html_id: 'facet-field',
+        values: []
       )
     end
 
     it 'renders a link to the modal' do
       expect(rendered).to have_link 'more Field', href: '/catalog/facet/modal'
+    end
+  end
+
+  context 'with inclusive facets' do
+    let(:facet_field) do
+      instance_double(
+        Blacklight::FacetFieldPresenter,
+        paginator: paginator,
+        facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+        key: 'field',
+        label: 'Field',
+        active?: false,
+        collapsed?: false,
+        modal_path: nil,
+        html_id: 'facet-field',
+        values: [%w[a b c]],
+        search_state: search_state
+      )
+    end
+
+    let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, Blacklight::Configuration.new) }
+    let(:params) { { f_inclusive: { field: %w[a b c] } } }
+
+    it 'displays the constraint above the list' do
+      expect(rendered).to have_content 'Any of:'
+      expect(rendered).to have_selector '.inclusive_or .facet-label', text: 'a'
+      expect(rendered).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=b&f_inclusive%5Bfield%5D%5B%5D=c'
+      expect(rendered).to have_selector '.inclusive_or .facet-label', text: 'b'
+      expect(rendered).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=a&f_inclusive%5Bfield%5D%5B%5D=c'
+      expect(rendered).to have_selector '.inclusive_or .facet-label', text: 'c'
+      expect(rendered).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=a&f_inclusive%5Bfield%5D%5B%5D=b'
     end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -301,6 +301,15 @@ RSpec.describe CatalogController, api: true do
     end
   end
 
+  describe 'GET advanced_search' do
+    it 'renders an advanced search form' do
+      get :advanced_search
+      expect(response).to be_successful
+
+      assert_facets_have_values(assigns(:response).aggregations)
+    end
+  end
+
   # SHOW ACTION
   describe "show action" do
     describe "with format :html" do

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Blacklight Advanced Search Form" do
+  describe "advanced search form" do
+    before do
+      visit '/catalog/advanced?hypothetical_existing_param=true&q=ignore+this+existing+query'
+    end
+
+    it "has field and facet blocks" do
+      expect(page).to have_selector('.query-criteria')
+      expect(page).to have_selector('.limit-criteria')
+    end
+
+    describe "query column" do
+      it "gives the user a choice between and/or queries" do
+        expect(page).to have_selector('#op')
+        within('#op') do
+          expect(page).to have_selector('option[value="must"]')
+          expect(page).to have_selector('option[value="should"]')
+        end
+      end
+
+      it "lists the configured search fields" do
+        expect(page).to have_field 'All Fields'
+        expect(page).to have_field 'Title'
+        expect(page).to have_field 'Author'
+        expect(page).to have_field 'Subject'
+      end
+    end
+
+    describe "facet column" do
+      it "lists facets" do
+        expect(page).to have_selector('.blacklight-language_ssim')
+
+        within('.blacklight-language_ssim') do
+          expect(page).to have_content 'Language'
+        end
+      end
+    end
+
+    it 'scopes searches to fields' do
+      fill_in 'Title', with: 'Medicine'
+      click_on 'advanced-search-submit'
+      expect(page).to have_content 'Remove constraint Title: Medicine'
+      expect(page).to have_content 'Strong Medicine speaks'
+    end
+  end
+
+  describe "prepopulated advanced search form" do
+    before do
+      visit '/catalog/advanced?op=must&clause[0][field]=title&clause[0]query=medicine'
+    end
+
+    it "does not create hidden inputs for search fields" do
+      expect(page).to have_field 'Title', with: 'medicine'
+    end
+
+    it "does not have multiple parameters for a search field" do
+      fill_in 'Title', with: 'bread'
+      click_on 'advanced-search-submit'
+      expect(page.current_url).to match(/bread/)
+      expect(page.current_url).not_to match(/medicine/)
+    end
+  end
+end

--- a/spec/models/blacklight/solr/repository_spec.rb
+++ b/spec/models/blacklight/solr/repository_spec.rb
@@ -134,6 +134,18 @@ RSpec.describe Blacklight::Solr::Repository, api: true do
         end
       end
     end
+
+    context 'with json parameters' do
+      it 'sends a post request with some json' do
+        allow(subject.connection).to receive(:send_and_receive) do |path, params|
+          expect(path).to eq 'select'
+          expect(params[:method]).to eq :post
+          expect(JSON.parse(params[:data]).with_indifferent_access).to include(query: { bool: {} })
+          expect(params[:headers]).to include({ 'Content-Type' => 'application/json' })
+        end.and_return('response' => { 'docs' => [] })
+        subject.search(json: { query: { bool: {} } })
+      end
+    end
   end
 
   describe "http_method configuration", integration: true do

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -734,4 +734,21 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       expect(subject.with_ex_local_param(nil, "some-value")).to eq "some-value"
     end
   end
+
+  context 'with advanced search clause parameters' do
+    before do
+      blacklight_config.search_fields.each_value do |v|
+        v.clause_params = { edismax: v.solr_parameters.dup }
+      end
+    end
+
+    let(:user_params) { { op: 'must', clause: { '0': { field: 'title', query: 'the book' }, '1': { field: 'author', query: 'the person' } } } }
+
+    it "has proper solr parameters" do
+      expect(subject.to_hash.with_indifferent_access.dig(:json, :query, :bool, :must, 0, :edismax, :query)).to eq 'the book'
+      expect(subject.to_hash.with_indifferent_access.dig(:json, :query, :bool, :must, 0, :edismax, :qf)).to eq '${title_qf}'
+      expect(subject.to_hash.with_indifferent_access.dig(:json, :query, :bool, :must, 1, :edismax, :query)).to eq 'the person'
+      expect(subject.to_hash.with_indifferent_access.dig(:json, :query, :bool, :must, 1, :edismax, :qf)).to eq '${author_qf}'
+    end
+  end
 end

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -259,6 +259,17 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       end
     end
 
+    describe 'with multi-valued facets' do
+      let(:user_params) { { f_inclusive: { format: %w[Book Movie CD] } } }
+
+      it "has proper solr parameters" do
+        expect(subject[:fq]).to include('{!lucene}{!query v=$f_inclusive.format.0} OR {!query v=$f_inclusive.format.1} OR {!query v=$f_inclusive.format.2}')
+        expect(subject['f_inclusive.format.0']).to eq '{!term f=format}Book'
+        expect(subject['f_inclusive.format.1']).to eq '{!term f=format}Movie'
+        expect(subject['f_inclusive.format.2']).to eq '{!term f=format}CD'
+      end
+    end
+
     describe "solr parameters for a field search from config (subject)" do
       let(:user_params) { subject_search_params }
 

--- a/spec/presenters/blacklight/clause_presenter_spec.rb
+++ b/spec/presenters/blacklight/clause_presenter_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Blacklight::ClausePresenter, type: :presenter do
+  subject(:presenter) do
+    described_class.new('0', params.with_indifferent_access.dig(:clause, '0'), field_config, controller.view_context, search_state)
+  end
+
+  let(:field_config) { Blacklight::Configuration::NullField.new key: 'some_field' }
+  let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, Blacklight::Configuration.new) }
+  let(:params) { {} }
+
+  describe '#field_label' do
+    it 'returns a label for the field' do
+      expect(subject.field_label).to eq 'Some Field'
+    end
+  end
+
+  describe '#label' do
+    let(:params) { { clause: { '0' => { query: 'some search string' } } } }
+
+    it 'returns the query value for the clause' do
+      expect(subject.label).to eq 'some search string'
+    end
+  end
+
+  describe '#remove_href' do
+    let(:params) { { clause: { '0' => { query: 'some_search_string' } } } }
+
+    it 'returns the href to remove the search clause' do
+      expect(subject.remove_href).not_to include 'some_search_string'
+    end
+  end
+end

--- a/spec/presenters/blacklight/facet_grouped_item_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_grouped_item_presenter_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Blacklight::FacetGroupedItemPresenter, type: :presenter do
+  subject(:presenter) do
+    described_class.new(group, facet_item, facet_config, view_context, facet_field, search_state)
+  end
+
+  let(:facet_config) { Blacklight::Configuration::FacetField.new(key: 'key') }
+  let(:facet_field) { instance_double(Blacklight::Solr::Response::Facets::FacetField) }
+  let(:view_context) { controller.view_context }
+
+  let(:facet_item) { 'a' }
+  let(:group) { %w[a b c] }
+  let(:search_state) { Blacklight::SearchState.new(params, Blacklight::Configuration.new) }
+  let(:params) { { f_inclusive: { key: group } } }
+
+  describe '#selected' do
+    it { is_expected.to be_selected }
+
+    context 'when the item is not in the group' do
+      let(:facet_item) { 'd' }
+
+      it { is_expected.not_to be_selected }
+    end
+
+    describe '#href' do
+      it 'removes the item from the "group" of filters' do
+        expect(Rack::Utils.parse_query(URI(presenter.href).query)).to include 'f_inclusive[key][]' => %w[b c]
+      end
+
+      context 'when the item is not in the group' do
+        let(:facet_item) { 'd' }
+
+        it 'adds the item to the "group" of filters' do
+          expect(Rack::Utils.parse_query(URI(presenter.href).query)).to include 'f_inclusive[key][]' => %w[a b c d]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR pulls in some of the key functional bits from advanced search:

- [x] a component for doing multi-select facets
- [x] a form for doing multi-field fielded search
- [x] support for generating solr queries for "inclusive" facets
- [x] support for generating solr boolean queries for multi-field search using the JSON query DSL (requires Solr 7.1+, but so much easier)
