### PR TITLE
Allow search fields to provide a query_builder configuration for constructing queries

### DIFF
--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -47,8 +47,8 @@ module Blacklight
     # @!attribute pivot
     #   @return []
     # @!attribute filter_query_builder
-    #   @return [nil, #call] a Proc (or other object responding to #call) that receives as parameters this facet config and an array of selected values;
-    #     The Proc returns a string suitable for e.g. Solr's fq parameter, or a 2-element array of the string and a hash of additional
+    #   @return [nil, #call] a Proc (or other object responding to #call) that receives as parameters: 1) the search builder, 2) this facet config
+    #     and 3) the solr parameters hash. The Proc returns a string suitable for e.g. Solr's fq parameter, or a 2-element array of the string and a hash of additional
     #     parameters to include with the query (i.e. for referenced subqueries); note that implementations are responsible for ensuring
     #     the additional parameter keys are unique.
     # @!attribute filter_class

--- a/lib/blacklight/configuration/search_field.rb
+++ b/lib/blacklight/configuration/search_field.rb
@@ -3,6 +3,11 @@ module Blacklight
   class Configuration::SearchField < Blacklight::Configuration::Field
     # @!attribute include_in_simple_select
     # @!attribute qt
+    # @!attribute query_builder
+    #   @return [nil, #call] a Proc (or other object responding to #call) that receives as parameters: 1) the search builder, 2) this search field,
+    #     and 3) the solr_parameters hash.  The Proc returns a string suitable for e.g. Solr's q parameter, or a 2-element array of the
+    #     string and a hash of additional parameters to include with the query (i.e. for referenced subqueries); note that
+    #     implementations are responsible for ensuring the additional parameter keys are unique.
 
     def normalize! blacklight_config = nil
       self.if = include_in_simple_select if self.if.nil?

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -399,6 +399,21 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       end
     end
 
+    describe 'the search field query_builder config' do
+      let(:blacklight_config) do
+        Blacklight::Configuration.new do |config|
+          config.add_search_field('built_query', query_builder: ->(builder, *_args) { [builder.blacklight_params[:q].reverse, qq1: 'xyz'] })
+        end
+      end
+
+      let(:user_params) { { search_field: 'built_query', q: 'value' } }
+
+      it 'uses the provided query builder' do
+        expect(subject[:q]).to eq 'eulav'
+        expect(subject[:qq1]).to eq 'xyz'
+      end
+    end
+
     describe "mapping facet.field" do
       let(:blacklight_config) do
         Blacklight::Configuration.new do |config|


### PR DESCRIPTION
Building on the pattern from #2366 (and tweaking the facet pattern to mirror search fields, which needed a more generic API...).