### PR TITLE
Extract Blacklight::SearchState::FilterField and use it to manage filter url parameters

### DIFF
--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -47,13 +47,15 @@ module Blacklight
     private
 
     def facet_item_presenters
-      @search_state.filter_params.each_pair.flat_map do |facet, values|
-        facet_config = @view_context.facet_configuration_for_field(facet)
+      Deprecation.silence(Blacklight::SearchState) do
+        @search_state.filter_params.each_pair.flat_map do |facet, values|
+          facet_config = @view_context.facet_configuration_for_field(facet)
 
-        Array(values).map do |val|
-          next if val.blank? # skip empty string
+          Array(values).map do |val|
+            next if val.blank? # skip empty string
 
-          facet_item_presenter(facet_config, val, facet)
+            facet_item_presenter(facet_config, val, facet)
+          end
         end
       end
     end

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -254,7 +254,10 @@ module Blacklight::FacetsHelperBehavior
   # @return [Boolean]
   def facet_field_in_params? field
     config = facet_configuration_for_field(field)
-    search_state.has_facet? config
+
+    Deprecation.silence(Blacklight::SearchState) do
+      search_state.has_facet? config
+    end
   end
   # Left undeprecated for the sake of temporary backwards compatibility
   # deprecation_deprecate :facet_field_in_params?
@@ -269,7 +272,10 @@ module Blacklight::FacetsHelperBehavior
   # @return [Boolean]
   def facet_in_params?(field, item)
     config = facet_configuration_for_field(field)
-    search_state.has_facet? config, value: facet_value_for_facet_item(item)
+
+    Deprecation.silence(Blacklight::SearchState) do
+      search_state.has_facet? config, value: facet_value_for_facet_item(item)
+    end
   end
   deprecation_deprecate :facet_in_params?
 

--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -84,12 +84,14 @@ module Blacklight::RenderConstraintsHelperBehavior
     Deprecation.warn(Blacklight::RenderConstraintsHelperBehavior, 'render_constraints_filters is deprecated')
     search_state = convert_to_search_state(params_or_search_state)
 
-    return "".html_safe if search_state.filter_params.blank?
+    Deprecation.silence(Blacklight::SearchState) do
+      return "".html_safe if search_state.filter_params.blank?
 
-    Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) do
-      safe_join(search_state.filter_params.each_pair.map do |facet, values|
-        render_filter_element(facet, values, search_state)
-      end, "\n")
+      Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) do
+        safe_join(search_state.filter_params.each_pair.map do |facet, values|
+          render_filter_element(facet, values, search_state)
+        end, "\n")
+      end
     end
   end
 

--- a/app/presenters/blacklight/facet_item_presenter.rb
+++ b/app/presenters/blacklight/facet_item_presenter.rb
@@ -18,7 +18,9 @@ module Blacklight
     # Check if the query parameters have the given facet field with the
     # given value.
     def selected?
-      search_state.has_facet? facet_config, value: facet_value
+      Deprecation.silence(Blacklight::SearchState) do
+        search_state.has_facet? facet_config, value: facet_value
+      end
     end
 
     def field_label
@@ -60,7 +62,9 @@ module Blacklight
 
     # @private
     def remove_href(path = search_state)
-      view_context.search_action_path(path.remove_facet_params(facet_config.key, facet_item))
+      Deprecation.silence(Blacklight::SearchState) do
+        view_context.search_action_path(path.remove_facet_params(facet_config.key, facet_item))
+      end
     end
 
     # @private

--- a/app/presenters/blacklight/rendering/link_to_facet.rb
+++ b/app/presenters/blacklight/rendering/link_to_facet.rb
@@ -32,7 +32,9 @@ module Blacklight
       end
 
       def facet_params(field, v)
-        context.search_state.reset.add_facet_params(field, v)
+        Deprecation.silence(Blacklight::SearchState) do
+          context.search_state.reset.add_facet_params(field, v)
+        end
       end
     end
   end

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -51,7 +51,9 @@ json.included do
           json.links do
             Deprecation.silence(Blacklight::FacetsHelperBehavior) do
               if facet_in_params?(facet.name, item.value)
-                json.remove search_action_path(search_state.remove_facet_params(facet.name, item.value))
+                Deprecation.silence(Blacklight::SearchState) do
+                  json.remove search_action_path(search_state.remove_facet_params(facet.name, item.value))
+                end
               else
                 json.self path_for_facet(facet.name, item.value, only_path: false)
               end

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -51,6 +51,8 @@ module Blacklight
     #     The Proc returns a string suitable for e.g. Solr's fq parameter, or a 2-element array of the string and a hash of additional
     #     parameters to include with the query (i.e. for referenced subqueries); note that implementations are responsible for ensuring
     #     the additional parameter keys are unique.
+    # @!attribute filter_class
+    #  @ return [nil, Blacklight::SearchState::FilterField] a class that implements the `FilterField`'s' API to manage URL parameters for a facet
 
     ##
     # Rendering:

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require 'blacklight/search_state/filter_field'
+
 module Blacklight
   # This class encapsulates the search state as represented by the query
   # parameters namely: :f, :q, :page, :per_page and, :sort
@@ -78,7 +81,9 @@ module Blacklight
     deprecation_deprecate :[]
 
     def has_constraints?
-      !(query_param.blank? && filter_params.blank?)
+      Deprecation.silence(Blacklight::SearchState) do
+        !(query_param.blank? && filter_params.blank? && filters.blank?)
+      end
     end
 
     def query_param
@@ -88,9 +93,16 @@ module Blacklight
     def filter_params
       params[:f] || {}
     end
+    deprecation_deprecate filter_params: 'Use #filters instead'
 
+    # @return [Blacklight::SearchState]
     def reset(params = nil)
       self.class.new(params || ActionController::Parameters.new, blacklight_config, controller)
+    end
+
+    # @return [Blacklight::SearchState]
+    def reset_search(additional_params = {})
+      reset(reset_search_params.merge(additional_params))
     end
 
     ##
@@ -115,23 +127,30 @@ module Blacklight
       p
     end
 
+    def filters
+      @filters ||= blacklight_config.facet_fields.each_value.map do |value|
+        f = filter(value)
+
+        f if f.any?
+      end.compact
+    end
+
+    def filter(field_key_or_field)
+      field = field_key_or_field if field_key_or_field.is_a? Blacklight::Configuration::Field
+      field ||= blacklight_config.facet_fields[field_key_or_field]
+      field ||= Blacklight::Configuration::NullField.new(key: field_key_or_field)
+
+      (field.filter_class || FilterField).new(field, self)
+    end
+
     # adds the value and/or field to params[:f]
     # Does NOT remove request keys and otherwise ensure that the hash
     # is suitable for a redirect. See
     # add_facet_params_and_redirect
     def add_facet_params(field, item)
-      p = reset_search_params
-
-      add_facet_param(p, field, item)
-
-      if item && item.respond_to?(:fq) && item.fq
-        Array(item.fq).each do |f, v|
-          add_facet_param(p, f, v)
-        end
-      end
-
-      p
+      filter(field).add(item).params
     end
+    deprecation_deprecate add_facet_params: 'Use filter(field).add(item) instead'
 
     # Used in catalog/facet action, facets.rb view, for a click
     # on a facet value. Add on the facet params to existing
@@ -141,7 +160,9 @@ module Blacklight
     # Change the action to 'index' to send them back to
     # catalog/index with their new facet choice.
     def add_facet_params_and_redirect(field, item)
-      new_params = add_facet_params(field, item)
+      new_params = Deprecation.silence(self.class) do
+        add_facet_params(field, item)
+      end
 
       # Delete any request params from facet-specific action, needed
       # to redir to index action properly.
@@ -158,45 +179,18 @@ module Blacklight
     # @param [String] field
     # @param [String] item
     def remove_facet_params(field, item)
-      if item.respond_to? :field
-        field = item.field
-      end
-
-      facet_config = facet_configuration_for_field(field)
-
-      url_field = facet_config.key
-
-      value = facet_value_for_facet_item(item)
-
-      p = reset_search_params
-      # need to dup the facet values too,
-      # if the values aren't dup'd, then the values
-      # from the session will get remove in the show view...
-      p[:f] = (p[:f] || {}).dup
-      p[:f][url_field] = (p[:f][url_field] || []).dup
-
-      collection = p[:f][url_field]
-      # collection should be an array, because we link to ?f[key][]=value,
-      # however, Facebook (and maybe some other PHP tools) tranform that parameters
-      # into ?f[key][0]=value, which Rails interprets as a Hash.
-      if collection.is_a? Hash
-        collection = collection.values
-      end
-      p[:f][url_field] = collection - [value]
-      p[:f].delete(url_field) if p[:f][url_field].empty?
-      p.delete(:f) if p[:f].empty?
-      p
+      filter(field).remove(item).params
     end
+    deprecation_deprecate remove_facet_params: 'Use filter(field).remove(item) instead'
 
     def has_facet?(config, value: nil)
-      facet = params&.dig(:f, config.key)
-
       if value
-        (facet || []).include? value
+        filter(config).include?(value)
       else
-        facet.present?
+        filter(config).any?
       end
     end
+    deprecation_deprecate has_facet?: 'Use filter(field).include?(value) or .any? instead'
 
     # Merge the source params with the params_to_merge hash
     # @param [Hash] params_to_merge to merge into above
@@ -225,36 +219,6 @@ module Blacklight
     # @return [ActionController::Parameters]
     def reset_search_params
       Parameters.sanitize(params).except(:page, :counter)
-    end
-
-    # TODO: this code is duplicated in Blacklight::FacetsHelperBehavior
-    def facet_value_for_facet_item item
-      if item.respond_to? :value
-        item.value
-      else
-        item
-      end
-    end
-
-    def add_facet_param(p, field, item)
-      if item.respond_to? :field
-        field = item.field
-      end
-
-      facet_config = facet_configuration_for_field(field)
-
-      url_field = facet_config.key
-
-      value = facet_value_for_facet_item(item)
-
-      p[:f] = (p[:f] || {}).dup # the command above is not deep in rails3, !@#$!@#$
-      p[:f][url_field] = (p[:f][url_field] || []).dup
-
-      if facet_config.single && p[:f][url_field].present?
-        p[:f][url_field] = []
-      end
-
-      p[:f][url_field].push(value)
     end
   end
 end

--- a/lib/blacklight/search_state/filter_field.rb
+++ b/lib/blacklight/search_state/filter_field.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class SearchState
+    # Modeling access to filter query parameters
+    class FilterField
+      # @param [Blacklight::Configuration::FacetField] config
+      attr_reader :config
+
+      # @param [Blacklight::SearchState] search_state
+      attr_reader :search_state
+
+      # @return [String,Symbol]
+      delegate :key, to: :config
+
+      # @param [Blacklight::Configuration::FacetField] config
+      # @param [Blacklight::SearchState] search_state
+      def initialize(config, search_state)
+        @config = config
+        @search_state = search_state
+      end
+
+      # @param [String,#value] a filter item to add to the url
+      # @return [Blacklight::SearchState] new state
+      def add(item)
+        new_state = search_state.reset_search
+
+        if item.respond_to?(:fq)
+          Array(item.fq).each do |f, v|
+            new_state = new_state.filter(f).add(v)
+          end
+        end
+
+        if item.respond_to?(:field) && item.field != key
+          return new_state.filter(item.field).add(item)
+        end
+
+        params = new_state.params
+        value = as_url_parameter(item)
+
+        # value could be a string
+        params[param] = (params[param] || {}).dup
+
+        if config.single
+          params[param][key] = [value]
+        else
+          params[param][key] = Array(params[param][key] || []).dup
+          params[param][key].push(value)
+        end
+
+        new_state.reset(params)
+      end
+
+      # @param [String,#value] a filter to remove from the url
+      # @return [Blacklight::SearchState] new state
+      def remove(item)
+        new_state = search_state.reset_search
+        if item.respond_to?(:field) && item.field != key
+          return new_state.filter(item.field).remove(item)
+        end
+
+        params = new_state.params
+        value = as_url_parameter(item)
+
+        # need to dup the facet values too,
+        # if the values aren't dup'd, then the values
+        # from the session will get remove in the show view...
+        params[param] = (params[param] || {}).dup
+        params[param][key] = (params[param][key] || []).dup
+
+        collection = params[param][key]
+        # collection should be an array, because we link to ?f[key][]=value,
+        # however, Facebook (and maybe some other PHP tools) tranform that parameters
+        # into ?f[key][0]=value, which Rails interprets as a Hash.
+        if collection.is_a? Hash
+          Deprecation.warn(self, 'Normalizing parameters in FilterField#remove is deprecated')
+          collection = collection.values
+        end
+        params[param][key] = collection - Array(value)
+        params[param].delete(key) if params[param][key].empty?
+        params.delete(param) if params[param].empty?
+
+        new_state.reset(params)
+      end
+
+      # @return [Array] an array of applied filters
+      def values
+        params = search_state.params
+        params.dig(param, key) || []
+      end
+      delegate :any?, to: :values
+
+      # @param [String,#value] a filter to remove from the url
+      # @return [Boolean] whether the provided filter is currently applied/selected
+      def include?(item)
+        if item.respond_to?(:field) && item.field != key
+          return search_state.filter(item.field).selected?(item)
+        end
+
+        value = as_url_parameter(item)
+        params = search_state.params
+
+        (params.dig(param, key) || []).include?(value)
+      end
+
+      private
+
+      def param
+        :f
+      end
+
+      # TODO: this code is duplicated in Blacklight::FacetsHelperBehavior
+      def as_url_parameter(item)
+        if item.respond_to? :value
+          item.value
+        else
+          item
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/blacklight/search_state/filter_field_spec.rb
+++ b/spec/lib/blacklight/search_state/filter_field_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::SearchState::FilterField do
+  let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, blacklight_config, controller) }
+
+  let(:params) { { f: { some_field: %w[1 2], another_field: ['3'] } } }
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field 'some_field'
+      config.add_facet_field 'another_field', single: true
+    end
+  end
+  let(:controller) { double }
+
+  describe '#add' do
+    it 'adds the parameter to the filter list' do
+      filter = search_state.filter('some_field')
+      new_state = filter.add('4')
+
+      expect(new_state.filter('some_field').values).to eq %w[1 2 4]
+    end
+
+    it 'creates new parameter as needed' do
+      filter = search_state.filter('unknown_field')
+      new_state = filter.add('4')
+
+      expect(new_state.filter('unknown_field').values).to eq %w[4]
+      expect(new_state.params[:f]).to include(:unknown_field)
+    end
+
+    context 'without any parameters in the url' do
+      let(:params) { {} }
+
+      it 'adds the necessary structure' do
+        filter = search_state.filter('some_field')
+        new_state = filter.add('1')
+
+        expect(new_state.filter('some_field').values).to eq %w[1]
+        expect(new_state.params).to include(:f)
+      end
+    end
+
+    context 'with a single-valued field' do
+      it 'replaces any existing parameter from the filter list' do
+        filter = search_state.filter('another_field')
+        new_state = filter.add('5')
+
+        expect(new_state.filter('another_field').values).to eq %w[5]
+      end
+    end
+
+    context 'with a pivot facet-type item' do
+      it 'includes the pivot facet fqs' do
+        filter = search_state.filter('some_field')
+        new_state = filter.add(OpenStruct.new(fq: { some_other_field: '5' }, value: '4'))
+
+        expect(new_state.filter('some_field').values).to eq %w[1 2 4]
+        expect(new_state.filter('some_other_field').values).to eq %w[5]
+      end
+
+      it 'handles field indirection' do
+        filter = search_state.filter('some_field')
+        new_state = filter.add(OpenStruct.new(field: 'some_other_field', value: '4'))
+
+        expect(new_state.filter('some_other_field').values).to eq %w[4]
+      end
+
+      it 'handles value indirection' do
+        filter = search_state.filter('some_field')
+        new_state = filter.add(OpenStruct.new(value: '4'))
+
+        expect(new_state.filter('some_field').values).to eq %w[1 2 4]
+      end
+    end
+  end
+
+  describe '#remove' do
+    it 'returns a search state without the given filter applied' do
+      filter = search_state.filter('some_field')
+      new_state = filter.remove('1')
+
+      expect(new_state.filter('some_field').values).to eq ['2']
+    end
+
+    it 'removes the whole field if there are no filter left for the field' do
+      filter = search_state.filter('another_field')
+      new_state = filter.remove('3')
+
+      expect(new_state.filter('another_field').values).to eq []
+      expect(new_state.params[:f]).not_to include :another_field
+    end
+
+    it 'removes the filter parameter entirely if there are no filters left' do
+      new_state = search_state.filter('some_field').remove('1')
+      new_state = new_state.filter('some_field').remove('2')
+      new_state = new_state.filter('another_field').remove('3')
+
+      expect(new_state.params).not_to include :f
+    end
+
+    it 'handles value indirection' do
+      filter = search_state.filter('some_field')
+      new_state = filter.remove(OpenStruct.new(value: '1'))
+
+      expect(new_state.filter('some_field').values).to eq ['2']
+    end
+  end
+
+  describe '#values' do
+    it 'returns the currently selected values of the filter' do
+      expect(search_state.filter('some_field').values).to eq %w[1 2]
+    end
+  end
+
+  describe '#include?' do
+    it 'checks whether the value is currently selected' do
+      expect(search_state.filter('some_field').include?('1')).to eq true
+      expect(search_state.filter('some_field').include?('3')).to eq false
+    end
+
+    it 'handles value indirection' do
+      expect(search_state.filter('some_field').include?(OpenStruct.new(value: '1'))).to eq true
+    end
+  end
+end

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe Blacklight::SearchState do
   subject(:search_state) { described_class.new(params, blacklight_config, controller) }
 
+  around { |test| Deprecation.silence(described_class) { test.call } }
+
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
       config.index.title_field = 'title_tsim'
@@ -242,9 +244,9 @@ RSpec.describe Blacklight::SearchState do
       end
 
       it "uses the facet's key in the url" do
-        allow(search_state).to receive(:facet_configuration_for_field).with('some_field').and_return(double(single: true, field: "a_solr_field", key: "some_key"))
+        blacklight_config.add_facet_field 'some_key', single: true, field: "a_solr_field"
 
-        result_params = search_state.add_facet_params('some_field', 'my_value')
+        result_params = search_state.add_facet_params('some_key', 'my_value')
 
         expect(result_params[:f]['some_key']).to have(1).item
         expect(result_params[:f]['some_key'].first).to eq 'my_value'
@@ -284,7 +286,7 @@ RSpec.describe Blacklight::SearchState do
       let(:params) { parameter_class.new f: { 'single_value_facet_field' => 'other_value' } }
 
       it "replaces facets configured as single" do
-        allow(search_state).to receive(:facet_configuration_for_field).with('single_value_facet_field').and_return(double(single: true, key: "single_value_facet_field"))
+        blacklight_config.add_facet_field 'single_value_facet_field', single: true
         result_params = search_state.add_facet_params('single_value_facet_field', 'my_value')
 
         expect(result_params[:f]['single_value_facet_field']).to have(1).item


### PR DESCRIPTION
This opens up a seam for a couple desirable features:

- an easy + consistent place to add native support for multi-select facets (like `f_inclusive` in adv search; PR to come as part of #2363..)
- facet fields can manage + customize their own URL parameters (like we do for range limit, "inclusive" facets in adv search, geo bounding boxes, etc)
- blacklight + plugins can use new `filters` method (which may include selected facets across whatever query parameter fields...), instead of needing to override `query_has_constraints?`, `has_constraints?`, etc and the relevant search builders (in conjunction with an additional PR to pass the original search state to the search builder).