### PR TITLE
Set @type="button" on facet collapse buttons

### DIFF
--- a/app/components/blacklight/facet_field_component.html.erb
+++ b/app/components/blacklight/facet_field_component.html.erb
@@ -1,6 +1,7 @@
 <div class="card facet-limit blacklight-<%= @facet_field.key %> <%= 'facet-limit-active' if @facet_field.active? %>">
   <h3 class="card-header p-0 facet-field-heading" id="<%= @facet_field.html_id %>-header">
     <button
+      type="button"
       class="btn btn-block p-2 text-left collapse-toggle <%= "collapsed" if @facet_field.collapsed? %>"
       data-toggle="collapse"
       data-target="#<%= @facet_field.html_id %>"


### PR DESCRIPTION
This stops browsers from trying to use the collapse buttons as submit buttons when they're used within a form.