### PR TITLE
Switch to Apparition as the js driver

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -37,8 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency "capybara", '~> 3'
-  s.add_development_dependency 'webdrivers', '~> 3.0'
-  s.add_development_dependency "selenium-webdriver", '>= 3.13.1'
+  s.add_development_dependency 'apparition'
   s.add_development_dependency 'engine_cart', '~> 2.1'
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency "simplecov"

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -56,10 +56,6 @@ RSpec.describe "Facets" do
 
     expect(page).to have_css('#facet-format', visible: false)
 
-    within('#facets .facets-header') do
-      page.find('button.navbar-toggler').click
-    end
-
     page.find('h3.facet-field-heading button', text: 'Format').click
 
     sleep(1) # let facet animation finish and wait for it to potentially re-collapse
@@ -70,14 +66,10 @@ RSpec.describe "Facets" do
   it 'is able to expand pivot facets when javascript is enabled', js: true do
     visit root_path
 
-    within('#facets .facets-header') do
-      page.find('button.navbar-toggler').click
-    end
-
     page.find('h3.facet-field-heading button', text: 'Pivot Field').click
 
     within '#facet-example_pivot_field' do
-      expect(page).to have_css('.facet-leaf-node', text: 'Book 30')
+      expect(page).to have_css('.facet-leaf-node', text: "Book\t30")
       expect(page).not_to have_css('.facet-select', text: 'Tibetan')
       page.find('.facet-toggle-handle').click
       click_link 'Tibetan'
@@ -85,23 +77,6 @@ RSpec.describe "Facets" do
 
     expect(page).to have_css('.constraint-value', text: 'Format Book')
     expect(page).to have_css('.constraint-value', text: 'Language Tibetan')
-  end
-
-  describe 'heading button focus with Firefox' do
-    before do
-      Capybara.current_driver = :selenium_headless
-    end
-
-    after do
-      Capybara.current_driver = :rack_test
-    end
-
-    it 'changes to the button on button click in Firefox' do
-      visit root_path
-      page.find('h3.facet-field-heading button', text: 'Format').click
-      focused_element_data_target = page.evaluate_script("document.activeElement")['data-target']
-      expect(focused_element_data_target).to eq '#facet-format'
-    end
   end
 
   describe '"More" links' do

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -168,12 +168,7 @@ RSpec.describe "Facets" do
   end
 
   it "is collapsed when not selected", js: true do
-    skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
-
-    within('#facets .facets-header') do
-      page.find('button.navbar-toggler').click
-    end
 
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
@@ -181,12 +176,7 @@ RSpec.describe "Facets" do
   end
 
   it "expands when the heading button is clicked", js: true do
-    skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
-
-    within('#facets .facets-header') do
-      page.find('button.navbar-toggler').click
-    end
 
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
@@ -196,12 +186,7 @@ RSpec.describe "Facets" do
   end
 
   it "expands when the button is clicked", js: true do
-    skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
-
-    within('#facets .facets-header') do
-      page.find('button.navbar-toggler').click
-    end
 
     within(".blacklight-subject_ssim") do
       expect(page).not_to have_selector(".card-body", visible: true)
@@ -211,12 +196,7 @@ RSpec.describe "Facets" do
   end
 
   it "keeps selected facets expanded on page load", js: true do
-    skip("Test passes locally but not on Travis.") if ENV['TRAVIS']
     visit root_path
-
-    within('#facets .facets-header') do
-      page.find('button.navbar-toggler').click
-    end
 
     within(".blacklight-subject_ssim") do
       page.find('h3.facet-field-heading', text: 'Topic').click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,12 +20,17 @@ require 'rspec/rails'
 require 'rspec/its'
 require 'rspec/collection_matchers'
 require 'capybara/rspec'
-require 'selenium-webdriver'
+require 'capybara/apparition'
 require 'equivalent-xml'
-require 'webdrivers'
 
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :apparition
 Capybara.disable_animation = true
+# Capybara.enable_aria_label = true
+
+# Uncomment for a headed browser
+# Capybara.register_driver :apparition do |app|
+#   Capybara::Apparition::Driver.new(app, headless: false)
+# end
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Apparition is maintained by the same person who maintains Capybara, so it's easier to maintain.
It also defaults to a sensible size viewport and it supports Ruby 3.  See https://github.com/SeleniumHQ/selenium/issues/9001