### PR TITLE
remove four-year-old deprecated -image scss code

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -14,11 +14,6 @@
     background: transparent $logo-image no-repeat top left;
   }
 
-  @if $logo_image {
-    // deprecated
-    background: transparent image_url($logo_image) no-repeat top left;
-  }
-
   display: inline-block;
   flex: 0 0 150px;
   height: 50px;

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -1,7 +1,6 @@
 /* Warning! If you want to change these, just copy them into your own theme css. But you want to remove the !default, which only will set them if not already set. */
 
 $logo-image: image_url('blacklight/logo.png') !default;
-$logo_image: false !default; // deprecated
 
 /* label (field names) */
 $field_name_color: $text-muted !default;


### PR DESCRIPTION
I'm not sure what this code is doing or intending to do. I think it is actually buggy code that only triggers in some cases. I don't think it's actually any backwards incompat to remove it, I don't think it was doing anything useful. But I'm not totally positive.

This is one possible closes #2414 see analysis there.

Review and a second opinion is welcome.