### PR TITLE
Backport some modal a11y changes

### DIFF
--- a/app/views/shared/_ajax_modal.html.erb
+++ b/app/views/shared/_ajax_modal.html.erb
@@ -1,4 +1,4 @@
-<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
+<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
     </div>

--- a/app/views/shared/_ajax_modal.html.erb
+++ b/app/views/shared/_ajax_modal.html.erb
@@ -1,5 +1,5 @@
 <div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog" role="document">
     <div class="modal-content">
     </div>
   </div>


### PR DESCRIPTION
Another potential change that could be tacked onto this (but I'm less convinced to do) is to replace the `aria-hidden` with an `aria-modal` attribute when showing the modal and swapping them back when hiding.  This happens for us in BS4 but not BS3.