### PR TITLE
fix syntax error in sort_facet_url

### DIFF
--- a/app/components/blacklight/facet_field_pagination_component.rb
+++ b/app/components/blacklight/facet_field_pagination_component.rb
@@ -7,7 +7,7 @@ module Blacklight
     end
 
     def sort_facet_url(sort)
-      @facet_field.paginator.params_for_resort_url(sort, @facet_fieldsearch_state.to_h)
+      @facet_field.paginator.params_for_resort_url(sort, @facet_field.search_state.to_h)
     end
 
     def param_name


### PR DESCRIPTION
Fixes a small bug that messes up facet sorting links in the facet modal popup.

Also, is it intentional that there are no specs for `FacetFieldPaginationComponent`? If not I could try and add some to this PR.

Thanks!