### PR TITLE
Pass helper methods options through as keyword args

### DIFF
--- a/app/presenters/blacklight/rendering/helper_method.rb
+++ b/app/presenters/blacklight/rendering/helper_method.rb
@@ -15,10 +15,10 @@ module Blacklight
 
       def render_helper
         context.send(config.helper_method,
-                     options.merge(document: document,
-                                   field: config.field,
-                                   config: config,
-                                   value: values))
+                     **options.merge(document: document,
+                                     field: config.field,
+                                     config: config,
+                                     value: values))
       end
     end
   end


### PR DESCRIPTION
This restores Ruby 3 compatibility with helper methods that use keyword arguments, and is functionally the same for Ruby 2.x   helper methods that accept a position hash argument (ruby does the conversion magic..)