### PR TITLE
Port over Rails 6's #try method onto Blacklight::Configuration to fix…

### DIFF
--- a/lib/blacklight/open_struct_with_hash_access.rb
+++ b/lib/blacklight/open_struct_with_hash_access.rb
@@ -4,7 +4,9 @@ module Blacklight
   ##
   # An OpenStruct that responds to common Hash methods
   class OpenStructWithHashAccess < OpenStruct
-    delegate :keys, :each, :map, :has_key?, :key?, :include?, :empty?, :length, :delete, :delete_if, :keep_if, :clear, :reject!, :select!, :replace, :fetch, :to_json, :as_json, :any?, to: :to_h
+    delegate :keys, :each, :map, :has_key?, :key?, :include?, :empty?,
+             :length, :delete, :delete_if, :keep_if, :clear, :reject!, :select!,
+             :replace, :fetch, :to_json, :as_json, :any?, to: :to_h
 
     ##
     # Expose the internal hash
@@ -44,6 +46,21 @@ module Blacklight
 
     def deep_dup
       self.class.new @table.deep_dup
+    end
+
+    if Rails.version < '6'
+      # Ported from Rails 6 to fix an incompatibility with ostruct
+      def try(method_name = nil, *args, &block)
+        if method_name.nil? && block_given?
+          if b.arity.zero?
+            instance_eval(&block)
+          else
+            yield self
+          end
+        elsif respond_to?(method_name)
+          public_send(method_name, *args, &b)
+        end
+      end
     end
   end
 end

--- a/spec/lib/blacklight/open_struct_with_hash_access_spec.rb
+++ b/spec/lib/blacklight/open_struct_with_hash_access_spec.rb
@@ -145,4 +145,12 @@ RSpec.describe Blacklight::OpenStructWithHashAccess do
       expect(copy.b[:c]).to eq 2
     end
   end
+
+  describe "#try" do
+    subject { described_class.new a: 1 }
+
+    it "works (and doesn't throw a stack error...)" do
+      expect(subject.try(:a)).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
… an incompatibility with the Rails 5 version and  ostruct