### PR TITLE
Add some accessors in the blacklight config for getting the appropria…

### DIFF
--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -46,7 +46,11 @@ module Blacklight
     private
 
     def presenter
-      @presenter ||= blacklight_config.index.search_bar_presenter_class.new(controller, blacklight_config)
+      @presenter ||= presenter_class.new(controller, blacklight_config)
+    end
+
+    def presenter_class
+      blacklight_config.view_config(action_name: :index).search_bar_presenter_class
     end
 
     def blacklight_config

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -198,7 +198,7 @@ module Blacklight::Catalog
   # @example
   #   config.index.respond_to.txt = Proc.new { render plain: "A list of docs." }
   def additional_response_formats(format)
-    blacklight_config.index.respond_to.each do |key, config|
+    blacklight_config.view_config(action_name: :index).respond_to.each do |key, config|
       format.send key do
         case config
         when false

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -380,7 +380,7 @@ module Blacklight::BlacklightHelperBehavior
   def show_presenter_class(_document)
     Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#show_presenter_class is deprecated; use #document_presenter_class instead')
 
-    blacklight_config.show.document_presenter_class
+    blacklight_config.view_config(:show, action_name: action_name).document_presenter_class
   end
 
   # @deprecated
@@ -388,13 +388,12 @@ module Blacklight::BlacklightHelperBehavior
   def index_presenter_class(_document)
     Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter_class is deprecated; use #document_presenter_class instead')
 
-    (blacklight_config.view.key?(document_index_view_type) && blacklight_config.dig(:view, document_index_view_type, :document_presenter_class)) ||
-      blacklight_config.index.document_presenter_class
+    blacklight_config.view_config(document_index_view_type, action_name: action_name).document_presenter_class
   end
 
   # @return [Class]
   def search_bar_presenter_class
-    blacklight_config.index.search_bar_presenter_class
+    blacklight_config.view_config(action_name: :index).search_bar_presenter_class
   end
 
   # @!group Layout helpers

--- a/app/helpers/blacklight/component_helper_behavior.rb
+++ b/app/helpers/blacklight/component_helper_behavior.rb
@@ -94,11 +94,11 @@ module Blacklight
     end
 
     def show_doc_actions?(document = @document, options = {})
-      filter_partials(blacklight_config.show.document_actions, { document: document }.merge(options)).any?
+      filter_partials(blacklight_config.view_config(:show).document_actions, { document: document }.merge(options)).any?
     end
 
     def document_actions(document, options: {})
-      filter_partials(blacklight_config.show.document_actions, { document: document }.merge(options)).map { |_k, v| v }
+      filter_partials(blacklight_config.view_config(:show).document_actions, { document: document }.merge(options)).map { |_k, v| v }
     end
 
     private

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -72,9 +72,9 @@ module Blacklight
       fields += Array.wrap(view_config[:"#{base_name}_display_type_field"]) if base_name && view_config.key?(:"#{base_name}_display_type_field")
       fields += Array.wrap(view_config.display_type_field)
 
-      if fields.empty?
-        fields += Array.wrap(configuration.show[:"#{base_name}_display_type_field"]) if base_name && configuration.show.key?(:"#{base_name}_display_type_field")
-        fields += Array.wrap(configuration.show.display_type_field)
+      if fields.empty? && show_view_config != view_config
+        fields += Array.wrap(show_view_config[:"#{base_name}_display_type_field"]) if base_name && show_view_config.key?(:"#{base_name}_display_type_field")
+        fields += Array.wrap(show_view_config.display_type_field)
       end
 
       fields += ['format'] if fields.empty? # backwards compatibility with the old default value for display_type_field
@@ -118,7 +118,11 @@ module Blacklight
     end
 
     def view_config
-      @view_config ||= configuration.view_config(:show)
+      @view_config ||= show_view_config
+    end
+
+    def show_view_config
+      configuration.view_config(:show)
     end
 
     private

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -95,7 +95,7 @@ module Blacklight
     ##
     # The key to use to retrieve the grouped field to display
     def grouped_key_for_results
-      blacklight_config.index.group
+      blacklight_config.view_config(action_name: :index).group
     end
 
     ##

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -3,7 +3,7 @@
 <% @page_title = t('blacklight.search.show.title', document_title: Deprecation.silence(Blacklight::BlacklightHelperBehavior) { document_show_html_title }, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
 
-<%= render (blacklight_config.show.document_component || Blacklight::DocumentComponent).new(document: @document, component: :div, title_component: :h1, show: true) do |component| %>
+<%= render (blacklight_config.view_config(:show).document_component || Blacklight::DocumentComponent).new(document: @document, component: :div, title_component: :h1, show: true) do |component| %>
   <% component.with(:footer) do %>
     <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
       <!--
@@ -17,7 +17,7 @@
 
   <%# Use :body for complete backwards compatibility (overriding the component body markup),
         but if the app explicitly  opted-in to components, make the partials data available as :partials to ease migrations pain %>
-  <% component.with(blacklight_config.show.document_component.blank? && blacklight_config.view_config(:show).partials.any? ? :body : :partials) do %>
+  <% component.with(blacklight_config.view_config(:show).document_component.blank? && blacklight_config.view_config(:show).partials.any? ? :body : :partials) do %>
     <div id="doc_<%= @document.id.to_s.parameterize %>">
       <%= render_document_partials @document, blacklight_config.view_config(:show).partials, component: component %>
     </div>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -95,6 +95,12 @@ module Blacklight
             partials: [:show_header, :show],
             document_actions: NestedOpenStructWithHashAccess.new(ToolConfig)
           ),
+          action_mapping: NestedOpenStructWithHashAccess.new(
+            ViewConfig,
+            default: { top_level_config: :index },
+            show: { top_level_config: :show },
+            citation: { parent_config: :show }
+          ),
           # Configurations for specific types of index views
           view: NestedOpenStructWithHashAccess.new(ViewConfig,
                                                    list: {},
@@ -307,13 +313,35 @@ module Blacklight
     end
     alias_method :inheritable_copy, :build
 
-    # Get a view configuration for the given view type
-    # including default values from the index configuration
+    # Get a view configuration for the given view type + action. The effective
+    # view configuration is inherited from:
+    # - the configuration from blacklight_config.view with the key `view_type`
+    # - the configuration from blacklight_config.action_mapping with the key `action_name`
+    # - any parent config for the action map result above
+    # - the action_mapping default configuration
+    # - the top-level index/show view configuration
+    #
     # @param [Symbol,#to_sym] view_type
     # @return [Blacklight::Configuration::ViewConfig]
-    def view_config(view_type)
-      view_type = view_type.to_sym unless view_type.is_a? Symbol
-      index.merge(view_type == :show ? show : view.fetch(view_type, {}))
+    def view_config(view_type = nil, action_name: :index)
+      view_type &&= view_type.to_sym
+      action_name &&= action_name.to_sym
+      action_name ||= :index
+
+      if view_type == :show
+        action_name = view_type
+        view_type = nil
+      end
+
+      @view_config ||= {}
+      @view_config[[view_type, action_name]] ||= begin
+        if view_type.nil?
+          action_config(action_name)
+        else
+          base_config = action_config(action_name)
+          base_config.merge(view.fetch(view_type, {}))
+        end
+      end
     end
 
     # YARD will include inline disabling as docs, cannot do multiline inside @!macro.  AND this must be separate from doc block.
@@ -440,6 +468,23 @@ module Blacklight
       else
         yield(object)
       end
+    end
+
+    def action_config(action, default: :index)
+      action_config = action_mapping[action]
+      action_config ||= action_mapping[:default]
+
+      if action_config.parent_config && action_config.parent_config != :default
+        parent_config = action_mapping[action_config.parent_config]
+        raise "View configuration error: the parent configuration of #{action_config.key}, #{parent_config.key}, must not specific its own parent configuration" if parent_config.parent_config
+
+        action_config = action_config.reverse_merge(parent_config)
+      end
+      action_config = action_config.reverse_merge(action_mapping[:default]) if action_config != action_mapping[:default]
+
+      action_config = action_config.reverse_merge(self[action_config.top_level_config]) if action_config.top_level_config
+      action_config = action_config.reverse_merge(show) if default == :show && action_config.top_level_config != :show
+      action_config.reverse_merge(index)
     end
   end
 end

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -38,6 +38,10 @@ class Blacklight::Configuration
       def document_presenter_class
         super || Blacklight::ShowPresenter
       end
+
+      def to_h
+        super.merge(document_presenter_class: document_presenter_class)
+      end
     end
 
     class Index < ViewConfig
@@ -51,6 +55,10 @@ class Blacklight::Configuration
 
       def document_presenter_class
         super || Blacklight::IndexPresenter
+      end
+
+      def to_h
+        super.merge(document_presenter_class: document_presenter_class)
       end
     end
   end

--- a/lib/blacklight/open_struct_with_hash_access.rb
+++ b/lib/blacklight/open_struct_with_hash_access.rb
@@ -44,6 +44,10 @@ module Blacklight
       @table.merge!((other_hash if other_hash.is_a? Hash) || other_hash.to_h)
     end
 
+    def reverse_merge(other_hash)
+      self.class.new to_h.reverse_merge((other_hash if other_hash.is_a? Hash) || other_hash.to_h)
+    end
+
     def deep_dup
       self.class.new @table.deep_dup
     end

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -115,9 +115,9 @@ module Blacklight
     # documents
     def url_for_document(doc, options = {})
       if respond_to?(:blacklight_config) &&
-          blacklight_config.show.route &&
+          blacklight_config.view_config(:show).route &&
           (!doc.respond_to?(:to_model) || doc.to_model.is_a?(SolrDocument))
-        route = blacklight_config.show.route.merge(action: :show, id: doc).merge(options)
+        route = blacklight_config.view_config(:show).route.merge(action: :show, id: doc).merge(options)
         route[:controller] = params[:controller] if route[:controller] == :current
         route
       else

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -367,7 +367,7 @@ module Blacklight::Solr
     ##
     # The key to use to retrieve the grouped field to display
     def grouped_key_for_results
-      blacklight_config.index.group
+      blacklight_config.view_config(action_name: :index).group
     end
 
     def facet_fields_to_include_in_request

--- a/spec/lib/blacklight/open_struct_with_hash_access_spec.rb
+++ b/spec/lib/blacklight/open_struct_with_hash_access_spec.rb
@@ -123,6 +123,18 @@ RSpec.describe Blacklight::OpenStructWithHashAccess do
     end
   end
 
+  describe '#reverse_merge' do
+    before do
+      @h = described_class.new
+      @h[:a] = 1
+      @h[:b] = 2
+    end
+
+    it 'reverse merges the object with the hash, preserving the object class' do
+      expect(@h.reverse_merge(b: 3, c: 4)).to have_attributes a: 1, b: 2, c: 4
+    end
+  end
+
   describe "#to_json" do
     subject { described_class.new a: 1, b: 2 }
 

--- a/spec/views/catalog/index.atom.builder_spec.rb
+++ b/spec/views/catalog/index.atom.builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "catalog/index" do
     end
   end
 
-  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:blacklight_config) { CatalogController.blacklight_config.deep_copy }
 
   before do
     @response = Blacklight::Solr::Response.new({ response: { numFound: 30 } }, start: 10, rows: 10)


### PR DESCRIPTION
…te config to use for an action + view type.

This allows applications to get the full effective view configuration instead of needing to piece it together outside the configuration. It's also a little more flexible/generic than our index vs show distinction, which should be handy in some types of applications (e.g. spotlight, where keying off index/show doesn't align with its notion of search results / single document views)