### PR TITLE
Try harder to map response parameters provided using the JSON Request API

### DIFF
--- a/lib/blacklight/solr/response.rb
+++ b/lib/blacklight/solr/response.rb
@@ -38,15 +38,15 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
   end
 
   def start
-    params[:start].to_i
+    single_valued_param(:start, json_key: :offset).to_i
   end
 
   def rows
-    params[:rows].to_i
+    single_valued_param(:rows, json_key: :limit).to_i
   end
 
   def sort
-    params[:sort]
+    single_valued_param(:sort)
   end
 
   def documents
@@ -100,5 +100,50 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
       end
     end
     value
+  end
+
+  # Extract JSON Request API parameters from the response header or the request itself
+  def json_params
+    encoded_json_params = header&.dig('params', 'json')
+
+    return request_params['json'] || {} if encoded_json_params.blank?
+
+    @json_params ||= JSON.parse(encoded_json_params).with_indifferent_access
+  end
+
+  # Handle merging solr parameters from the myriad of ways they may be expressed by applying the single-value
+  # precedence logic:
+  #
+  # From https://solr.apache.org/guide/8_8/json-request-api.html#json-parameter-merging :
+  # When multiple parameter values conflict with one another a single value is chosen based on the following precedence rules:
+  # - Traditional query parameters (q, rows, etc.) take first precedence and are used over any other specified values.
+  # - json-prefixed query parameters are considered next.
+  # - Values specified in the JSON request body have the lowest precedence and are only used if specified nowhere else.
+  #
+  # @param [String] key the solr parameter to use
+  # @param [String] json_key the alternative key used by the JSON request API
+  def single_valued_param(key, json_key: nil)
+    params[key] ||
+      params["json.#{key}"] ||
+      json_params[json_key || key] ||
+      json_params.dig(:params, key) ||
+      json_params.dig(:params, "json.#{key}")
+  end
+
+  # Merge together multi-valued solr parameters from the myriad of ways they may be expressed.
+  # Unlike single-valued parameters, this merges all the values across the params.
+  #
+  # @param [String] key the solr parameter to use
+  # @param [String] json_key the alternative key used by the JSON request API
+  def multivalued_param(key, json_key: nil)
+    [
+      params[key],
+      params["json.#{key}"],
+      json_params[json_key || key],
+      json_params.dig(:params, key),
+      json_params.dig(:params, "json.#{key}")
+    ].select(&:present?).inject([]) do |memo, arr|
+      memo.concat(Array.wrap(arr))
+    end
   end
 end

--- a/lib/blacklight/solr/response.rb
+++ b/lib/blacklight/solr/response.rb
@@ -9,6 +9,7 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
     autoload :MoreLikeThis
     autoload :GroupResponse
     autoload :Group
+    autoload :Params
   end
 
   include PaginationMethods
@@ -16,6 +17,7 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
   include Facets
   include Response
   include MoreLikeThis
+  include Params
 
   attr_reader :request_params
   attr_accessor :blacklight_config, :options
@@ -31,22 +33,6 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
 
   def header
     self['responseHeader'] || {}
-  end
-
-  def params
-    header['params'] || request_params
-  end
-
-  def start
-    single_valued_param(:start, json_key: :offset).to_i
-  end
-
-  def rows
-    single_valued_param(:rows, json_key: :limit).to_i
-  end
-
-  def sort
-    single_valued_param(:sort)
   end
 
   def documents
@@ -100,50 +86,5 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
       end
     end
     value
-  end
-
-  # Extract JSON Request API parameters from the response header or the request itself
-  def json_params
-    encoded_json_params = header&.dig('params', 'json')
-
-    return request_params['json'] || {} if encoded_json_params.blank?
-
-    @json_params ||= JSON.parse(encoded_json_params).with_indifferent_access
-  end
-
-  # Handle merging solr parameters from the myriad of ways they may be expressed by applying the single-value
-  # precedence logic:
-  #
-  # From https://solr.apache.org/guide/8_8/json-request-api.html#json-parameter-merging :
-  # When multiple parameter values conflict with one another a single value is chosen based on the following precedence rules:
-  # - Traditional query parameters (q, rows, etc.) take first precedence and are used over any other specified values.
-  # - json-prefixed query parameters are considered next.
-  # - Values specified in the JSON request body have the lowest precedence and are only used if specified nowhere else.
-  #
-  # @param [String] key the solr parameter to use
-  # @param [String] json_key the alternative key used by the JSON request API
-  def single_valued_param(key, json_key: nil)
-    params[key] ||
-      params["json.#{key}"] ||
-      json_params[json_key || key] ||
-      json_params.dig(:params, key) ||
-      json_params.dig(:params, "json.#{key}")
-  end
-
-  # Merge together multi-valued solr parameters from the myriad of ways they may be expressed.
-  # Unlike single-valued parameters, this merges all the values across the params.
-  #
-  # @param [String] key the solr parameter to use
-  # @param [String] json_key the alternative key used by the JSON request API
-  def multivalued_param(key, json_key: nil)
-    [
-      params[key],
-      params["json.#{key}"],
-      json_params[json_key || key],
-      json_params.dig(:params, key),
-      json_params.dig(:params, "json.#{key}")
-    ].select(&:present?).inject([]) do |memo, arr|
-      memo.concat(Array.wrap(arr))
-    end
   end
 end

--- a/lib/blacklight/solr/response/facets.rb
+++ b/lib/blacklight/solr/response/facets.rb
@@ -180,22 +180,6 @@ module Blacklight::Solr::Response::Facets
     end
   end
 
-  def facet_field_aggregation_options(facet_field_name)
-    options = {}
-    options[:sort] = (single_valued_param(:"f.#{facet_field_name}.facet.sort") || single_valued_param(:'facet.sort'))
-
-    limit = single_valued_param(:"f.#{facet_field_name}.facet.limit") || single_valued_param(:"facet.limit")
-    options[:limit] = limit.to_i if limit.present?
-
-    offset = single_valued_param(:"f.#{facet_field_name}.facet.offset") || single_valued_param(:"facet.offset")
-    options[:offset] = offset.to_i if offset.present?
-
-    prefix = single_valued_param(:"f.#{facet_field_name}.facet.prefix") || single_valued_param(:"facet.prefix")
-    options[:prefix] = prefix if prefix
-
-    options
-  end
-
   ##
   # Aggregate Solr's facet_query response into the virtual facet fields defined
   # in the blacklight configuration

--- a/lib/blacklight/solr/response/facets.rb
+++ b/lib/blacklight/solr/response/facets.rb
@@ -182,18 +182,17 @@ module Blacklight::Solr::Response::Facets
 
   def facet_field_aggregation_options(facet_field_name)
     options = {}
-    options[:sort] = (params[:"f.#{facet_field_name}.facet.sort"] || params[:'facet.sort'])
-    if params[:"f.#{facet_field_name}.facet.limit"] || params[:"facet.limit"]
-      options[:limit] = (params[:"f.#{facet_field_name}.facet.limit"] || params[:"facet.limit"]).to_i
-    end
+    options[:sort] = (single_valued_param(:"f.#{facet_field_name}.facet.sort") || single_valued_param(:'facet.sort'))
 
-    if params[:"f.#{facet_field_name}.facet.offset"] || params[:'facet.offset']
-      options[:offset] = (params[:"f.#{facet_field_name}.facet.offset"] || params[:'facet.offset']).to_i
-    end
+    limit = single_valued_param(:"f.#{facet_field_name}.facet.limit") || single_valued_param(:"facet.limit")
+    options[:limit] = limit.to_i if limit.present?
 
-    if params[:"f.#{facet_field_name}.facet.prefix"] || params[:'facet.prefix']
-      options[:prefix] = (params[:"f.#{facet_field_name}.facet.prefix"] || params[:'facet.prefix'])
-    end
+    offset = single_valued_param(:"f.#{facet_field_name}.facet.offset") || single_valued_param(:"facet.offset")
+    options[:offset] = offset.to_i if offset.present?
+
+    prefix = single_valued_param(:"f.#{facet_field_name}.facet.prefix") || single_valued_param(:"facet.prefix")
+    options[:prefix] = prefix if prefix
+
     options
   end
 

--- a/lib/blacklight/solr/response/params.rb
+++ b/lib/blacklight/solr/response/params.rb
@@ -15,15 +15,15 @@ module Blacklight::Solr::Response::Params
   end
 
   def start
-    single_valued_param(:start).to_i
+    search_builder&.start || single_valued_param(:start).to_i
   end
 
   def rows
-    single_valued_param(:rows).to_i
+    search_builder&.rows || single_valued_param(:rows).to_i
   end
 
   def sort
-    single_valued_param(:sort)
+    search_builder&.sort || single_valued_param(:sort)
   end
 
   def facet_field_aggregation_options(facet_field_name)
@@ -42,6 +42,10 @@ module Blacklight::Solr::Response::Params
   end
 
   private
+
+  def search_builder
+    request_params if request_params.is_a?(Blacklight::SearchBuilder)
+  end
 
   # Extract JSON Request API parameters from the response header or the request itself
   def json_params

--- a/lib/blacklight/solr/response/params.rb
+++ b/lib/blacklight/solr/response/params.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+module Blacklight::Solr::Response::Params
+  # From https://solr.apache.org/guide/8_8/json-request-api.html#supported-properties-and-syntax
+  QUERY_PARAMETER_TO_JSON_PARAMETER_MAPPING = {
+    q: :query,
+    fq: :filter,
+    start: :offset,
+    rows: :limit,
+    fl: :fields,
+    sort: :sort
+  }.freeze
+
+  def params
+    header['params'] || request_params
+  end
+
+  def start
+    single_valued_param(:start).to_i
+  end
+
+  def rows
+    single_valued_param(:rows).to_i
+  end
+
+  def sort
+    single_valued_param(:sort)
+  end
+
+  def facet_field_aggregation_options(facet_field_name)
+    sort = single_valued_param(:"f.#{facet_field_name}.facet.sort") || single_valued_param(:'facet.sort')
+    limit_param = single_valued_param(:"f.#{facet_field_name}.facet.limit") || single_valued_param(:"facet.limit")
+    limit = (limit_param.to_i if limit_param.present?) || 100
+    offset = single_valued_param(:"f.#{facet_field_name}.facet.offset") || single_valued_param(:"facet.offset")
+    prefix = single_valued_param(:"f.#{facet_field_name}.facet.prefix") || single_valued_param(:"facet.prefix")
+
+    {
+      sort: sort || (limit.positive? ? 'count' : 'index'),
+      limit: limit,
+      offset: (offset.to_i if offset.present?) || 0,
+      prefix: prefix
+    }
+  end
+
+  private
+
+  # Extract JSON Request API parameters from the response header or the request itself
+  def json_params
+    encoded_json_params = header&.dig('params', 'json')
+
+    return request_params['json'] || {} if encoded_json_params.blank?
+
+    @json_params ||= JSON.parse(encoded_json_params).with_indifferent_access
+  end
+
+  # Handle merging solr parameters from the myriad of ways they may be expressed by applying the single-value
+  # precedence logic:
+  #
+  # From https://solr.apache.org/guide/8_8/json-request-api.html#json-parameter-merging :
+  # When multiple parameter values conflict with one another a single value is chosen based on the following precedence rules:
+  # - Traditional query parameters (q, rows, etc.) take first precedence and are used over any other specified values.
+  # - json-prefixed query parameters are considered next.
+  # - Values specified in the JSON request body have the lowest precedence and are only used if specified nowhere else.
+  #
+  # @param [String] key the solr parameter to use
+  def single_valued_param(key)
+    json_key = QUERY_PARAMETER_TO_JSON_PARAMETER_MAPPING[key]
+
+    params[key] ||
+      params["json.#{key}"] ||
+      json_params[json_key || key] ||
+      json_params.dig(:params, key) ||
+      json_params.dig(:params, "json.#{key}")
+  end
+
+  # Merge together multi-valued solr parameters from the myriad of ways they may be expressed.
+  # Unlike single-valued parameters, this merges all the values across the params.
+  #
+  # @param [String] key the solr parameter to use
+  def multivalued_param(key)
+    json_key = QUERY_PARAMETER_TO_JSON_PARAMETER_MAPPING[key]
+
+    [
+      params[key],
+      params["json.#{key}"],
+      json_params[json_key || key],
+      json_params.dig(:params, key),
+      json_params.dig(:params, "json.#{key}")
+    ].select(&:present?).inject([]) do |memo, arr|
+      memo.concat(Array.wrap(arr))
+    end
+  end
+end

--- a/spec/models/blacklight/solr/response_spec.rb
+++ b/spec/models/blacklight/solr/response_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe Blacklight::Solr::Response, api: true do
     expect(r.params['test']).to eq :test
   end
 
+  it 'extracts json params' do
+    raw_response = eval(mock_query_response)
+    raw_response['responseHeader']['params']['test'] = 'from query'
+    raw_response['responseHeader']['params'].delete('rows')
+    raw_response['responseHeader']['params']['json'] = { limit: 5, params: { test: 'from json params' } }.to_json
+    r = described_class.new(raw_response, raw_response['params'])
+    expect(r.params['test']).to eq 'from query'
+    expect(r.rows).to eq 5
+  end
+
   it 'provides the solr-returned params and "rows" should be 11' do
     raw_response = eval(mock_query_response)
     r = described_class.new(raw_response, {})


### PR DESCRIPTION
I feel like I must be missing something; surely it can't be this hard to know what parameters Solr's actually decided to apply??