### PR TITLE
Add Blacklight::Solr::Request#append_query and #append_boolean_query to build up json query dsl boolean queries

### DIFF
--- a/lib/blacklight/solr/request.rb
+++ b/lib/blacklight/solr/request.rb
@@ -17,6 +17,37 @@ class Blacklight::Solr::Request < ActiveSupport::HashWithIndifferentAccess
     end
   end
 
+  def append_query(query)
+    if self['q'] || dig(:json, :query, :bool)
+      self[:json] ||= { query: { bool: { must: [] } } }
+      self[:json][:query] ||= { bool: { must: [] } }
+      self[:json][:query][:bool][:must] << query
+
+      if self['q']
+        self[:json][:query][:bool][:must] << self['q']
+        delete 'q'
+      end
+    else
+      self['q'] = query
+    end
+  end
+
+  def append_boolean_query(bool_operator, query)
+    return if query.blank?
+
+    self[:json] ||= { query: { bool: { bool_operator => [] } } }
+    self[:json][:query] ||= { bool: { bool_operator => [] } }
+    self[:json][:query][:bool][bool_operator] ||= []
+
+    if self['q']
+      self[:json][:query][:bool][:must] ||= []
+      self[:json][:query][:bool][:must] << self['q']
+      delete 'q'
+    end
+
+    self[:json][:query][:bool][bool_operator] << query
+  end
+
   def append_filter_query(query)
     self['fq'] << query
   end

--- a/spec/models/blacklight/solr/request_spec.rb
+++ b/spec/models/blacklight/solr/request_spec.rb
@@ -1,36 +1,69 @@
 # frozen_string_literal: true
 
 RSpec.describe Blacklight::Solr::Request, api: true do
-  before do
-    subject[:qt] = 'hey'
-    subject[:fq] = ["what's up.", "dood"]
-    subject['q'] = "what's"
-    subject[:wt] = "going"
-    subject[:start] = "on"
-    subject[:rows] = "Man"
-    subject['hl'] = "I"
-    subject['hl.fl'] = "wish"
-    subject['group'] = "I"
-    subject['defType'] = "had"
-    subject['spellcheck'] = "a"
-    subject['spellcheck.q'] = "fleece"
-    subject['f.title_facet.facet.limit'] = "vest"
-    subject['facet.field'] = []
+  context 'with some solr parameter keys' do
+    before do
+      subject[:qt] = 'hey'
+      subject[:fq] = ["what's up.", "dood"]
+      subject['q'] = "what's"
+      subject[:wt] = "going"
+      subject[:start] = "on"
+      subject[:rows] = "Man"
+      subject['hl'] = "I"
+      subject['hl.fl'] = "wish"
+      subject['group'] = "I"
+      subject['defType'] = "had"
+      subject['spellcheck'] = "a"
+      subject['spellcheck.q'] = "fleece"
+      subject['f.title_facet.facet.limit'] = "vest"
+      subject['facet.field'] = []
+    end
+
+    it "accepts valid parameters" do
+      expect(subject.to_hash).to eq("defType" => "had",
+                                    "f.title_facet.facet.limit" => "vest",
+                                    "fq" => ["what's up.", "dood"],
+                                    "group" => "I",
+                                    "hl" => "I",
+                                    "hl.fl" => "wish",
+                                    "q" => "what's",
+                                    "qt" => "hey",
+                                    "rows" => "Man",
+                                    "spellcheck" => "a",
+                                    "spellcheck.q" => "fleece",
+                                    "start" => "on",
+                                    "wt" => "going")
+    end
   end
 
-  it "accepts valid parameters" do
-    expect(subject.to_hash).to eq("defType" => "had",
-                                  "f.title_facet.facet.limit" => "vest",
-                                  "fq" => ["what's up.", "dood"],
-                                  "group" => "I",
-                                  "hl" => "I",
-                                  "hl.fl" => "wish",
-                                  "q" => "what's",
-                                  "qt" => "hey",
-                                  "rows" => "Man",
-                                  "spellcheck" => "a",
-                                  "spellcheck.q" => "fleece",
-                                  "start" => "on",
-                                  "wt" => "going")
+  describe '#append_query' do
+    it 'populates the q parameter' do
+      subject.append_query 'this is my query'
+      expect(subject['q']).to eq 'this is my query'
+    end
+
+    it 'handles multiple queries by converting it to a boolean query' do
+      subject.append_query 'this is my query'
+      subject.append_query 'another:query'
+      expect(subject).not_to have_key 'q'
+      expect(subject.dig('json', 'query', 'bool', 'must')).to match_array ['this is my query', 'another:query']
+    end
+  end
+
+  describe '#append_boolean_query' do
+    it 'populates the boolean query with the queries' do
+      subject.append_boolean_query :must, 'required'
+      subject.append_boolean_query :should, 'optional'
+      subject.append_boolean_query :should, 'also optional'
+
+      expect(subject.dig('json', 'query', 'bool')).to include should: ['optional', 'also optional'], must: ['required']
+    end
+
+    it 'converts existing q parameters to a boolean query' do
+      subject['q'] = 'some query'
+      subject.append_boolean_query :must, 'also required'
+
+      expect(subject.dig('json', 'query', 'bool', 'must')).to match_array ['some query', 'also required']
+    end
   end
 end


### PR DESCRIPTION
This allows Blacklight to easily combine multiple query parameters into a single json query parameter.

Queries are combined + rewritten as JSON boolean queries if:

- `append_query` is called when there's already a `q` parameter to send
-   `append_boolean_query` is called when there's already a `q` parameter

If JSON boolean queries are already being used:
- `append_query(query)` acts like `append_boolean_query(:must, query)`

JSON boolean queries are only available in Solr 7.1+, but this new behavior is effectively opt-in out-of-the-box. If undesired (or this behavior is accidentally triggered by some unusual configuration -- like setting a default `q` parameter in `default_solr_params` instead of e.g. `q.alt`), it can be explicitly disabled using an additional SearchBuilder step to rewrite anything under `solr_params[:json]` (although doing a 1:1 implementation turns into a rats-nest of `_query_` subqueries)