### PR TITLE
Add support for JSON facet responses

### DIFF
--- a/lib/blacklight/solr/facet_paginator.rb
+++ b/lib/blacklight/solr/facet_paginator.rb
@@ -20,6 +20,8 @@ module Blacklight::Solr
     def initialize(all_facet_values, arguments = {})
       super
 
+      @sort = arguments[:sort].keys.first.to_s if arguments[:sort].is_a? Hash
+
       # count is solr's default
       @sort ||= if @limit.to_i > 0
                   'count'

--- a/lib/blacklight/solr/response/facets.rb
+++ b/lib/blacklight/solr/response/facets.rb
@@ -29,6 +29,7 @@ module Blacklight::Solr::Response::Facets
   # represents a facet; which is a field and its values
   class FacetField
     attr_reader :name, :items
+    attr_accessor :missing
 
     def initialize name, items, options = {}
       @name = name
@@ -50,6 +51,14 @@ module Blacklight::Solr::Response::Facets
 
     def prefix
       @options[:prefix] || solr_default_prefix
+    end
+
+    def type
+      @options[:type] || 'terms'
+    end
+
+    def data
+      @options[:data] || {}
     end
 
     def index?
@@ -90,7 +99,7 @@ module Blacklight::Solr::Response::Facets
   # Get all the Solr facet data (fields, queries, pivots) as a hash keyed by
   # both the Solr field name and/or by the blacklight field name
   def aggregations
-    @aggregations ||= {}.merge(facet_field_aggregations).merge(facet_query_aggregations).merge(facet_pivot_aggregations)
+    @aggregations ||= {}.merge(facet_field_aggregations).merge(facet_query_aggregations).merge(facet_pivot_aggregations).merge(json_facet_aggregations)
   end
 
   def facet_counts
@@ -159,19 +168,24 @@ module Blacklight::Solr::Response::Facets
       items = values.map do |value, hits|
         i = FacetItem.new(value: value, hits: hits)
 
-        # solr facet.missing serialization
+        # legacy solr facet.missing serialization
         if value.nil?
           i.label = I18n.t(:"blacklight.search.fields.facet.missing.#{facet_field_name}", default: [:"blacklight.search.facets.missing"])
           i.fq = "-#{facet_field_name}:[* TO *]"
+          i.missing = true
         end
 
         i
       end
 
       options = facet_field_aggregation_options(facet_field_name)
-      hash[facet_field_name] = FacetField.new(facet_field_name,
-                                              items,
-                                              options)
+      facet_field = FacetField.new(facet_field_name, items, options)
+
+      if values[nil]
+        facet_field.missing = items.find(&:missing)
+      end
+
+      hash[facet_field_name] = facet_field
 
       # alias all the possible blacklight config names..
       blacklight_config.facet_fields.select { |_k, v| v.field == facet_field_name }.each_key do |key|
@@ -194,9 +208,25 @@ module Blacklight::Solr::Response::Facets
         Blacklight::Solr::Response::Facets::FacetItem.new(value: key, hits: hits, label: facet_field.query[key][:label])
       end
 
+      items += facet_query_aggregations_from_json(facet_field)
+
       items = items.sort_by(&:hits).reverse if facet_field.sort && facet_field.sort.to_sym == :count
 
       hash[field_name] = Blacklight::Solr::Response::Facets::FacetField.new field_name, items
+    end
+  end
+
+  def facet_query_aggregations_from_json(facet_field)
+    return [] unless self['facets']
+
+    salient_facet_queries = facet_field.query.map { |_k, x| x[:fq] }
+
+    relevant_facet_data = self['facets'].select { |k, _v| salient_facet_queries.include?(k) }.reject { |_key, data| data['count'].zero? }
+
+    relevant_facet_data.map do |key, data|
+      salient_fields = facet_field.query.select { |_key, val| val[:fq] == key }
+      facet_key = ((salient_fields.keys if salient_fields.respond_to? :keys) || salient_fields.first).first
+      Blacklight::Solr::Response::Facets::FacetItem.new(value: facet_key, hits: data[:count], label: facet_field.query[facet_key][:label])
     end
   end
 
@@ -226,5 +256,46 @@ module Blacklight::Solr::Response::Facets
     end
 
     Blacklight::Solr::Response::Facets::FacetItem.new(value: lst[:value], hits: lst[:count], field: lst[:field], items: items, fq: parent_fq)
+  end
+
+  def construct_json_nested_facet_fields(bucket, parent_fq = {})
+    bucket.select { |_, nested| nested.is_a?(Hash) && nested.key?('buckets') }.map do |facet_field_name, nested|
+      nested['buckets'].map do |subbucket|
+        i = Blacklight::Solr::Response::Facets::FacetItem.new(field: facet_field_name, value: subbucket['val'], hits: subbucket['count'], fq: parent_fq, data: subbucket)
+
+        i.items = construct_json_nested_facet_fields(subbucket, parent_fq.merge(key => subbucket['val'])) if has_json_nested_facets?(subbucket)
+        i
+      end
+    end.flatten
+  end
+
+  def has_json_nested_facets?(bucket)
+    bucket.any? { |_, nested| nested.is_a?(Hash) && nested.key?('buckets') }
+  end
+
+  def json_facet_aggregations
+    return {} unless self['facets']
+
+    self['facets'].each_with_object({}) do |(facet_field_name, data), hash|
+      next if facet_field_name == 'count'
+
+      items = (data['buckets'] || []).map do |bucket|
+        i = Blacklight::Solr::Response::Facets::FacetItem.new(value: bucket['val'], hits: bucket['count'], data: bucket)
+
+        i.items = construct_json_nested_facet_fields(bucket, facet_field_name => bucket['val']) if has_json_nested_facets?(bucket)
+
+        i
+      end
+
+      options = facet_field_aggregation_options(facet_field_name).merge(data: data)
+      facet_field = FacetField.new(facet_field_name, items, options)
+
+      facet_field.missing = Blacklight::Solr::Response::Facets::FacetItem.new(
+        hits: data.dig('missing', 'count'),
+        data: data['missing']
+      ) if data['missing']
+
+      hash[facet_field_name] = facet_field
+    end
   end
 end

--- a/spec/models/blacklight/solr/facet_paginator_spec.rb
+++ b/spec/models/blacklight/solr/facet_paginator_spec.rb
@@ -20,5 +20,9 @@ RSpec.describe Blacklight::Solr::FacetPaginator, api: true do
     it 'defaults to "index" if no limit is given' do
       expect(described_class.new([]).sort).to eq 'index'
     end
+
+    it 'handles json facet api-style parameter sorts' do
+      expect(described_class.new([], sort: { count: :desc }).sort).to eq 'count'
+    end
   end
 end

--- a/spec/models/blacklight/solr/response/facets_spec.rb
+++ b/spec/models/blacklight/solr/response/facets_spec.rb
@@ -160,6 +160,12 @@ RSpec.describe Blacklight::Solr::Response::Facets, api: true do
       expect(missing.label).to eq "[Missing]"
       expect(missing.fq).to eq "-some_field:[* TO *]"
     end
+
+    it 'extracts the missing field data to a separate facet field attribute' do
+      missing = subject.aggregations["some_field"].missing
+
+      expect(missing).to have_attributes(label: '[Missing]', hits: 2)
+    end
   end
 
   describe "query facets" do
@@ -276,6 +282,109 @@ RSpec.describe Blacklight::Solr::Response::Facets, api: true do
 
       expect(field.items.first.items.size).to eq 1
       expect(field.items.first.items.first.fq).to eq('field_a' => 'a')
+    end
+  end
+
+  describe 'json facets' do
+    subject { Blacklight::Solr::Response.new(response, {}, blacklight_config: blacklight_config) }
+
+    let(:response) do
+      {
+        facets: {
+          "count": 32,
+          "categories": {
+            "buckets": [
+              {
+                "val": "electronics",
+                "count": 12,
+                "max_price": 60
+              },
+              {
+                "val": "currency",
+                "count": 4
+              },
+              {
+                "val": "memory",
+                "count": 3
+              }
+            ]
+          }
+        }
+      }
+    end
+    let(:facet_config) do
+      Blacklight::Configuration::FacetField.new(key: 'categories', json: true, query: false)
+    end
+
+    let(:blacklight_config) { double(facet_fields: { 'categories' => facet_config }) }
+    let(:field) { subject.aggregations['categories'] }
+
+    it 'has access to the original response data' do
+      expect(field.data).to include 'buckets'
+    end
+
+    it 'converts buckets into facet items' do
+      expect(field.items.length).to eq 3
+    end
+
+    context 'with nested buckets' do
+      let(:response) do
+        {
+          facets: {
+            "categories": {
+              "buckets": [
+                {
+                  "val": "electronics",
+                  "count": 12,
+                  "top_manufacturer": {
+                    "buckets": [{
+                      "val": "corsair",
+                      "count": 3
+                    }]
+                  }
+                },
+                {
+                  "val": "currency",
+                  "count": 4,
+                  "top_manufacturer": {
+                    "buckets": [{
+                      "val": "boa",
+                      "count": 1
+                    }]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      end
+
+      it 'converts nested buckets into pivot facets' do
+        expect(field.items.first).to have_attributes hits: 12
+        expect(field.items.first.items.first).to have_attributes field: 'top_manufacturer', value: 'corsair', hits: 3, fq: { "categories" => "electronics" }
+      end
+    end
+
+    context 'with missing values' do
+      let(:response) do
+        {
+          facets: {
+            "categories": {
+              "missing" => { "count" => 13 },
+              "buckets" => [{ "val" => "India", "count" => 2 }, { "val" => "Iran", "count" => 2 }]
+            }
+          }
+        }
+      end
+
+      it 'converts "missing" facet data into a missing facet item' do
+        expect(field.items.length).to eq 2
+        expect(field.missing).to have_attributes(hits: 13)
+      end
+    end
+
+    it 'exposes any extra query function results' do
+      expect(field.items.first.data).to include 'max_price' => 60
     end
   end
 end

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -259,6 +259,23 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       end
     end
 
+    describe 'with a json facet' do
+      let(:user_params) { { f: { json_facet: ['value'] } }.with_indifferent_access }
+
+      before do
+        blacklight_config.add_facet_field 'json_facet', field: 'foo', json: { bar: 'baz' }
+      end
+
+      it "has proper solr parameters" do
+        expect(subject[:fq]).to include('{!term f=foo}value')
+        expect(subject.dig(:json, :facet, 'json_facet')).to include(
+          field: 'foo',
+          type: 'terms',
+          bar: 'baz'
+        )
+      end
+    end
+
     describe 'with multi-valued facets' do
       let(:user_params) { { f_inclusive: { format: %w[Book Movie CD] } } }
 


### PR DESCRIPTION
This PR adds support for Solr's "new"(ish) JSON facet responses. This initial implementation maps the json facet response data into compatible structures for term-based facets, facet queries, and pivot facets.

Additional JSON facet response data is available through the `data` accessor on the fields and facet items, which provides access to functions, stats,  and other bucket aggregations.

This PR also adds support for sending solr requests that include JSON facet api fields:

```
config.add_facet_field 'my_field', json: { missing: true, numBuckets: true }
#...
config.add_facet_fields_to_solr_request!
```

(See https://solr.apache.org/guide/8_8/json-facet-api.html#terms-facet for other parameters)