### PR TITLE
Include the BlacklightHelper after initializing

### DIFF
--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -8,7 +8,9 @@ module Blacklight
     # BlacklightHelper is needed by all helpers, so we inject it
     # into action view base here.
     initializer 'blacklight.helpers' do
-      ActionView::Base.include BlacklightHelper
+      config.after_initialize do
+        ActionView::Base.include BlacklightHelper
+      end
     end
 
     # This makes our rake tasks visible.


### PR DESCRIPTION
Because autoloading is not supported during the initialization step in rails any more.
Fixes #2438