### PR TITLE
Fix view type icon rendering

### DIFF
--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -15,7 +15,9 @@ module Blacklight
       end
 
       def icon
-        @view_context.render_view_type_group_icon(@view.icon || @key)
+        Deprecation.silence(Blacklight::CatalogHelperBehavior) do
+          @view_context.render_view_type_group_icon(@view.icon || @key)
+        end
       end
 
       def label

--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -15,7 +15,7 @@ module Blacklight
       end
 
       def icon
-        @view_context.render_view_type_group_icon(@view)
+        @view_context.render_view_type_group_icon(@view.icon || @key)
       end
 
       def label

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -253,11 +253,13 @@ module Blacklight::CatalogHelperBehavior
   ##
   # Render the view type icon for the results view picker
   #
+  # @deprecated
   # @param [String] view
   # @return [String]
   def render_view_type_group_icon view
     blacklight_icon(view)
   end
+  deprecation_deprecate render_view_type_group_icon: 'call blacklight_icon instead'
 
   ##
   # Get the default view type classes for a view in the results view picker

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -11,6 +11,8 @@ class Blacklight::Configuration
     #   @return [String, Symbol] solr field to use to render a document title
     # @!attribute display_type_field
     #   @return [String, Symbol] solr field to use to render format-specific partials
+    # @!attribute icon
+    #   @return [String, Symbol] icon file to use in the view picker
     # @!attribute document_actions
     #   @return [NestedOpenStructWithHashAccess{Symbol => Blacklight::Configuration::ToolConfig}] 'tools' to render for each document
     def search_bar_presenter_class

--- a/spec/views/catalog/_view_type_group.html.erb_spec.rb
+++ b/spec/views/catalog/_view_type_group.html.erb_spec.rb
@@ -3,13 +3,9 @@
 RSpec.describe "catalog/_view_type_group" do
   let(:blacklight_config) { Blacklight::Configuration.new }
   let(:response) { instance_double(Blacklight::Solr::Response, empty?: false) }
-  let(:icon_instance) { instance_double(Blacklight::Icon) }
 
   before do
     allow(view).to receive(:view_label), &:to_s
-    allow(Blacklight::Icon).to receive(:new).and_return icon_instance
-    allow(icon_instance).to receive(:svg).and_return '<svg></svg>'
-    allow(icon_instance).to receive(:options).and_return({})
     allow(view).to receive_messages(how_sort_and_per_page?: true, blacklight_config: blacklight_config)
     controller.request.path_parameters[:action] = 'index'
     assign(:response, response)
@@ -24,13 +20,16 @@ RSpec.describe "catalog/_view_type_group" do
   it "displays the group" do
     blacklight_config.configure do |config|
       config.view.delete(:list)
-      config.view.a
-      config.view.b
-      config.view.c
+      config.view.a.icon = :list
+      config.view.b.icon = :list
+      config.view.c.icon = :list
     end
     render partial: 'catalog/view_type_group'
     expect(rendered).to have_selector('.btn-group.view-type-group')
     expect(rendered).to have_selector('.view-type-a', text: 'a')
+    within '.view-type-a' do
+      expect(rendered).to have_selector 'svg'
+    end
     expect(rendered).to have_selector('.view-type-b', text: 'b')
     expect(rendered).to have_selector('.view-type-c', text: 'c')
   end
@@ -38,8 +37,8 @@ RSpec.describe "catalog/_view_type_group" do
   it "sets the current view to 'active'" do
     blacklight_config.configure do |config|
       config.view.delete(:list)
-      config.view.a
-      config.view.b
+      config.view.a.icon = :list
+      config.view.b.icon = :list
     end
     render partial: 'catalog/view_type_group'
     expect(rendered).to have_selector('.active', text: 'a')


### PR DESCRIPTION
This was a regression in v7.17.0 that went uncaught due to some pretty aggressive mocking. Now there's a marginally more useful test and also the ability to provide icons as part of the configuration.