### PR TITLE
Extend Blacklight::Configuration#freeze to freeze (at least) the 1st …

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -170,6 +170,8 @@ module Blacklight
     def initialize(hash = {})
       super(self.class.default_values.deep_dup.merge(hash))
       yield(self) if block_given?
+
+      @view_config ||= {}
     end
 
     def document_model
@@ -333,7 +335,6 @@ module Blacklight
         view_type = nil
       end
 
-      @view_config ||= {}
       @view_config[[view_type, action_name]] ||= begin
         if view_type.nil?
           action_config(action_name)
@@ -426,6 +427,11 @@ module Blacklight
       end
 
       fields.merge(show_fields)
+    end
+
+    def freeze
+      each { |_k, v| v.is_a?(OpenStruct) && v.freeze }
+      super
     end
 
     private

--- a/lib/blacklight/open_struct_with_hash_access.rb
+++ b/lib/blacklight/open_struct_with_hash_access.rb
@@ -6,7 +6,7 @@ module Blacklight
   class OpenStructWithHashAccess < OpenStruct
     delegate :keys, :each, :map, :has_key?, :key?, :include?, :empty?,
              :length, :delete, :delete_if, :keep_if, :clear, :reject!, :select!,
-             :replace, :fetch, :to_json, :as_json, :any?, to: :to_h
+             :replace, :fetch, :to_json, :as_json, :any?, :freeze, :unfreeze, :frozen?, to: :to_h
 
     ##
     # Expose the internal hash

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -621,4 +621,14 @@ RSpec.describe "Blacklight::Configuration", api: true do
       end
     end
   end
+
+  describe '#freeze' do
+    it 'freezes the configuration' do
+      config.freeze
+
+      expect(config.a).to be_nil
+      expect { config.a = '123' }.to raise_error(FrozenError)
+      expect { config.view.a = '123' }.to raise_error(FrozenError)
+    end
+  end
 end


### PR DESCRIPTION
…+ 2nd level configurations.

I don't know if this breaks any expectations about how freeze works or what it freezes, but I thought it'd be handy to have a way to make the configuration immutable (at least to see where you might accidentally mutate it..).

🤷‍♂️ 
