### PR TITLE
Guard against the same conditions coming through the query parameter …

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -45,6 +45,7 @@ module Blacklight
     ##
     # Update the :q (query) parameter
     def where(conditions)
+      Deprecation.warn("SearchBuilder#where must be called with a hash, received #{conditions.inspect}.") unless conditions.is_a? Hash
       params_will_change!
       @search_state = @search_state.reset(@search_state.params.merge(q: conditions))
       @blacklight_params = @search_state.params.dup

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -800,4 +800,13 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       expect(subject.to_hash.with_indifferent_access.dig(:json, :query, :bool, :must, 1, :edismax, :qf)).to eq '${author_qf}'
     end
   end
+
+  describe '#where' do
+    let(:user_params) { {} }
+
+    it 'adds additional query filters on the search' do
+      subject.where(id: [1, 2, 3])
+      expect(subject.to_hash).to include q: '{!lucene}id:(1 OR 2 OR 3)'
+    end
+  end
 end


### PR DESCRIPTION
…and as an additional filter.

We intentionally do this (for now..) to preserve backwards compatibility for different types of `#where` values, but it unintentionally turns these queries into json query DSLs.
