### PR TITLE
Pass the current view config through the template chain as locals

### DIFF
--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -89,7 +89,7 @@ module Blacklight::RenderPartialsHelperBehavior
     end
 
     if template
-      template.render(self, locals.merge(documents: documents))
+      template.render(self, locals.merge(documents: documents, view_config: blacklight_config&.view_config(view)))
     else
       ''
     end

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,6 +1,7 @@
 <% # container for a single doc -%>
-<%= render (blacklight_config.view_config(document_index_view_type).document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
-  <% component.public_send(blacklight_config.view_config(document_index_view_type).document_component.blank? && blacklight_config.view_config(document_index_view_type).partials.any? ? :body : :partial) do %>
-    <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, component: component, document_counter: document_counter %>
+<% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type) %>
+<%= render (view_config.document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
+  <% component.public_send(view_config.document_component.blank? && view_config.partials.any? ? :body : :partial) do %>
+    <%= render_document_partials document, view_config.partials, component: component, document_counter: document_counter %>
   <% end %>
 <% end %>

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,4 +1,5 @@
 <% # container for all documents in index list view -%>
-<div id="documents" class="documents-<%= document_index_view_type %>">
-  <%= render documents, :as => :document %>
+<% view_config = local_assigns[:view_config] || blacklight_config&.view_config(document_index_view_type) %>
+<div id="documents" class="documents-<%= view_config&.key || document_index_view_type %>">
+  <%= render documents, as: :document, view_config: view_config %>
 </div>

--- a/spec/views/catalog/_document.html.erb_spec.rb
+++ b/spec/views/catalog/_document.html.erb_spec.rb
@@ -46,4 +46,13 @@ RSpec.describe "catalog/_document" do
     expect(rendered).to have_selector 'article.document header', text: '22. xyz'
     expect(rendered).not_to match(/partial/)
   end
+
+  it 'renders the partial using a provided view config' do
+    view_config = Blacklight::Configuration::ViewConfig.new partials: %w[a]
+    stub_template "catalog/_a_default.html.erb" => "partial"
+
+    render partial: "catalog/document", locals: { document: document, document_counter: 1, view_config: view_config }
+
+    expect(rendered).to match(/partial/)
+  end
 end

--- a/spec/views/catalog/_document_list.html.erb_spec.rb
+++ b/spec/views/catalog/_document_list.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "catalog/_document_list", type: :view do
   before do
-    allow(view).to receive_messages(document_index_view_type: "some-view", documents: [])
+    allow(view).to receive_messages(document_index_view_type: "some-view", documents: [], blacklight_config: nil)
   end
 
   it "includes a class for the current view" do


### PR DESCRIPTION
… because it might not be the same as the global default when using render_document_index_with_view.

We used to hard-code the templates to render, but the document components made it possible to reuse shared partials more. 

