### PR TITLE
Add ViewConfig#template configuration to allow view types to specify …

### DIFF
--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -84,12 +84,16 @@ module Blacklight::RenderPartialsHelperBehavior
   # @param [Hash] locals to pass to the render call
   # @return [String]
   def render_document_index_with_view view, documents, locals = {}
+    view_config = blacklight_config&.view_config(view)
+
+    return render partial: view_config.template, locals: locals.merge(documents: documents, view_config: view_config) if view_config&.template
+
     template = cached_view ['index', view].join('_') do
       find_document_index_template_with_view(view, locals)
     end
 
     if template
-      template.render(self, locals.merge(documents: documents, view_config: blacklight_config&.view_config(view)))
+      template.render(self, locals.merge(documents: documents, view_config: view_config))
     else
       ''
     end

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Blacklight::Configuration
   class ViewConfig < Blacklight::OpenStructWithHashAccess
+    # @!attribute template
+    #   @return [String] partial to render around the documents
     # @!attribute partials
     #   @return [Array<String>] partials to render for each document(see #render_document_partials)
     # @!attribute document_presenter_class

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -320,6 +320,24 @@ RSpec.describe BlacklightHelper do
       response = helper.render_document_index_with_view :view_type, [obj1, obj1]
       expect(response).to have_selector "div#documents"
     end
+
+    context 'with a template partial provided by the view config' do
+      before do
+        blacklight_config.view.gallery(template: '/my/partial')
+      end
+
+      def stub_template(hash)
+        view.view_paths.unshift(ActionView::FixtureResolver.new(hash))
+      end
+
+      it 'renders that template' do
+        stub_template 'my/_partial.html.erb' => 'some content'
+
+        response = helper.render_document_index_with_view :gallery, [obj1, obj1]
+
+        expect(response).to eq 'some content'
+      end
+    end
   end
 
   describe "#document_index_view_type" do


### PR DESCRIPTION
…the partial to render for the search result.

This should allow applications to opt-out of some of the partial name calculating magic, if they so choose, by explicitly specifying the partial to use for rendering a search result, e.g.:

```ruby
blacklight_config.view.list.template = 'document_list'
```