### PR TITLE
Pass the deprecated context class to the deprecation warning 

### DIFF
--- a/app/components/blacklight/content_areas_shim.rb
+++ b/app/components/blacklight/content_areas_shim.rb
@@ -5,7 +5,8 @@ module Blacklight
   module ContentAreasShim
     # Shim the `with` helper to write content into slots instead
     def with(slot_name, *args, **kwargs, &block)
-      Deprecation.warn('ViewComponents deprecated `with` and it will be removed in ViewComponents 3.0. content_areas. Use slots (https://viewcomponent.org/guide/slots.html) instead.')
+      Deprecation.warn(Blacklight::ContentAreasShim,
+                       'ViewComponents deprecated `with` and it will be removed in ViewComponents 3.0. content_areas. Use slots (https://viewcomponent.org/guide/slots.html) instead.')
       public_send(slot_name, *args, **kwargs, &block)
     end
   end

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -25,7 +25,7 @@ module Blacklight
       next static_content if static_content.present?
       next unless component
 
-      Deprecation.warn('Pass the presenter to the DocumentComponent') if @presenter.nil?
+      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if @presenter.nil?
 
       component.new(*args, document: @document, presenter: @presenter, document_counter: @document_counter, **kwargs)
     end)
@@ -34,7 +34,7 @@ module Blacklight
     renders_one :metadata, (lambda do |static_content = nil, *args, component: nil, fields: nil, **kwargs|
       next static_content if static_content.present?
 
-      Deprecation.warn('Pass the presenter to the DocumentComponent') if !fields && @presenter.nil?
+      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if !fields && @presenter.nil?
 
       component ||= Blacklight::DocumentMetadataComponent
 
@@ -48,7 +48,7 @@ module Blacklight
       next image_options_or_static_content if image_options_or_static_content.is_a? String
 
       component ||= @presenter&.view_config&.thumbnail_component || Blacklight::Document::ThumbnailComponent
-      Deprecation.warn('Pass the presenter to the DocumentComponent') if !component && @presenter.nil?
+      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if !component && @presenter.nil?
 
       component.new(*args, document: @document, presenter: @presenter, counter: @counter, image_options: image_options_or_static_content, **kwargs)
     end)
@@ -93,13 +93,13 @@ module Blacklight
       @id = id || ('document' if show)
       @classes = classes
 
-      Deprecation.warn('Passing embed_component is deprecated') if @embed_component.present?
+      Deprecation.warn(Blacklight::DocumentComponent, 'Passing embed_component is deprecated') if @embed_component.present?
       @embed_component = embed_component
 
-      Deprecation.warn('Passing metadata_component is deprecated') if @metadata_component.present?
+      Deprecation.warn(Blacklight::DocumentComponent, 'Passing metadata_component is deprecated') if @metadata_component.present?
       @metadata_component = metadata_component || Blacklight::DocumentMetadataComponent
 
-      Deprecation.warn('Passing thumbnail_component is deprecated') if @thumbnail_component.present?
+      Deprecation.warn(Blacklight::DocumentComponent, 'Passing thumbnail_component is deprecated') if @thumbnail_component.present?
       @thumbnail_component = thumbnail_component || Blacklight::Document::ThumbnailComponent
 
       @document_counter = document_counter

--- a/app/components/blacklight/metadata_field_layout_component.rb
+++ b/app/components/blacklight/metadata_field_layout_component.rb
@@ -25,7 +25,7 @@ module Blacklight
     def value(*args, **kwargs, &block)
       return set_slot(:values, *args, **kwargs, &block) if block_given?
 
-      Deprecation.warn('The `value` content area is deprecated; render from the values slot instead')
+      Deprecation.warn(Blacklight::MetadataFieldLayoutComponent, 'The `value` content area is deprecated; render from the values slot instead')
 
       values.first
     end

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -20,7 +20,7 @@ class Blacklight::Configuration
     end
 
     def display_label(deprecated_key = nil, **options)
-      Deprecation.warn('Passing the key argument to ViewConfig#display_label is deprecated') if deprecated_key.present?
+      Deprecation.warn(Blacklight::Configuration::ViewConfig, 'Passing the key argument to ViewConfig#display_label is deprecated') if deprecated_key.present?
 
       I18n.t(
         :"blacklight.search.view_title.#{deprecated_key || key}",

--- a/lib/blacklight/nested_open_struct_with_hash_access.rb
+++ b/lib/blacklight/nested_open_struct_with_hash_access.rb
@@ -101,7 +101,9 @@ module Blacklight
               new_ostruct_member!(m)
               @table[m] = args.first
             elsif len.zero? && kwargs.blank? && !block
-              Deprecation.warn("Initializing a #{nested_class} implicitly (by calling #{mid}) is deprecated. Call it as #{mid}! or pass initialize arguments")
+              Deprecation.warn(Blacklight::NestedOpenStructWithHashAccess,
+                               "Initializing a #{nested_class} implicitly (by calling #{mid}) is deprecated. Call it as #{mid}! or pass initialize arguments")
+
               new_ostruct_member!(mid)
               @table[mid]
             else

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -45,7 +45,7 @@ module Blacklight
     ##
     # Update the :q (query) parameter
     def where(conditions)
-      Deprecation.warn("SearchBuilder#where must be called with a hash, received #{conditions.inspect}.") unless conditions.is_a? Hash
+      Deprecation.warn(Blacklight::SearchBuilder, "SearchBuilder#where must be called with a hash, received #{conditions.inspect}.") unless conditions.is_a? Hash
       params_will_change!
       @search_state = @search_state.reset(@search_state.params.merge(q: conditions))
       @blacklight_params = @search_state.params.dup

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -66,7 +66,7 @@ module Blacklight::Solr
         add_search_field_with_local_parameters(solr_parameters)
       elsif search_state.query_param.is_a? Hash
         if search_state.query_param == @additional_filters && !processor_chain.include?(:add_additional_filters)
-          Deprecation.warn('Expecting to see the processor step add_additional_filters; falling back to legacy query handling')
+          Deprecation.warn(Blacklight::Solr::SearchBuilderBehavior, 'Expecting to see the processor step add_additional_filters; falling back to legacy query handling')
           add_additional_filters(solr_parameters, search_state.query_param)
         end
       elsif search_state.query_param


### PR DESCRIPTION
…so it can be silenced downstream