### PR TITLE
Update the solr search builder to better handle parameter overriding

### DIFF
--- a/lib/blacklight/solr/request.rb
+++ b/lib/blacklight/solr/request.rb
@@ -2,7 +2,10 @@
 class Blacklight::Solr::InvalidParameter < ArgumentError; end
 
 class Blacklight::Solr::Request < ActiveSupport::HashWithIndifferentAccess
+  # @deprecated
   SINGULAR_KEYS = %w(facet fl q qt rows start spellcheck spellcheck.q sort per_page wt hl group defType)
+
+  # @deprecated
   ARRAY_KEYS = %w(facet.field facet.query facet.pivot fq hl.fl)
 
   def initialize(constructor = {})
@@ -11,9 +14,6 @@ class Blacklight::Solr::Request < ActiveSupport::HashWithIndifferentAccess
       update(constructor)
     else
       super(constructor)
-    end
-    ARRAY_KEYS.each do |key|
-      self[key] ||= []
     end
   end
 
@@ -49,26 +49,29 @@ class Blacklight::Solr::Request < ActiveSupport::HashWithIndifferentAccess
   end
 
   def append_filter_query(query)
+    self['fq'] ||= []
+    self['fq'] = Array(self['fq']) if self['fq'].is_a? String
+
     self['fq'] << query
   end
 
   def append_facet_fields(values)
+    self['facet.field'] ||= []
     self['facet.field'] += Array(values)
   end
 
   def append_facet_query(values)
+    self['facet.query'] ||= []
     self['facet.query'] += Array(values)
   end
 
   def append_facet_pivot(query)
+    self['facet.pivot'] ||= []
     self['facet.pivot'] << query
   end
 
   def append_highlight_field(query)
+    self['hl.fl'] ||= []
     self['hl.fl'] << query
-  end
-
-  def to_hash
-    reject { |key, value| ARRAY_KEYS.include?(key) && value.blank? }
   end
 end

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -43,10 +43,10 @@ module Blacklight::Solr
       ###
       # Merge in search field configured values, if present, over-writing general
       # defaults
-
       if search_field
         solr_parameters[:qt] = search_field.qt if search_field.qt
-        solr_parameters.merge!(search_field.solr_parameters) if search_field.solr_parameters
+
+        solr_parameters.deep_merge!(search_field.solr_parameters) if search_field.solr_parameters
       end
     end
 

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -18,13 +18,13 @@ module Blacklight::Solr
     # merge to dup values, to avoid later mutating the original by mistake.
     def default_solr_parameters(solr_parameters)
       blacklight_config.default_solr_params.each do |key, value|
-        solr_parameters[key] = if value.respond_to? :deep_dup
-                                 value.deep_dup
-                               elsif value.respond_to?(:dup) && value.duplicable?
-                                 value.dup
-                               else
-                                 value
-                               end
+        solr_parameters[key] ||= if value.respond_to? :deep_dup
+                                   value.deep_dup
+                                 elsif value.respond_to?(:dup) && value.duplicable?
+                                   value.dup
+                                 else
+                                   value
+                                 end
       end
     end
 

--- a/spec/models/blacklight/solr/request_spec.rb
+++ b/spec/models/blacklight/solr/request_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Blacklight::Solr::Request, api: true do
       subject['spellcheck'] = "a"
       subject['spellcheck.q'] = "fleece"
       subject['f.title_facet.facet.limit'] = "vest"
-      subject['facet.field'] = []
     end
 
     it "accepts valid parameters" do

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
     end
   end
 
+  context 'with merged parameters from the defaults + the search field' do
+    before do
+      blacklight_config.default_solr_params = { json: { whatever: [1, 2, 3] } }
+      blacklight_config.search_fields['all_fields'].solr_parameters = { json: { and_also: [4, 5, 6] } }
+    end
+
+    let(:user_params) { { search_field: 'all_fields' } }
+
+    it 'deep merges hash values' do
+      expect(subject.to_hash.dig(:json, :whatever)).to eq [1, 2, 3]
+      expect(subject.to_hash.dig(:json, :and_also)).to eq [4, 5, 6]
+    end
+  end
+
   context "with a complex parameter environment" do
     subject { search_builder.with(user_params).processed_parameters }
 

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -304,7 +304,6 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
 
       it "does not include weird keys not in field definition" do
         expect(subject[:phrase_filters]).to be_nil
-        expect(subject[:fq]).to eq []
         expect(subject[:commit]).to be_nil
         expect(subject[:action]).to be_nil
         expect(subject[:controller]).to be_nil


### PR DESCRIPTION
This PR makes a couple things possible:

- injecting additional parameters before the `default_solr_parameters` step without being overridden by the defaults
- deep merging search field-provided solr parameters to enable e.g. json request data to get gracefully merged
