### PR TITLE
Support bootstrap 4 + 5

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -352,7 +352,7 @@ Blacklight.modal.modalCloseSelector = '[data-blacklight-modal~=close]'; // Calle
 
 Blacklight.modal.onFailure = function (jqXHR, textStatus, errorThrown) {
   console.error('Server error:', this.url, jqXHR.status, errorThrown);
-  var contents = '<div class="modal-header">' + '<div class="modal-title">There was a problem with your request.</div>' + '<button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="Close">' + '  <span aria-hidden="true">&times;</span>' + '</button></div>' + ' <div class="modal-body"><p>Expected a successful response from the server, but got an error</p>' + '<pre>' + this.type + ' ' + this.url + "\n" + jqXHR.status + ': ' + errorThrown + '</pre></div>';
+  var contents = '<div class="modal-header">' + '<div class="modal-title">There was a problem with your request.</div>' + '<button type="button" class="blacklight-modal-close btn-close close" data-dismiss="modal" aria-label="Close">' + '  <span aria-hidden="true">&times;</span>' + '</button></div>' + ' <div class="modal-body"><p>Expected a successful response from the server, but got an error</p>' + '<pre>' + this.type + ' ' + this.url + "\n" + jqXHR.status + ': ' + errorThrown + '</pre></div>';
   $(Blacklight.modal.modalSelector).find('.modal-content').html(contents);
   $(Blacklight.modal.modalSelector).modal('show');
 };
@@ -495,4 +495,3 @@ Blacklight.handleSearchContextMethod = function (event) {
 Blacklight.onLoad(function () {
   Blacklight.doSearchContextBehavior();
 });
-

--- a/app/assets/stylesheets/blacklight/_balanced_list.scss
+++ b/app/assets/stylesheets/blacklight/_balanced_list.scss
@@ -2,11 +2,11 @@
   dt {
     font-weight: normal;
     color: $field_name_color;
-    @media (max-width: breakpoint-max(sm)) {
+    @media (max-width: breakpoint-min(md)) {
       text-align: left;
     }
 
-    @media (min-width: breakpoint-max(sm)) {
+    @media (min-width: breakpoint-min(md)) {
       text-align: right;
     }
   }

--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -5,7 +5,7 @@
 // Facet field headings and buttons
 .facet-field-heading {
   border-bottom: 0;
-  
+
   button {
     font-weight: $headings-font-weight;
 

--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -8,8 +8,8 @@
     text-overflow: ellipsis;
     overflow: hidden;
 
-    @media (max-width: breakpoint-max(xs)) {
-      max-width: breakpoint-max(xs) / 2;
+    @media (max-width: breakpoint-min(sm)) {
+      max-width: breakpoint-min(sm) / 2;
     }
 
     @media (min-width: breakpoint-min(sm)) and (max-width: breakpoint-max(sm)) {

--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -34,7 +34,8 @@
   display: inline-block;
 
   .caption {
-    @extend .sr-only;
+    @extend .sr-only !optional;
+    @extend .visually-hidden !optional;
   }
 }
 

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -3,7 +3,8 @@
     border-color: $navbar-light-toggler-border-color;
     color: $navbar-light-active-color;
 
-    @include hover-focus {
+    &:hover,
+    &:focus {
       color: $navbar-light-active-color;
     }
   }
@@ -83,6 +84,7 @@
     color: $text-muted;
     font-weight: bold;
     padding-left: $spacer / 2;
+    text-decoration: none;
 
     &:hover {
       color: theme-color("danger");

--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -44,7 +44,12 @@
   .submit-search-text {
     // hide 'search' label at very small screens
     @media screen and (max-width: breakpoint-max(xs)) {
-      @include sr-only();
+      @if mixin-exists(sr-only) {
+        @include sr-only();
+      }
+      @if mixin-exists(visually-hidden) {
+        @include visually-hidden();
+      }
     }
   }
 }

--- a/app/components/blacklight/constraint_layout_component.html.erb
+++ b/app/components/blacklight/constraint_layout_component.html.erb
@@ -10,7 +10,7 @@
   <% if @remove_path.present? %>
     <%= link_to(@remove_path, class: 'btn btn-outline-secondary remove') do %>
       <span class="remove-icon" aria-hidden="true">✖</span>
-      <span class="sr-only">
+      <span class="sr-only visually-hidden">
         <%= if @label.blank?
             t('blacklight.search.filters.remove.value', value: @value)
           else

--- a/app/components/blacklight/constraints_component.html.erb
+++ b/app/components/blacklight/constraints_component.html.erb
@@ -1,9 +1,9 @@
 <%= content_tag :div, id: @id, class: @classes do %>
-  <h2 class="sr-only"><%= t('blacklight.search.search_constraints_header') %></h2>
+  <h2 class="sr-only visually-hidden"><%= t('blacklight.search.search_constraints_header') %></h2>
 
   <%= link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-primary" %>
 
-  <span class="constraints-label sr-only"><%= t('blacklight.search.filters.title') %></span>
+  <span class="constraints-label sr-only visually-hidden"><%= t('blacklight.search.filters.title') %></span>
   <% if query_constraints_area.present? %>
     <% query_constraints_area.each do |constraint| %>
       <%= constraint %>

--- a/app/components/blacklight/facet_field_component.html.erb
+++ b/app/components/blacklight/facet_field_component.html.erb
@@ -2,9 +2,11 @@
   <h3 class="card-header p-0 facet-field-heading" id="<%= @facet_field.html_id %>-header">
     <button
       type="button"
-      class="btn btn-block p-2 text-left collapse-toggle <%= "collapsed" if @facet_field.collapsed? %>"
+      class="btn w-100 d-block btn-block p-2 text-start text-left collapse-toggle <%= "collapsed" if @facet_field.collapsed? %>"
       data-toggle="collapse"
+      data-bs-toggle="collapse"
       data-target="#<%= @facet_field.html_id %>"
+      data-bs-target="#<%= @facet_field.html_id %>"
       aria-expanded="<%= @facet_field.collapsed? ? 'false' : 'true' %>"
     >
       <%= label %>

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -87,7 +87,7 @@ module Blacklight
           # remove link
           link_to(@href, class: "remove") do
             tag.span('✖', class: "remove-icon", aria: { hidden: true }) +
-              tag.span(@view_context.t(:'blacklight.search.facets.selected.remove'), class: 'sr-only')
+              tag.span(@view_context.t(:'blacklight.search.facets.selected.remove'), class: 'sr-only visually-hidden')
           end
       end + render_facet_count(classes: ["selected"])
     end

--- a/app/components/blacklight/facet_item_pivot_component.rb
+++ b/app/components/blacklight/facet_item_pivot_component.rb
@@ -56,7 +56,7 @@ module Blacklight
 
     def facet_toggle_button(id)
       content_tag 'button', class: 'btn facet-toggle-handle collapsed',
-                            data: { toggle: 'collapse', target: "##{id}" },
+                            data: { toggle: 'collapse', 'bs-toggle': 'collapse', target: "##{id}", 'bs-target': "##{id}" },
                             aria: { expanded: false, controls: id, describedby: "#{id}_label" } do
         concat toggle_icon(:show)
         concat toggle_icon(:hide)
@@ -66,7 +66,7 @@ module Blacklight
     def toggle_icon(type)
       content_tag 'span', class: type do
         concat @icons[type]
-        concat content_tag('span', t(type, scope: 'blacklight.search.facets.pivot'), class: 'sr-only')
+        concat content_tag('span', t(type, scope: 'blacklight.search.facets.pivot'), class: 'sr-only visually-hidden')
       end
     end
 

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -9,6 +9,8 @@
       data: {
         toggle: 'collapse',
         target: "##{@panel_id}",
+        'bs-toggle': 'collapse',
+        'bs-target': "##{@panel_id}"
       },
       aria: {
         controls: @panel_id,

--- a/app/components/blacklight/response/view_type_component.html.erb
+++ b/app/components/blacklight/response/view_type_component.html.erb
@@ -1,5 +1,5 @@
 <div class="view-type">
-  <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
+  <span class="sr-only visually-hidden"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
     <% views.each do |view| %>
       <%= view %>

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => scoped_t('submit') do %>
   <%= render_hash_as_hidden_fields(@params) %>
   <% if @search_fields.length > 1 %>
-    <label for="search_field" class="sr-only"><%= scoped_t('search_field.label') %></label>
+    <label for="search_field" class="sr-only visually-hidden"><%= scoped_t('search_field.label') %></label>
   <% end %>
   <div class="input-group">
     <%= prepend %>
@@ -11,12 +11,12 @@
                        options_for_select(@search_fields, h(@search_field)),
                        title: scoped_t('search_field.title'),
                        id: "#{@prefix}search_field",
-                       class: "custom-select search-field") %>
+                       class: "custom-select form-select search-field") %>
     <% elsif @search_fields.length == 1 %>
       <%= hidden_field_tag :search_field, @search_fields.first.last %>
     <% end %>
 
-    <label for="<%= @prefix %><%= @query_param %>" class="sr-only"><%= scoped_t('search.label') %></label>
+    <label for="<%= @prefix %><%= @query_param %>" class="sr-only visually-hidden"><%= scoped_t('search.label') %></label>
     <%= text_field_tag @query_param, @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{@search_fields.length > 1 ? '0' : 'left'}", id: "#{@prefix}q", autocomplete: autocomplete_path.present? ? "off" : "", autofocus: @autofocus, data: { autocomplete_enabled: autocomplete_path.present?, autocomplete_path: autocomplete_path }  %>
 
     <span class="input-group-append">

--- a/app/components/blacklight/system/dropdown_component.rb
+++ b/app/components/blacklight/system/dropdown_component.rb
@@ -4,7 +4,7 @@ module Blacklight
   module System
     class DropdownComponent < ViewComponent::Base
       renders_one :button, (lambda do |classes:, label:|
-        button_tag class: classes, aria: { expanded: false }, data: { toggle: 'dropdown' } do
+        button_tag class: classes, aria: { expanded: false }, data: { toggle: 'dropdown', 'bs-toggle': 'dropdown' } do
           safe_join([label, content_tag(:span, '', class: 'caret')])
         end
       end)

--- a/app/components/blacklight/system/flash_message_component.html.erb
+++ b/app/components/blacklight/system/flash_message_component.html.erb
@@ -1,4 +1,4 @@
 <div class="alert <%= @classes %>">
   <%= message %>
-  <a class="close" data-dismiss="alert" href="#">&times;</a>
+  <a class="btn-close close" data-dismiss="alert" href="#">&times;</a>
 </div>

--- a/app/components/blacklight/system/modal_component.html.erb
+++ b/app/components/blacklight/system/modal_component.html.erb
@@ -6,7 +6,7 @@
       <h1 class="modal-title"><%= title %></h1>
     <% end) %>
 
-    <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <button type="button" class="blacklight-modal-close btn-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>

--- a/app/helpers/blacklight/component_helper_behavior.rb
+++ b/app/helpers/blacklight/component_helper_behavior.rb
@@ -14,7 +14,7 @@ module Blacklight
       if action_opts.path
         send(action_opts.path, url_opts)
       elsif url_opts[:id].class.respond_to?(:model_name)
-        url_for([action_opts.key, url_opts[:id]])
+        url_for([action_opts.key.to_sym, url_opts[:id]])
       else
         send("#{action_opts.key}_#{controller_name}_path", url_opts)
       end

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -106,7 +106,7 @@ Blacklight.modal.onFailure = function(jqXHR, textStatus, errorThrown) {
 
   var contents = '<div class="modal-header">' +
             '<div class="modal-title">There was a problem with your request.</div>' +
-            '<button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="Close">' +
+            '<button type="button" class="blacklight-modal-close btn-close close" data-dismiss="modal" aria-label="Close">' +
             '  <span aria-hidden="true">&times;</span>' +
             '</button></div>' +
             ' <div class="modal-body"><p>Expected a successful response from the server, but got an error</p>' +

--- a/app/views/blacklight/nav/_bookmark.html.erb
+++ b/app/views/blacklight/nav/_bookmark.html.erb
@@ -1,4 +1,4 @@
 <%= link_to bookmarks_path, id:'bookmarks_nav', class: 'nav-link' do %>
   <%= t('blacklight.header_links.bookmarks') %>
-<span class="badge badge-secondary" data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>
+<span class="badge badge-secondary bg-secondary" data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>
 <% end %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -13,7 +13,7 @@
   <% else %>
     <%= render 'sort_and_per_page' %>
     <%= render partial: 'tools', locals: { document_list: @response.documents } %>
-    <h2 class='section-heading sr-only'><%= t('blacklight.bookmarks.list_title') %></h2>
+    <h2 class='section-heading sr-only visually-hidden'><%= t('blacklight.bookmarks.list_title') %></h2>
     <%= render_document_index %>
     <%= render 'results_pagination' %>
   <% end %>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -4,10 +4,10 @@
   <% Deprecation.warn(Blacklight::RenderConstraintsHelperBehavior, 'Constraints helpers or partials were overridden; not using components') %>
   <% if Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) { query_has_constraints? } %>
     <div id="appliedParams" class="clearfix constraints-container">
-      <h2 class="sr-only"><%= t('blacklight.search.search_constraints_header') %></h2>
+      <h2 class="sr-only visually-hidden"><%= t('blacklight.search.search_constraints_header') %></h2>
 
       <%= render 'start_over' %>
-      <span class="constraints-label sr-only"><%= t('blacklight.search.filters.title') %></span>
+      <span class="constraints-label sr-only visually-hidden"><%= t('blacklight.search.filters.title') %></span>
       <%= render_constraints(controller.params != params ? params : search_state) %>
     </div>
   <% end %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -31,7 +31,7 @@
 
 <%# This is the same panel shown in the Rails welcome template %>
 <div id="about" class="card">
-  <h2 class='card-header collapsed collapse-toggle' data-toggle="collapse" data-target="#about-content"><a href="/rails/info/properties">About your application&rsquo;s environment</a></h2>
+  <h2 class='card-header collapsed collapse-toggle' data-toggle="collapse" data-bs-toggle="collapse" data-bs-target="#about-content" data-target="#about-content"><a href="/rails/info/properties">About your application&rsquo;s environment</a></h2>
   <div id="about-content" class="card-body collapse"></div>
 </div>
 

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -1,5 +1,5 @@
 <% if show_sort_and_per_page? %>
-  <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
+  <span class="sr-only visually-hidden"><%= t('blacklight.search.per_page.title') %></span>
   <%= render(Blacklight::System::DropdownComponent.new(
     param: :per_page,
     choices: per_page_options_for_select,

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -12,14 +12,14 @@
 <% end %>
 
 <% content_for(:container_header) do -%>
-  <h1 class="sr-only top-content-title"><%= t('blacklight.search.header') %></h1>
+  <h1 class="sr-only visually-hidden top-content-title"><%= t('blacklight.search.header') %></h1>
 
   <%= render 'constraints' %>
 <% end %>
 
 <%= render 'search_header' %>
 
-<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+<h2 class="sr-only visually-hidden"><%= t('blacklight.search.search_results') %></h2>
 
 <%- if @response.empty? %>
   <%= render "zero_results" %>

--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -9,7 +9,7 @@
               blacklight.clear_search_history_path,
               method: :delete,
               data: { confirm: t('blacklight.search_history.clear.action_confirm') },
-              class: 'btn btn-danger float-md-right' %>
+              class: 'btn btn-danger float-md-right float-md-end' %>
   <h2 class='section-heading'><%= t('blacklight.search_history.recent') %></h2>
   <table class="table table-striped search-history">
     <% @searches.each_with_index do |search,index| %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
   <div class="<%= container_classes %>">
     <%= link_to application_name, root_path, class: 'mb-0 navbar-brand navbar-logo' %>
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -157,7 +157,7 @@ ar:
         request_error: "معذرة، لم أفهم ما تبحث عنه."
         invalid_solr_id: "معذرة! لقد طلبت سجلًا غير موجود."
       per_page:
-        label: '%{count}<span class="sr-only"> لكل صفحة</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> لكل صفحة</span>'
         button_label: '%{count} لكل صفحة' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> لكل صفحة</span>'
         title: 'عدد النتائج المعروضة في الصفحة'
@@ -209,7 +209,7 @@ ar:
           count: 'ترتيب رقمي'
           index: 'ترتيب أبجدي'
         count: '%{number}'
-        more_html: 'المزيد <span class="sr-only">%{field_name}</span> »'
+        more_html: 'المزيد <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[إزالة]'
         missing: "[غير موجود]"

--- a/config/locales/blacklight.ca.yml
+++ b/config/locales/blacklight.ca.yml
@@ -147,7 +147,7 @@ ca:
         request_error: "No ha estat possible entendre la cerca"
         invalid_solr_id: "El registre que heu sol·licitat no existeix."
       per_page:
-        label: '%{count}<span class="sr-only"> per pàgina</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> per pàgina</span>'
         button_label: '%{count} per pàgina' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> per pàgina</span>'
         title: 'Nombre de resultats a mostrar per pàgina'
@@ -189,7 +189,7 @@ ca:
           count: 'Numèricament'
           index: 'Alfabèticament'
         count: '%{number}'
-        more_html: 'més <span class="sr-only">%{field_name}</span> »'
+        more_html: 'més <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[eliminar]'
         missing: "[Desaparegut]"

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -147,7 +147,7 @@ de:
         request_error: "Entschuldigung, ich habe Ihre Suche nicht verstanden."
         invalid_solr_id: "Entschuldigung, Sie haben einen nicht vorhandenen Datensatz angefordert."
       per_page:
-        label: '%{count}<span class="sr-only"> pro Seite</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> pro Seite</span>'
         button_label: '%{count} pro Seite' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> pro Seite</span>'
         title: 'Anzahl der Ergebnisse, die pro Seite angezeigt werden'
@@ -190,7 +190,7 @@ de:
           count: 'Numerisch ordnen'
           index: 'A-Z Ordnen'
         count: '%{number}'
-        more_html: 'mehr <span class="sr-only">%{field_name}</span> »'
+        more_html: 'mehr <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[entfernen]'
         missing: [fehlt]

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -147,7 +147,7 @@ en:
         request_error: "Sorry, I don't understand your search."
         invalid_solr_id: "Sorry, you have requested a record that doesn't exist."
       per_page:
-        label: '%{count}<span class="sr-only"> per page</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> per page</span>'
         button_label: '%{count} per page' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> per page</span>'
         title: 'Number of results to display per page'
@@ -189,7 +189,7 @@ en:
           count: 'Numerical Sort'
           index: 'A-Z Sort'
         count: '%{number}'
-        more_html: 'more <span class="sr-only">%{field_name}</span> »'
+        more_html: 'more <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[remove]'
         missing: "[Missing]"

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -147,7 +147,7 @@ es:
         request_error: "Lo siento, no entiendo esta búsqueda"
         invalid_solr_id: "Lo sentimos, usted ha solicitado un registro que no existe."
       per_page:
-        label: '%{count}<span class="sr-only"> por página</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> por página</span>'
         button_label: '%{count} por página' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> por página</span>'
         title: 'El número de resultados a mostrar por página'
@@ -190,7 +190,7 @@ es:
           count: 'Ordenación numérica'
           index: 'Ordenación A-Z'
         count: '%{number}'
-        more_html: 'más <span class="sr-only">%{field_name}</span> »'
+        more_html: 'más <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[borrar]'
         missing: '[Falta]'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -150,7 +150,7 @@ fr:
         request_error: "Pardon, nous n'avons pas compris votre recherche."
         invalid_solr_id: "Vous avez demandé une notice qui n'existe pas."
       per_page:
-        label: '%{count}<span class="sr-only"> par page</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> par page</span>'
         button_label: '%{count} par page' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> par page</span>'
         title: 'Nombre de résultats à afficher par page'
@@ -193,7 +193,7 @@ fr:
           count: 'Du + au - fréquent'
           index: 'Tri de A à Z'
         count: '%{number}'
-        more_html: 'plus <span class="sr-only">%{field_name}</span> »'
+        more_html: 'plus <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[ X ]'
         missing: '[manquante]'

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -147,7 +147,7 @@ hu:
         request_error: "Elnézést, nem tudom értelmezni a keresést."
         invalid_solr_id: "Elnézést, de az Ön által kért rekord nem létezik."
       per_page:
-        label: '%{count}<span class="sr-only"> oldalanként</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> oldalanként</span>'
         button_label: '%{count} oldalanként' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> oldalanként</span>'
         title: 'Az eredmények száma oldalanként'
@@ -190,7 +190,7 @@ hu:
           count: 'Numerikus rendezés'
           index: 'A-Z rendezés'
         count: '%{number}'
-        more_html: 'több <span class="sr-only">%{field_name}</span> »'
+        more_html: 'több <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[eltávolítás]'
         missing: "[Hiányzó]"

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -147,7 +147,7 @@ it:
         request_error: "La richiesta non è comprensibile."
         invalid_solr_id: "Il numero di scheda richiesto non esiste."
       per_page:
-        label: '%{count}<span class="sr-only"> per pagina</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> per pagina</span>'
         button_label: '%{count} per pagina' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> per pagina</span>'
         title: 'Risultati per pagina'
@@ -190,7 +190,7 @@ it:
           count: 'Ordina per numero'
           index: 'Ordina A-Z'
         count: '%{number}'
-        more_html: 'altri <span class="sr-only">%{field_name}</span> »'
+        more_html: 'altri <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[cancella]'
         missing: [Mancante]

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -147,7 +147,7 @@ nl:
         request_error: "Sorry, ik kon uw zoekopdracht niet begrijpen."
         invalid_solr_id: "Sorry, u vroeg een onbestaande record op."
       per_page:
-        label: '%{count}<span class="sr-only"> per pagina</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> per pagina</span>'
         button_label: '%{count} per pagina' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> per pagina</span>'
         title: 'Toon aantal zoekresultaten per pagina'
@@ -190,7 +190,7 @@ nl:
           count: 'Numeriek sorteren'
           index: 'A-Z Sorteren'
         count: '%{number}'
-        more_html: 'Meer <span class="sr-only">%{field_name}</span> »'
+        more_html: 'Meer <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[verwijder]'
         missing: "[Ontbrekend]"

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -191,7 +191,7 @@ pt-BR:
           count: 'Ordenar por Número'
           index: 'Ordem Alfabética A-Z'
         count: '%{number}'
-        more_html: 'mais <span class="sr-only">%{field_name}</span> »'
+        more_html: 'mais <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[remover]'
         missing: [Ausência]

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -147,7 +147,7 @@ sq:
         request_error: "Na vjen keq, unë nuk e kuptoj kërkimin tuaj."
         invalid_solr_id: "Na vjen keq, ju keni kërkuar një të dhënë që nuk ekziston."
       per_page:
-        label: '%{count}<span class="sr-only"> për faqe</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> për faqe</span>'
         button_label: '%{count} për faqe' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> për faqe</span>'
         title: 'Numri i rezultateve që do të shfaqen për faqe'
@@ -190,7 +190,7 @@ sq:
           count: 'Renditja numerike'
           index: 'A-Z Renditja'
         count: '%{number}'
-        more_html: 'Më shumë <span class="sr-only">%{field_name}</span> »'
+        more_html: 'Më shumë <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[fshije]'
         missing: "[Mungon]"

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -147,7 +147,7 @@ zh:
         request_error: "抱歉，我不明白你要找什么。"
         invalid_solr_id: "抱歉，你要找的结果不存在。"
       per_page:
-        label: '%{count}<span class="sr-only"> 每页</span>'
+        label: '%{count}<span class="sr-only visually-hidden"> 每页</span>'
         button_label: '%{count} 每页' # TODO: Remove during major release
         button_label_html: '%{count}<span class="d-none d-sm-inline"> 每页</span>'
         title: '每页显示结果数'
@@ -190,7 +190,7 @@ zh:
           count: '按数量排序'
           index: '按字母排序'
         count: '%{number}'
-        more_html: '更多 <span class="sr-only">%{field_name}</span> »'
+        more_html: '更多 <span class="sr-only visually-hidden">%{field_name}</span> »'
         selected:
           remove: '[删除]'
         missing: "[未找到]"

--- a/spec/components/blacklight/constraint_layout_component_spec.rb
+++ b/spec/components/blacklight/constraint_layout_component_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
 
     it "has an accessible remove label" do
       expect(rendered).to have_selector(".remove") do |s|
-        expect(s).to have_selector('.sr-only', text: 'Remove constraint my label: my value')
+        expect(s).to have_selector('.visually-hidden', text: 'Remove constraint my label: my value')
       end
     end
   end

--- a/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
   it 'renders a collapsible card' do
     expect(rendered).to have_selector '.card'
     expect(rendered).to have_button 'Field'
-    expect(rendered).to have_selector 'button[data-target="#facet-field"]'
+    expect(rendered).to have_selector 'button[data-bs-target="#facet-field"]'
     expect(rendered).to have_selector '#facet-field.collapse.show'
   end
 

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
   it 'renders a collapsible card' do
     expect(rendered).to have_selector '.card'
     expect(rendered).to have_button 'Field'
-    expect(rendered).to have_selector 'button[data-target="#facet-field"]'
+    expect(rendered).to have_selector 'button[data-bs-target="#facet-field"]'
     expect(rendered).to have_selector '#facet-field.collapse.show'
   end
 

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -84,13 +84,13 @@ RSpec.describe "Facets" do
       pending 'Capybara::NotSupportedByDriverError: Capybara::Driver::Base#evaluate_script'
       visit root_path
       page.find('h3.facet-field-heading button', text: 'Format').click
-      focused_element_data_target = page.evaluate_script("document.activeElement")['data-target']
+      focused_element_data_target = page.evaluate_script("document.activeElement")['data-bs-target']
       expect(focused_element_data_target).to eq '#facet-format'
     end
   end
 
   describe '"More" links' do
-    it 'has default more link with sr-only text' do
+    it 'has default more link with visually-hidden text' do
       visit root_path
       within '#facet-language_ssim' do
         expect(page).to have_css 'div.more_facets', text: 'more Language'

--- a/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/configuration_helper_behavior_spec.rb
@@ -194,9 +194,9 @@ RSpec.describe Blacklight::ConfigurationHelperBehavior do
   describe "#per_page_options_for_select" do
     it "is the per-page values formatted as options_for_select" do
       allow(helper).to receive_messages(blacklight_config: double(per_page: [11, 22, 33]))
-      expect(helper.per_page_options_for_select).to include ["11<span class=\"sr-only\"> per page</span>", 11]
-      expect(helper.per_page_options_for_select).to include ["22<span class=\"sr-only\"> per page</span>", 22]
-      expect(helper.per_page_options_for_select).to include ["33<span class=\"sr-only\"> per page</span>", 33]
+      expect(helper.per_page_options_for_select).to include ["11<span class=\"sr-only visually-hidden\"> per page</span>", 11]
+      expect(helper.per_page_options_for_select).to include ["22<span class=\"sr-only visually-hidden\"> per page</span>", 22]
+      expect(helper.per_page_options_for_select).to include ["33<span class=\"sr-only visually-hidden\"> per page</span>", 33]
     end
   end
 

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe "catalog/facet_layout" do
 
   it "is collapsable" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
-    expect(rendered).to have_selector 'button.collapsed[data-toggle="collapse"][aria-expanded="false"]'
+    expect(rendered).to have_selector 'button.collapsed[data-toggle="collapse"][data-bs-toggle="collapse"][aria-expanded="false"]'
     expect(rendered).to have_selector '.collapse .card-body'
   end
 
   it "is configured to be open by default" do
     allow(facet_field).to receive_messages(collapse: false)
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
-    expect(rendered).to have_selector 'button[data-toggle="collapse"][aria-expanded="true"]'
+    expect(rendered).to have_selector 'button[data-toggle="collapse"][data-bs-toggle="collapse"][aria-expanded="true"]'
     expect(rendered).not_to have_selector '.card-header.collapsed'
     expect(rendered).to have_selector '.collapse.show .card-body'
   end


### PR DESCRIPTION
This addresses the major differences/incompatibilities between bootstrap 4 + 5 by supporting both markups simultaneously.

I briefly considered adding something to allow us to render one or the other, but so many changes need to be made in the javascript (and in the i18n files, apparently), it seemed like more of a challenge than was warranted by these mostly innocuous changes 🤷  


