### PR TITLE
Fix up some backwards incompatible changes with view components

### DIFF
--- a/app/components/blacklight/facet_field_no_layout_component.rb
+++ b/app/components/blacklight/facet_field_no_layout_component.rb
@@ -10,7 +10,7 @@ module Blacklight
     def initialize(**); end
 
     def call
-      body
+      body.to_s
     end
   end
 end

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -27,7 +27,7 @@ module Blacklight
                   render_facet_value
                 end
 
-      return if content.blank?
+      return '' if content.blank?
       return content unless @wrapping_element
 
       content_tag @wrapping_element, content

--- a/spec/components/blacklight/constraint_layout_component_spec.rb
+++ b/spec/components/blacklight/constraint_layout_component_spec.rb
@@ -3,12 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
-  subject(:render) do
-    render_inline(described_class.new(**params))
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(**params))
   end
 
   describe "for simple display" do

--- a/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
@@ -3,12 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
-  subject(:render) do
-    render_inline(described_class.new(facet_field: facet_field))
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(facet_field: facet_field))
   end
 
   let(:facet_field) do

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -3,12 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
-  subject(:render) do
-    render_inline(described_class.new(facet_field: facet_field))
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(facet_field: facet_field))
   end
 
   let(:facet_field) do

--- a/spec/components/blacklight/facet_item_component_spec.rb
+++ b/spec/components/blacklight/facet_item_component_spec.rb
@@ -3,12 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetItemComponent, type: :component do
-  subject(:render) do
-    render_inline(described_class.new(facet_item: facet_item))
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(facet_item: facet_item))
   end
 
   let(:facet_item) do

--- a/spec/components/blacklight/facet_item_pivot_component_spec.rb
+++ b/spec/components/blacklight/facet_item_pivot_component_spec.rb
@@ -3,12 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
-  subject(:render) do
-    render_inline(described_class.new(facet_item: facet_item))
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(facet_item: facet_item))
   end
 
   let(:search_state) do
@@ -31,7 +27,7 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
 
   it 'links to the facet and shows the number of hits' do
     expect(rendered).to have_selector 'li'
-    expect(rendered).to have_link 'x', href: '/catalog?f[z]=x'
+    expect(rendered).to have_link 'x', href: '/catalog?f%5Bz%5D=x'
     expect(rendered).to have_selector '.facet-count', text: '10'
   end
 

--- a/spec/components/blacklight/hidden_search_state_component_spec.rb
+++ b/spec/components/blacklight/hidden_search_state_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Blacklight::HiddenSearchStateComponent, type: :component do
-  subject(:render) { render_inline(instance) }
+  subject(:rendered) { render_inline_to_capybara_node(instance) }
 
   let(:params) do
     { q: "query",
@@ -11,14 +11,13 @@ RSpec.describe Blacklight::HiddenSearchStateComponent, type: :component do
       f: { field1: %w[a b], field2: ["z"] } }
   end
   let(:instance) { described_class.new(params: params) }
-  let(:generated) { Capybara::Node::Simple.new("<div>#{render.to_html}</div>") }
 
   it "converts a hash with nested complex data to Rails-style hidden form fields" do
-    expect(generated).to have_selector("input[type='hidden'][name='q'][value='query']", visible: :hidden)
-    expect(generated).to have_selector("input[type='hidden'][name='per_page'][value='10']", visible: :hidden)
-    expect(generated).to have_selector("input[type='hidden'][name='extra_arbitrary_key'][value='arbitrary_value']", visible: :hidden)
-    expect(generated).to have_selector("input[type='hidden'][name='f[field2][]'][value='z']", visible: :hidden)
-    expect(generated).to have_selector("input[type='hidden'][name='f[field1][]'][value='a']", visible: :hidden)
-    expect(generated).to have_selector("input[type='hidden'][name='f[field1][]'][value='b']", visible: :hidden)
+    expect(rendered).to have_selector("input[type='hidden'][name='q'][value='query']", visible: :hidden)
+    expect(rendered).to have_selector("input[type='hidden'][name='per_page'][value='10']", visible: :hidden)
+    expect(rendered).to have_selector("input[type='hidden'][name='extra_arbitrary_key'][value='arbitrary_value']", visible: :hidden)
+    expect(rendered).to have_selector("input[type='hidden'][name='f[field2][]'][value='z']", visible: :hidden)
+    expect(rendered).to have_selector("input[type='hidden'][name='f[field1][]'][value='a']", visible: :hidden)
+    expect(rendered).to have_selector("input[type='hidden'][name='f[field1][]'][value='b']", visible: :hidden)
   end
 end

--- a/spec/components/blacklight/metadata_field_component_spec.rb
+++ b/spec/components/blacklight/metadata_field_component_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::MetadataFieldComponent, type: :component do
-  subject(:render) do
-    render_inline(described_class.new(field: field))
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(field: field))
   end
 
   let(:view_context) { controller.view_context }
@@ -13,10 +13,6 @@ RSpec.describe Blacklight::MetadataFieldComponent, type: :component do
 
   let(:field) do
     Blacklight::FieldPresenter.new(view_context, document, field_config)
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
   end
 
   it 'renders the field label' do
@@ -28,8 +24,8 @@ RSpec.describe Blacklight::MetadataFieldComponent, type: :component do
   end
 
   context 'from a show view' do
-    subject(:render) do
-      render_inline(described_class.new(field: field, show: true))
+    subject(:rendered) do
+      render_inline_to_capybara_node(described_class.new(field: field, show: true))
     end
 
     it 'renders the right field label' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include PresenterTestHelpers, type: :presenter
   config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponentCapybaraTestHelpers, type: :component
 
   config.include(ControllerLevelHelpers, type: :helper)
   config.before(:each, type: :helper) { initialize_controller_helpers(helper) }

--- a/spec/support/view_component_capybara_test_helpers.rb
+++ b/spec/support/view_component_capybara_test_helpers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ViewComponentCapybaraTestHelpers
+  # Work around for https://github.com/teamcapybara/capybara/issues/2466
+  def render_inline_to_capybara_node(component)
+    Capybara::Node::Simple.new(render_inline(component).to_s)
+  end
+end


### PR DESCRIPTION
As of view components 2.32.0, components must return strings (as a side-effect of https://github.com/github/view_component/pull/921).

485a3ae works around another change (in Nokogiri?) that segfaults when the capybara node is an existing nokogiri fragment: https://github.com/teamcapybara/capybara/issues/2466