### PR TITLE
Remove the role attribute from the compact pagination

### DIFF
--- a/app/views/catalog/_paginate_compact.html.erb
+++ b/app/views/catalog/_paginate_compact.html.erb
@@ -2,5 +2,6 @@
   response: paginate_compact,
   theme: :blacklight_compact,
   page_entries_info: page_entries_info(paginate_compact),
+  role: nil,
   html: { aria: {} })
 %>


### PR DESCRIPTION
the containing element already has an appropriate role and aria label.