### PR TITLE
logic to check if we have a collation available in the spelling response versus just words.

### DIFF
--- a/app/components/blacklight/response/spellcheck_component.rb
+++ b/app/components/blacklight/response/spellcheck_component.rb
@@ -8,7 +8,12 @@ module Blacklight
       # @param [Array<String>] options explicit spellcheck options to render
       def initialize(response:, options: nil)
         @response = response
-        @options = options || @response&.spelling&.words
+        @options = options
+        if @response&.spelling&.collation
+          @options = [@response.spelling.collation]
+        elsif @response&.spelling&.words
+          @options = response.spelling.words
+        end
       end
 
       def link_to_query(query)


### PR DESCRIPTION
This adds a check to see if we have a collation, and then uses that instead of the individual words.  I didn't try to handle having multiple collations, we just grab a singular one.  

See https://github.com/projectblacklight/blacklight/issues/2029.

I also didn't change the default blacklight solrconfiguration, as I wasn't sure about how to test it.

This is what my spellcheck set up looks like, including a custom `mm=100%` parameter to make sure to filter to only collations that we have documents for:
```
      <!-- spellchecking -->
      <str name="spellcheck">true</str>
      <str name="spellcheck.dictionary">title</str>
      <str name="spellcheck.onlyMorePopular">true</str>
      <str name="spellcheck.extendedResults">true</str>
      <str name="spellcheck.collate">true</str>
      <str name="spellcheck.maxCollations">100</str>
      <str name="spellcheck.maxCollationTries">5</str>
      <str name="spellcheck.count">5</str>
      <!-- filter out any collations that don't match documents -->
      <str name="spellcheck.collateParam.mm">100%</str>
```

