### PR TITLE
Handles graciously error generating back to catalog link

### DIFF
--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -163,6 +163,10 @@ module Blacklight::UrlHelperBehavior
     label ||= t('blacklight.back_to_search')
 
     link_to label, link_url, opts
+  rescue ActionController::UrlGenerationError
+    # This exception is triggered if the user's session has information that results in an
+    # invalid back to catalog link, for example if their session is corrupted.
+    link_to t('blacklight.back_to_search'), root_url
   end
 
   # Search History and Saved Searches display


### PR DESCRIPTION
This handles the case where users' session has invalid information (either a corrupt session or the URLs in the system have changed) that results in an invalid URL. In that case `link_to` throws an exception and prevents the *page* from rendering. 

This fix handles the exception by producing a link that goes back to the root rather than crashing the rendering process.