### PR TITLE
check current_user is defined in agent_is crawler

### DIFF
--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -73,7 +73,7 @@ module Blacklight::SearchContext
   #
   def agent_is_crawler?
     crawler_proc = blacklight_config.crawler_detector
-    return false if crawler_proc.nil? || current_user.present?
+    return false if crawler_proc.nil? || (defined?(current_user) && current_user.present?)
 
     crawler_proc.call(request)
   end


### PR DESCRIPTION
I did as suggested in https://github.com/projectblacklight/blacklight/pull/1736#issuecomment-335977563 to disable search tracking, ie `config.crawler_detector = lambda { |req| true }`, but that resulted in:
```
NameError in CatalogController#index
undefined local variable or method `current_user' for #<CatalogController:0x0000000000ceb8>

Did you mean?
current_or_guest_user
Extracted source (around line #76):
              
74  def agent_is_crawler?
75    crawler_proc = blacklight_config.crawler_detector
76    return false if crawler_proc.nil? || current_user.present?
77
78    crawler_proc.call(request)
79  end

Rails.root: /src/blacklightapp

Application Trace | Framework Trace | Full Trace
blacklight (7.13.2) app/controllers/concerns/blacklight/search_context.rb:76:in `agent_is_crawler?'
blacklight (7.13.2) app/controllers/concerns/blacklight/search_context.rb:41:in `find_search_session'
blacklight (7.13.2) app/controllers/concerns/blacklight/search_context.rb:32:in `current_search_session'
blacklight (7.13.2) app/controllers/concerns/blacklight/search_context.rb:37:in `set_current_search_session'
activesupport (6.1.3.2) lib/active_support/callbacks.rb:427:in `block in make_lambda'
```
I've installed blacklight without devise, I have no need for users logging in, yet.
The patch seems to fix the issue, it just checks something called `current_user` is defined...