### PR TITLE
Remove "role=region" from nav element

### DIFF
--- a/app/components/blacklight/response/pagination_component.html.erb
+++ b/app/components/blacklight/response/pagination_component.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :nav, class: 'pagination', role: 'region', **@html_attr do %>
+<%= content_tag :section, class: 'pagination',  **@html_attr do %>
   <%= pagination %>
 <% end %>


### PR DESCRIPTION
<nav> element implies role=navigation; it can also have roles menu, menubar or tablist instead.  It can't have a role=region.