### PR TITLE
Avoid division in sass

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -12,19 +12,19 @@
     overflow: hidden;
 
     @media (max-width: breakpoint-min(sm)) {
-      max-width: breakpoint-min(sm) / 2;
+      max-width: breakpoint-min(sm) * .5;
     }
 
     @media (min-width: breakpoint-min(sm)) and (max-width: breakpoint-max(sm)) {
-      max-width: breakpoint-min(sm) / 2;
+      max-width: breakpoint-min(sm) * .5;
     }
 
     @media (min-width: breakpoint-min(md)) and (max-width: breakpoint-max(md)) {
-      max-width: breakpoint-min(md) / 2;
+      max-width: breakpoint-min(md) * .5;
     }
 
     @media (min-width: breakpoint-min(lg)) {
-      max-width: breakpoint-min(lg) / 2;
+      max-width: breakpoint-min(lg) * .5;
     }
 
     &:hover, &:active {

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -83,7 +83,7 @@
   .remove {
     color: $text-muted;
     font-weight: bold;
-    padding-left: $spacer / 2;
+    padding-left: $spacer * .5;
     text-decoration: none;
 
     &:hover {
@@ -104,7 +104,7 @@
     padding-right: 1em;
     text-indent: -15px;
     padding-left: 15px;
-    padding-bottom: $spacer / 2;
+    padding-bottom: $spacer * .5;
     @include hyphens-auto;
   }
 

--- a/app/assets/stylesheets/blacklight/_pagination.scss
+++ b/app/assets/stylesheets/blacklight/_pagination.scss
@@ -6,7 +6,7 @@
 }
 
 .record-padding {
-  margin-top: $spacer / 2;
+  margin-top: $spacer * .5;
 }
 
 .pagination {


### PR DESCRIPTION
dart-sass has deprecated division and it's recommended replacement (math.div) doesn't work with libsass, so avoid division altogether.

Fixes #2500