### PR TITLE
Guard against the page not having a no-js element

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -38,6 +38,7 @@ Blacklight.listeners().forEach(function (listener) {
 });
 Blacklight.onLoad(function () {
   const elem = document.querySelector('.no-js');
+  if (!elem) return;
   elem.classList.remove('no-js');
   elem.classList.add('js');
 });

--- a/app/javascript/blacklight/core.js
+++ b/app/javascript/blacklight/core.js
@@ -39,7 +39,10 @@ Blacklight.listeners().forEach(function(listener) {
 })
 
 Blacklight.onLoad(function () {
-  const elem = document.querySelector('.no-js')
+  const elem = document.querySelector('.no-js');
+
+  if (!elem) return;
+
   elem.classList.remove('no-js')
   elem.classList.add('js')
 })


### PR DESCRIPTION
Otherwise you get:

`Uncaught TypeError: can't access property "classList", elem is null`

Either when your app doesn't have a no-js in the first place, or Turbolinks is loading the page and doesn't replace the `<html>` element (where Blacklight puts it). 

Fixes a regression from #2489 