### PR TITLE
Fix typo in german locale

### DIFF
--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -232,7 +232,7 @@ de:
     entry_name:
       default:
         one: Eintrag
-        other: Enträge
+        other: Einträge
       grouped:
         default: 'gruppiertes Ergebnis'
 


### PR DESCRIPTION
Replace "Enträge" with "Einträge"

This typo originated from my Issue #2466... my apologies.