### PR TITLE
stop skipping check for aria-allowed-role in axe accessibility check

### DIFF
--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -11,15 +11,14 @@ RSpec.describe 'Accessibility testing', api: false, js: true do
     fill_in "q", with: 'history'
     click_button 'search'
 
-    # aria-allowed-role doesn't like nav[role="region"]
-    expect(page).to be_accessible(skipping: ['aria-allowed-role'])
+    expect(page).to be_accessible
 
     within '.card.blacklight-language_ssim' do
       click_button 'Language'
       click_link "Tibetan"
     end
 
-    expect(page).to be_accessible(skipping: ['aria-allowed-role'])
+    expect(page).to be_accessible
   end
 
   it 'validates the single results page' do


### PR DESCRIPTION
The axe check is back in #2511. This exception should hopefully no longer necessary after #2491