### PR TITLE
Represent facet.missing facets with an explicit internal representation

### DIFF
--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -63,14 +63,10 @@ module Blacklight
 
       Deprecation.silence(Blacklight::SearchState) do
         @search_state.filters.map do |facet|
-          missing_facet = @search_state.params.dig("f", "-#{facet.key}:").present?
           facet.values.map do |val|
-            next if val.blank? && !missing_facet
+            next if val.blank?
 
-            if missing_facet && val.blank?
-              missing = I18n.t("blacklight.search.facets.missing")
-              yield facet_item_presenter(facet.config, missing, facet.key)
-            elsif val.is_a?(Array)
+            if val.is_a?(Array)
               yield inclusive_facet_item_presenter(facet.config, val, facet.key) if val.any?(&:present?)
             else
               yield facet_item_presenter(facet.config, val, facet.key)

--- a/app/presenters/blacklight/facet_item_presenter.rb
+++ b/app/presenters/blacklight/facet_item_presenter.rb
@@ -56,6 +56,8 @@ module Blacklight
         view_context.public_send(facet_config.helper_method, label_value)
       elsif facet_config.query && facet_config.query[label_value]
         facet_config.query[label_value][:label]
+      elsif value.is_a?(Hash) && value[:missing]
+        I18n.t("blacklight.search.facets.missing")
       elsif facet_config.date
         localization_options = facet_config.date == true ? {} : facet_config.date
         I18n.l(Time.zone.parse(label_value), **localization_options)

--- a/app/presenters/blacklight/facet_item_presenter.rb
+++ b/app/presenters/blacklight/facet_item_presenter.rb
@@ -56,7 +56,7 @@ module Blacklight
         view_context.public_send(facet_config.helper_method, label_value)
       elsif facet_config.query && facet_config.query[label_value]
         facet_config.query[label_value][:label]
-      elsif value.is_a?(Hash) && value[:missing]
+      elsif value == Blacklight::SearchState::FilterField::MISSING
         I18n.t("blacklight.search.facets.missing")
       elsif facet_config.date
         localization_options = facet_config.date == true ? {} : facet_config.date

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -48,5 +48,7 @@ module Blacklight
     config.action_dispatch.rescue_responses["Blacklight::Exceptions::RecordNotFound"] = :not_found
 
     config.enable_search_bar_autofocus = false
+
+    config.facet_missing_param = '[* TO *]'
   end
 end

--- a/lib/blacklight/search_state/filter_field.rb
+++ b/lib/blacklight/search_state/filter_field.rb
@@ -25,7 +25,9 @@ module Blacklight
       def add(item)
         new_state = search_state.reset_search
 
-        if item.respond_to?(:fq)
+        if item.try(:missing)
+          # if this is a 'missing' facet value, the :fq is only for backwards compatibility
+        elsif item.respond_to?(:fq)
           Array(item.fq).each do |f, v|
             new_state = new_state.filter(f).add(v)
           end
@@ -35,21 +37,28 @@ module Blacklight
           return new_state.filter(item.field).add(item)
         end
 
+        url_key = key
         params = new_state.params
         param = :f
         value = as_url_parameter(item)
+
+        if value.is_a?(Hash) && value[:missing]
+          url_key = "-#{key}"
+          value = Blacklight::Engine.config.facet_missing_param
+        end
+
         param = :f_inclusive if value.is_a?(Array)
 
         # value could be a string
         params[param] = (params[param] || {}).dup
 
         if value.is_a? Array
-          params[param][key] = value
+          params[param][url_key] = value
         elsif config.single
-          params[param][key] = [value]
+          params[param][url_key] = [value]
         else
-          params[param][key] = Array(params[param][key] || []).dup
-          params[param][key].push(value)
+          params[param][url_key] = Array(params[param][url_key] || []).dup
+          params[param][url_key].push(value)
         end
 
         new_state.reset(params)
@@ -63,19 +72,26 @@ module Blacklight
           return new_state.filter(item.field).remove(item)
         end
 
+        url_key = config.key
         params = new_state.params
 
         param = :f
         value = as_url_parameter(item)
+
+        if value.is_a?(Hash) && value[:missing]
+          url_key = "-#{key}"
+          value = Blacklight::Engine.config.facet_missing_param
+        end
+
         param = :f_inclusive if value.is_a?(Array)
 
         # need to dup the facet values too,
         # if the values aren't dup'd, then the values
         # from the session will get remove in the show view...
         params[param] = (params[param] || {}).dup
-        params[param][key] = (params[param][key] || []).dup
+        params[param][url_key] = (params[param][url_key] || []).dup
 
-        collection = params[param][key]
+        collection = params[param][url_key]
         # collection should be an array, because we link to ?f[key][]=value,
         # however, Facebook (and maybe some other PHP tools) tranform that parameters
         # into ?f[key][0]=value, which Rails interprets as a Hash.
@@ -84,17 +100,9 @@ module Blacklight
           collection = collection.values
         end
 
-        params[param][key] = collection - Array(value)
-        params[param].delete(key) if params[param][key].empty?
+        params[param][url_key] = collection - Array(value)
+        params[param].delete(url_key) if params[param][url_key].empty?
         params.delete(param) if params[param].empty?
-
-        # Handle missing field queries.
-        missing = I18n.t("blacklight.search.facets.missing")
-        if (item.respond_to?(:fq) && item.fq == "-#{key}:[* TO *]") ||
-           item == missing
-          params[param].delete("-#{key}:")
-          params[param].delete(key) if params[param][key] == [""]
-        end
 
         new_state.reset(params)
       end
@@ -104,8 +112,9 @@ module Blacklight
         params = search_state.params
         f = Array(params.dig(:f, key))
         f_inclusive = [params.dig(:f_inclusive, key)] if params.dig(:f_inclusive, key).present?
+        f_missing = [{ missing: true }] if params.dig(:f, "-#{key}")&.any? { |v| v == Blacklight::Engine.config.facet_missing_param }
 
-        f + (f_inclusive || [])
+        f + (f_inclusive || []) + (f_missing || [])
       end
       delegate :any?, to: :values
 
@@ -121,6 +130,8 @@ module Blacklight
 
         if value.is_a?(Array)
           (params.dig(:f_inclusive, key) || []).to_set == value.to_set
+        elsif value.is_a?(Hash) && value.keys.first == :missing
+          (params.dig(:f, "-#{key}") || []).include?(Blacklight::Engine.config.facet_missing_param)
         else
           (params.dig(:f, key) || []).include?(value)
         end
@@ -130,7 +141,9 @@ module Blacklight
 
       # TODO: this code is duplicated in Blacklight::FacetsHelperBehavior
       def as_url_parameter(item)
-        if item.respond_to? :value
+        if item.respond_to?(:missing) && item.missing
+          { missing: true }
+        elsif item.respond_to? :value
           item.value
         else
           item

--- a/lib/blacklight/solr/response/facets.rb
+++ b/lib/blacklight/solr/response/facets.rb
@@ -172,7 +172,7 @@ module Blacklight::Solr::Response::Facets
         if value.nil?
           i.label = I18n.t(:"blacklight.search.fields.facet.missing.#{facet_field_name}", default: [:"blacklight.search.facets.missing"])
           i.fq = "-#{facet_field_name}:[* TO *]" # this explicit fq is deprecated; the missing attribute below is a better thing to check for this case
-          i.value = { missing: true }
+          i.value = Blacklight::SearchState::FilterField::MISSING
           i.missing = true
         end
 

--- a/lib/blacklight/solr/response/facets.rb
+++ b/lib/blacklight/solr/response/facets.rb
@@ -171,7 +171,8 @@ module Blacklight::Solr::Response::Facets
         # legacy solr facet.missing serialization
         if value.nil?
           i.label = I18n.t(:"blacklight.search.fields.facet.missing.#{facet_field_name}", default: [:"blacklight.search.facets.missing"])
-          i.fq = "-#{facet_field_name}:[* TO *]"
+          i.fq = "-#{facet_field_name}:[* TO *]" # this explicit fq is deprecated; the missing attribute below is a better thing to check for this case
+          i.value = { missing: true }
           i.missing = true
         end
 

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -10,7 +10,6 @@ module Blacklight::Solr
         :add_facetting_to_solr, :add_solr_fields_to_query, :add_paging_to_solr,
         :add_sorting_to_solr, :add_group_config_to_solr,
         :add_facet_paging_to_solr, :add_adv_search_clauses,
-        :add_missing_field_query,
         :add_additional_filters
       ]
     end
@@ -80,19 +79,6 @@ module Blacklight::Solr
       elsif search_state.query_param
         solr_parameters.append_query search_state.query_param
       end
-    end
-
-    ##
-    # Build and append a missing field query.
-    ##
-    def add_missing_field_query(solr_parameters)
-      return unless solr_parameters["facet.missing"]
-
-      solr_parameters[:fq] = [] if solr_parameters[:fq].blank?
-
-      solr_parameters[:fq].append(*(blacklight_params["f"] || [])
-        .select { |f| f.match(/^-/) }
-        .map { |k, _v| "#{k}[* TO *]" })
     end
 
     def add_additional_filters(solr_parameters, additional_filters = nil)
@@ -384,6 +370,8 @@ module Blacklight::Solr
       elsif value.is_a?(Range)
         prefix = "{!#{local_params.join(' ')}}" unless local_params.empty?
         "#{prefix}#{solr_field}:[#{value.first} TO #{value.last}]"
+      elsif value.is_a?(Hash) && value[:missing]
+        "-#{solr_field}:[* TO *]"
       else
         "{!term f=#{solr_field}#{(' ' + local_params.join(' ')) unless local_params.empty?}}#{convert_to_term_value(value)}"
       end

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -370,7 +370,7 @@ module Blacklight::Solr
       elsif value.is_a?(Range)
         prefix = "{!#{local_params.join(' ')}}" unless local_params.empty?
         "#{prefix}#{solr_field}:[#{value.first} TO #{value.last}]"
-      elsif value.is_a?(Hash) && value[:missing]
+      elsif value == Blacklight::SearchState::FilterField::MISSING
         "-#{solr_field}:[* TO *]"
       else
         "{!term f=#{solr_field}#{(' ' + local_params.join(' ')) unless local_params.empty?}}#{convert_to_term_value(value)}"

--- a/spec/features/facet_missing_spec.rb
+++ b/spec/features/facet_missing_spec.rb
@@ -32,8 +32,12 @@ RSpec.describe "Facet missing" do
   end
 
   context "unselecting the facet missing facet" do
-    it "unselects the missig field facet" do
-      visit root_path + "?f[-subject_geo_ssim:[* TO *]][]=&f[subject_geo_ssim][]="
+    it "unselects the missing field facet" do
+      visit root_path
+
+      within "#facet-subject_geo_ssim" do
+        click_link "[Missing]"
+      end
 
       within "#facet-subject_geo_ssim" do
         click_link "remove"
@@ -45,8 +49,12 @@ RSpec.describe "Facet missing" do
   end
 
   context "unselecting the facet missing constraint" do
-    it "unselects the missig field facet" do
-      visit root_path + "?f[-subject_geo_ssim:[* TO *]][]=&f[subject_geo_ssim][]="
+    it "unselects the missing field facet" do
+      visit root_path
+
+      within "#facet-subject_geo_ssim" do
+        click_link "[Missing]"
+      end
 
       within ".filter-subject_geo_ssim" do
         click_link "Remove constraint Region: [Missing]"

--- a/spec/lib/blacklight/search_state/filter_field_spec.rb
+++ b/spec/lib/blacklight/search_state/filter_field_spec.rb
@@ -162,28 +162,14 @@ RSpec.describe Blacklight::SearchState::FilterField do
 
     context "With facet.missing field" do
       let(:params) do
-        { f: { some_field: [""], "-some_field:": [""] } }
+        { f: { "-some_field": ["[* TO *]"] } }
       end
 
       it "removes facet.missing facet params" do
         filter = search_state.filter("some_field")
-        new_state = filter.remove(OpenStruct.new(fq: "-some_field:[* TO *]"))
+        new_state = filter.remove(OpenStruct.new(key: 'some_field', missing: true))
 
-        expect(new_state.params).to eq("f" => {})
-      end
-    end
-
-    context "With facet.missing field value" do
-      let(:params) do
-        { f: { some_field: [""], "-some_field:": [""] } }
-      end
-
-      it "removes facet.missing facet params" do
-        missing = I18n.t("blacklight.search.facets.missing")
-        filter = search_state.filter("some_field")
-        new_state = filter.remove(missing)
-
-        expect(new_state.params).to eq("f" => {})
+        expect(new_state.params).to eq({})
       end
     end
   end

--- a/spec/models/blacklight/solr/response/facets_spec.rb
+++ b/spec/models/blacklight/solr/response/facets_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Blacklight::Solr::Response::Facets, api: true do
     end
 
     it "marks the facet.missing field with a human-readable label and fq" do
-      missing = subject.aggregations["some_field"].items.find { |i| i.value.nil? }
+      missing = subject.aggregations["some_field"].items.find(&:missing)
 
       expect(missing.label).to eq "[Missing]"
       expect(missing.fq).to eq "-some_field:[* TO *]"

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
     it "uses the class-level default_processor_chain" do
       expect(subject.processor_chain).to eq search_builder_class.default_processor_chain
     end
-
-    it "appends the :add_missing_field_query processor" do
-      expect(subject.processor_chain).to include(:add_missing_field_query)
-    end
   end
 
   context 'with merged parameters from the defaults + the search field' do
@@ -824,15 +820,6 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
     it 'adds additional query filters on the search' do
       subject.where(id: [1, 2, 3])
       expect(subject.to_hash).to include q: '{!lucene}id:(1 OR 2 OR 3)'
-    end
-  end
-
-  describe "#add_missing_field_query" do
-    it "precesses facet.missing query" do
-      subject.with("f" => { "-hello:" => [""] })
-      solr_params = { "facet.missing" => true, fq: [] }
-
-      expect(subject.add_missing_field_query(solr_params)).to eq(["-hello:[* TO *]"])
     end
   end
 end


### PR DESCRIPTION
This PR extracts a consistent internal representation for the "facet missing" facet item and addresses some url parameter parsing that leaked out of the `SearchState` into query building and constraint display.

I've also changed the URL representation from 2 kinda strange-looking parameters (`f[-subject_geo_ssim:[* TO *]][]=` and `f[subject_geo_ssim][]=`) to 1 (`f[-subject_geo_ssim][]=[* TO *]`). I'm not sure to what extent we need to support the previous url representation here or not 🤷‍♂️ 
