### PR TITLE
Load test scaffolding first

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,6 @@ SimpleCov.start do
   add_filter "/spec/"
 end
 
-require 'rsolr'
-require 'blacklight'
-
 require 'engine_cart'
 EngineCart.load_application!
 
@@ -24,6 +21,9 @@ require 'webdrivers'
 require 'selenium-webdriver'
 require 'equivalent-xml'
 require 'axe-rspec'
+
+require 'rsolr'
+require 'blacklight'
 
 Capybara.javascript_driver = :headless_chrome
 


### PR DESCRIPTION
jbuilder 2.11.3 has a hard, but undeclared dependency on action_view now, so make sure we don't try to load it up (through `lib/blacklight.rb` unless the rest of the testing scaffolding loads)