### PR TITLE
Fix modal close button for bootstrap 5

### DIFF
--- a/app/components/blacklight/system/modal_component.html.erb
+++ b/app/components/blacklight/system/modal_component.html.erb
@@ -6,8 +6,8 @@
       <h1 class="modal-title"><%= title %></h1>
     <% end) %>
 
-    <button type="button" class="blacklight-modal-close btn-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
-      <span aria-hidden="true">&times;</span>
+    <button type="button" class="blacklight-modal-close btn-close close" data-bs-dismiss="modal" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+      <span aria-hidden="true" class="visually-hidden">&times;</span>
     </button>
   </div>
 


### PR DESCRIPTION
Fixes: #2518

This rebases #2519 on top of `main`