### PR TITLE
Move the class configuration defaults into Blacklight::Configuration.default_values

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,6 +1,6 @@
 <% # container for a single doc -%>
 <% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type) %>
-<%= render (view_config.document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
+<%= render view_config.document_component.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
   <% view_config.partials.each do |partial| %>
     <% component.partial do %>
       <%= render_document_partial document, partial, component: component, document_counter: document_counter %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -2,7 +2,8 @@
 
 <% @page_title = t('blacklight.search.show.title', document_title: document_presenter(@document).html_title, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
-<%= render (blacklight_config.view_config(:show).document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(@document), component: :div, show: true) do |component| %>
+
+<%= render (blacklight_config.view_config(:show).document_component).new(presenter: document_presenter(@document), component: :div, show: true) do |component| %>
   <% component.title(as: 'h1', classes: '', link_to_document: false, actions: false) %>
   <% component.footer do %>
     <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -48,17 +48,19 @@ module Blacklight
             ##
             # == Response models
             ## Class for sending and receiving requests from a search index
-            repository_class: nil,
+            repository_class: Blacklight::Solr::Repository,
             ## Class for converting Blacklight parameters to request parameters for the repository_class
-            search_builder_class: nil,
+            search_builder_class: ::SearchBuilder,
             # model that maps index responses to the blacklight response model
-            response_model: nil,
+            response_model: Blacklight::Solr::Response,
             # the model to use for each response document
-            document_model: nil,
+            document_model: ::SolrDocument,
+            # the factory that builds document
+            document_factory: Blacklight::DocumentFactory,
             # Class for paginating long lists of facet fields
-            facet_paginator_class: nil,
+            facet_paginator_class: Blacklight::Solr::FacetPaginator,
             # repository connection configuration
-            connection_config: nil,
+            connection_config: Blacklight.connection_config,
             ##
             # == Blacklight view configuration
             navbar: OpenStructWithHashAccess.new(partials: {}),
@@ -184,50 +186,8 @@ module Blacklight
       @view_config ||= {}
     end
 
-    def document_model
-      super || ::SolrDocument
-    end
-
-    # A class that builds documents
-    def document_factory
-      super || Blacklight::DocumentFactory
-    end
-
-    # only here to support alias_method
-    def document_model=(*args)
-      super
-    end
-
-    def response_model
-      super || Blacklight::Solr::Response
-    end
-
-    def response_model=(*args)
-      super
-    end
-
-    def repository_class
-      super || Blacklight::Solr::Repository
-    end
-
     def repository
       repository_class.new(self)
-    end
-
-    def connection_config
-      super || Blacklight.connection_config
-    end
-
-    def search_builder_class
-      super || locate_search_builder_class
-    end
-
-    def locate_search_builder_class
-      ::SearchBuilder
-    end
-
-    def facet_paginator_class
-      super || Blacklight::Solr::FacetPaginator
     end
 
     def default_per_page

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -68,9 +68,8 @@ module Blacklight
             index: ViewConfig::Index.new(
               # document presenter class used by helpers and views
               document_presenter_class: nil,
-              # component class used to render a document; defaults to Blacklight::DocumentComponent,
-              #   but can be set explicitly to avoid any legacy behavior
-              document_component: nil,
+              # component class used to render a document
+              document_component: Blacklight::DocumentComponent,
               # solr field to use to render a document title
               title_field: nil,
               # solr field to use to render format-specific partials
@@ -88,7 +87,7 @@ module Blacklight
             show: ViewConfig::Show.new(
               # document presenter class used by helpers and views
               document_presenter_class: nil,
-              document_component: nil,
+              document_component: Blacklight::DocumentComponent,
               display_type_field: nil,
               # Default route parameters for 'show' requests.
               # Set this to a hash with additional arguments to merge into the route,

--- a/lib/blacklight/open_struct_with_hash_access.rb
+++ b/lib/blacklight/open_struct_with_hash_access.rb
@@ -53,18 +53,19 @@ module Blacklight
       self.class.new @table.deep_dup
     end
 
-    if Rails.version < '6'
-      # Ported from Rails 6 to fix an incompatibility with ostruct
-      def try(method_name = nil, *args, &block)
-        if method_name.nil? && block_given?
-          if b.arity.zero?
-            instance_eval(&block)
-          else
-            yield self
-          end
-        elsif respond_to?(method_name)
-          public_send(method_name, *args, &b)
+    def deep_transform_values(&method)
+      self.class.new @table.deep_transform_values(&method)
+    end
+
+    def try(method_name = nil, *args, &block)
+      if method_name.nil? && block_given?
+        if b.arity.zero?
+          instance_eval(&block)
+        else
+          yield self
         end
+      elsif respond_to?(method_name)
+        public_send(method_name, *args, &b)
       end
     end
   end

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe "Blacklight::Configuration", api: true do
     end
 
     it "has ordered hashes for field configuration" do
-      expect(config.facet_fields).to be_a_kind_of ActiveSupport::OrderedHash
-      expect(config.index_fields).to be_a_kind_of ActiveSupport::OrderedHash
-      expect(config.show_fields).to be_a_kind_of ActiveSupport::OrderedHash
-      expect(config.search_fields).to be_a_kind_of ActiveSupport::OrderedHash
-      expect(config.show_fields).to be_a_kind_of ActiveSupport::OrderedHash
-      expect(config.search_fields).to be_a_kind_of ActiveSupport::OrderedHash
-      expect(config.sort_fields).to be_a_kind_of ActiveSupport::OrderedHash
+      expect(config.facet_fields).to be_a_kind_of Hash
+      expect(config.index_fields).to be_a_kind_of Hash
+      expect(config.show_fields).to be_a_kind_of Hash
+      expect(config.search_fields).to be_a_kind_of Hash
+      expect(config.show_fields).to be_a_kind_of Hash
+      expect(config.search_fields).to be_a_kind_of Hash
+      expect(config.sort_fields).to be_a_kind_of Hash
     end
   end
 
@@ -158,18 +158,6 @@ RSpec.describe "Blacklight::Configuration", api: true do
       it "does not dup response_model or document_model" do
         expect(config_copy.response_model).to eq Hash
         expect(config_copy.document_model).to eq Array
-      end
-    end
-
-    context "when model classes are not set" do
-      it "leaves response_model and document_model empty" do
-        expect(config_copy.fetch(:response_model, nil)).to be_nil
-        expect(config_copy.fetch(:document_model, nil)).to be_nil
-      end
-
-      it "returns default classes" do
-        expect(config_copy.response_model).to eq Blacklight::Solr::Response
-        expect(config_copy.document_model).to eq SolrDocument
       end
     end
 


### PR DESCRIPTION
And, now that we've dropped Rails 5.x, we can use `#deep_transform_values` directly.