### PR TITLE
Prevent deprecation warnings in tests

### DIFF
--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "catalog/index.json", api: true do
   let(:presenter) { Blacklight::JsonPresenter.new(response, config) }
 
   let(:hash) do
-    render template: "catalog/index.json", format: :json
+    render template: "catalog/index", formats: [:json]
     JSON.parse(rendered).with_indifferent_access
   end
 

--- a/spec/views/catalog/show.json.jbuilder_spec.rb
+++ b/spec/views/catalog/show.json.jbuilder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "catalog/show.json" do
   end
 
   let(:hash) do
-    render template: "catalog/show.json", format: :json
+    render template: "catalog/show", formats: [:json]
     JSON.parse(rendered).with_indifferent_access
   end
 


### PR DESCRIPTION
Previously we were seeing:
```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: catalog/show.json (called from block (2 levels) in <top (required)> at /home/runner/work/blacklight/blacklight/spec/views/catalog/show.json.jbuilder_spec.rb:14
```