### PR TITLE
Deprecate passing no arguments to render_document_index

### DIFF
--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -9,7 +9,10 @@ module Blacklight::RenderPartialsHelperBehavior
   # @param [Hash] locals to pass to the render call
   # @return [String]
   def render_document_index documents = nil, locals = {}
-    documents ||= @response.documents
+    unless documents
+      Deprecation.warn(self, "Calling render_document_index without documents is deprecated and will be removed in version 8")
+      documents = @response.documents
+    end
     render_document_index_with_view(document_index_view_type, documents, locals)
   end
 

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -14,7 +14,7 @@
     <%= render 'sort_and_per_page' %>
     <%= render partial: 'tools', locals: { document_list: @response.documents } %>
     <h2 class='section-heading sr-only visually-hidden'><%= t('blacklight.bookmarks.list_title') %></h2>
-    <%= render_document_index %>
+    <%= render_document_index @response.documents %>
     <%= render 'results_pagination' %>
   <% end %>
 </div>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -26,7 +26,7 @@
 <%- elsif render_grouped_response? %>
   <%= Deprecation.silence(Blacklight::RenderPartialsHelperBehavior) { render_grouped_document_index } %>
 <%- else %>
-  <%= render_document_index %>
+  <%= render_document_index @response.documents %>
 <%- end %>
 
 <%= render 'results_pagination' %>


### PR DESCRIPTION
So that this can be removed in v8.0 Ref #2527