### PR TITLE
Normalize the facet component

### DIFF
--- a/app/components/blacklight/facet_component.rb
+++ b/app/components/blacklight/facet_component.rb
@@ -22,10 +22,8 @@ module Blacklight
     end
 
     def call
-      component = @field_config.component.presence || Blacklight::FacetFieldListComponent
-
       render(
-        component.new(
+        @field_config.component.new(
           facet_field: helpers.facet_field_presenter(@field_config, @display_facet),
           layout: @layout
         )

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -71,6 +71,7 @@ module Blacklight
       self.if = show if self.if.nil?
       self.index_range = 'A'..'Z' if index_range == true
       self.presenter ||= Blacklight::FacetFieldPresenter
+      self.component = Blacklight::FacetFieldListComponent if component.nil? || component == true
 
       super
 

--- a/spec/lib/blacklight/configuration/facet_field_spec.rb
+++ b/spec/lib/blacklight/configuration/facet_field_spec.rb
@@ -2,19 +2,40 @@
 
 RSpec.describe Blacklight::Configuration::FacetField do
   describe '#normalize!' do
-    it 'preserves existing properties' do
-      expected = double
-      subject.presenter = expected
+    context 'with existing properties' do
+      let(:expected_presenter) { double }
+      let(:expected_component) { double }
 
-      subject.normalize!
+      before do
+        subject.presenter = expected_presenter
+        subject.component = expected_component
+      end
 
-      expect(subject.presenter).to eq expected
+      it 'preserves existing properties' do
+        subject.normalize!
+
+        expect(subject.presenter).to eq expected_presenter
+        expect(subject.component).to eq expected_component
+      end
     end
 
-    it 'adds a default presenter' do
+    it 'adds a default presenter and component' do
       subject.normalize!
 
       expect(subject.presenter).to eq Blacklight::FacetFieldPresenter
+      expect(subject.component).to eq Blacklight::FacetFieldListComponent
+    end
+
+    context 'when component is set to true' do
+      before do
+        subject.component = true
+      end
+
+      it 'casts to the default component' do
+        subject.normalize!
+
+        expect(subject.component).to eq Blacklight::FacetFieldListComponent
+      end
     end
   end
 end


### PR DESCRIPTION
So that people who still have `component: true` on their facet field configuration, won't see an error.