### PR TITLE
Remove unnecessary dependency rspec-its

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rsolr", ">= 1.0.6", "< 3"  # Library for interacting with rSolr.
   s.add_development_dependency "rspec-rails", "~> 5.0"
-  s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency 'axe-core-rspec'
   s.add_development_dependency "capybara", '~> 3'

--- a/spec/models/blacklight/facet_paginator_spec.rb
+++ b/spec/models/blacklight/facet_paginator_spec.rb
@@ -13,44 +13,89 @@ RSpec.describe Blacklight::FacetPaginator, api: true do
   let(:limit) { 6 }
 
   context 'on the first page of two pages' do
-    subject { described_class.new(seven_facet_values, limit: limit) }
+    subject(:paginator) { described_class.new(seven_facet_values, limit: limit) }
 
     it { is_expected.to be_first_page }
     it { is_expected.not_to be_last_page }
-    its(:current_page) { is_expected.to eq 1 }
-    its(:prev_page) { is_expected.to be_nil }
-    its(:next_page) { is_expected.to eq 2 }
+
+    describe '#current_page' do
+      subject { paginator.current_page }
+
+      it { is_expected.to eq 1 }
+    end
+
+    describe '#prev_page' do
+      subject { paginator.prev_page }
+
+      it { is_expected.to be_nil }
+    end
+
+    describe '#next_page' do
+      subject { paginator.next_page }
+
+      it { is_expected.to eq 2 }
+    end
 
     it 'limits items to limit, if limit is smaller than items.length' do
-      expect(subject.items.size).to eq 6
+      expect(paginator.items.size).to eq 6
     end
   end
 
   context 'on the last page of two pages' do
-    subject { described_class.new([f7], offset: 6, limit: limit) }
+    subject(:paginator) { described_class.new([f7], offset: 6, limit: limit) }
 
     it { is_expected.not_to be_first_page }
     it { is_expected.to be_last_page }
-    its(:current_page) { is_expected.to eq 2 }
-    its(:prev_page) { is_expected.to eq 1 }
-    its(:next_page) { is_expected.to be_nil }
+
+    describe '#current_page' do
+      subject { paginator.current_page }
+
+      it { is_expected.to eq 2 }
+    end
+
+    describe '#prev_page' do
+      subject { paginator.prev_page }
+
+      it { is_expected.to eq 1 }
+    end
+
+    describe '#next_page' do
+      subject { paginator.next_page }
+
+      it { is_expected.to be_nil }
+    end
 
     it 'returns all items when limit is greater than items.length' do
-      expect(subject.items.size).to eq 1
+      expect(paginator.items.size).to eq 1
     end
   end
 
   context 'on the second page of three pages' do
-    subject { described_class.new(seven_facet_values, offset: 6, limit: limit) }
+    subject(:paginator) { described_class.new(seven_facet_values, offset: 6, limit: limit) }
 
     it { is_expected.not_to be_first_page }
     it { is_expected.not_to be_last_page }
-    its(:current_page) { is_expected.to eq 2 }
-    its(:prev_page) { is_expected.to eq 1 }
-    its(:next_page) { is_expected.to eq 3 }
+
+    describe '#current_page' do
+      subject { paginator.current_page }
+
+      it { is_expected.to eq 2 }
+    end
+
+    describe '#prev_page' do
+      subject { paginator.prev_page }
+
+      it { is_expected.to eq 1 }
+    end
+
+    describe '#next_page' do
+      subject { paginator.next_page }
+
+      it { is_expected.to eq 3 }
+    end
 
     it 'limits items to limit, if limit is smaller than items.length' do
-      expect(subject.items.size).to eq 6
+      expect(paginator.items.size).to eq 6
     end
   end
 

--- a/spec/models/blacklight/solr/response/facets_spec.rb
+++ b/spec/models/blacklight/solr/response/facets_spec.rb
@@ -3,21 +3,59 @@
 RSpec.describe Blacklight::Solr::Response::Facets, api: true do
   describe Blacklight::Solr::Response::Facets::FacetField do
     describe "A field with default options" do
-      subject { described_class.new "my_field", [] }
+      subject(:field) { described_class.new "my_field", [] }
 
-      its(:name) { is_expected.to eq "my_field" }
-      its(:limit) { is_expected.to eq 100 }
-      its(:sort) { is_expected.to eq 'count' }
-      its(:offset) { is_expected.to eq 0 }
+      describe '#name' do
+        subject { field.name }
+
+        it { is_expected.to eq "my_field" }
+      end
+
+      describe '#limit' do
+        subject { field.limit }
+
+        it { is_expected.to eq 100 }
+      end
+
+      describe '#sort' do
+        subject { field.sort }
+
+        it { is_expected.to eq 'count' }
+      end
+
+      describe '#offset' do
+        subject { field.offset }
+
+        it { is_expected.to eq 0 }
+      end
     end
 
     describe "A field with additional options" do
-      subject { described_class.new "my_field", [], limit: 15, sort: 'alpha', offset: 23 }
+      subject(:field) { described_class.new "my_field", [], limit: 15, sort: 'alpha', offset: 23 }
 
-      its(:name) { is_expected.to eq "my_field" }
-      its(:limit) { is_expected.to eq 15 }
-      its(:sort) { is_expected.to eq 'alpha' }
-      its(:offset) { is_expected.to eq 23 }
+      describe '#name' do
+        subject { field.name }
+
+        it { is_expected.to eq "my_field" }
+      end
+
+      describe '#limit' do
+        subject { field.limit }
+
+        it { is_expected.to eq 15 }
+      end
+
+      describe '#sort' do
+        subject { field.sort }
+
+        it { is_expected.to eq 'alpha' }
+      end
+
+      describe '#offset' do
+        subject { field.offset }
+
+        it { is_expected.to eq 23 }
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ require 'engine_cart'
 EngineCart.load_application!
 
 require 'rspec/rails'
-require 'rspec/its'
 require 'rspec/collection_matchers'
 require 'capybara/rails'
 require 'webdrivers'


### PR DESCRIPTION
This was only used in 2 tests.  Having extra dependencies makes it more difficult to manage and understand the code.