### PR TITLE
Deprecate render_document_partials. 

### DIFF
--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -3,6 +3,7 @@
 module Blacklight
   class FacetFieldListComponent < ::ViewComponent::Base
     extend Deprecation
+    self.deprecation_horizon = 'blacklight 9.0'
 
     def initialize(facet_field:, layout: nil)
       @facet_field = facet_field

--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Blacklight::RenderPartialsHelperBehavior
+  extend Deprecation
+  self.deprecation_horizon = 'blacklight 9.0'
+
   ##
   # Render the document index view
   #
@@ -22,6 +25,7 @@ module Blacklight::RenderPartialsHelperBehavior
       render_document_partial(doc, action_name, locals)
     end, "\n")
   end
+  deprecation_deprecate render_document_partials: 'Render the document_component instead'
 
   ##
   # Return the list of xml for a given solr document. Doesn't safely escape for HTML.

--- a/app/views/catalog/_document.atom.builder
+++ b/app/views/catalog/_document.atom.builder
@@ -20,9 +20,8 @@ xml.entry do
 
   with_format(:html) do
     xml.summary "type" => "html" do
-      xml.text! render_document_partials(document,
-                                         blacklight_config.view_config(:atom).summary_partials,
-                                         document_counter: document_counter)
+      document_component = blacklight_config.view_config(:atom).summary_component
+      xml.text! render document_component.new(presenter: document_presenter(document), component: :div, show: true)
     end
   end
 

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -115,7 +115,7 @@ module Blacklight
                                                    atom: {
                                                      if: false, # by default, atom should not show up as an alternative view
                                                      partials: [:document],
-                                                     summary_partials: [:index]
+                                                     summary_component: Blacklight::DocumentComponent
                                                    },
                                                    rss: {
                                                      if: false, # by default, rss should not show up as an alternative view


### PR DESCRIPTION
This was only used by the atom partial renderer. We can replace this with the document component

Fixes #2537