### PR TITLE
Set field configuration default values in the normalize step of the configuration

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -5,8 +5,8 @@ module Blacklight
     renders_many :constraints
     renders_many :search_field_controls
     renders_many :search_filter_controls, (lambda do |config:, display_facet:, presenter: nil, component: nil, **kwargs|
-      presenter ||= (config.presenter || Blacklight::FacetFieldPresenter).new(config, display_facet, helpers)
-      component = component || config.advanced_search_component || Blacklight::FacetFieldCheckboxesComponent
+      presenter ||= config.presenter.new(config, display_facet, helpers)
+      component ||= config.advanced_search_component
 
       component.new(facet_field: presenter, **kwargs)
     end)

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -77,7 +77,7 @@ module Blacklight
     end
 
     def facet_item_presenter(facet_config, facet_item, facet_field)
-      Blacklight::FacetItemPresenter.new(facet_item, facet_config, helpers, facet_field)
+      (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, facet_config, helpers, facet_field)
     end
 
     def inclusive_facet_item_presenter(facet_config, facet_item, facet_field)

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -77,7 +77,7 @@ module Blacklight
     end
 
     def facet_item_presenter(facet_config, facet_item, facet_field)
-      (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, facet_config, helpers, facet_field)
+      facet_config.item_presenter.new(facet_item, facet_config, helpers, facet_field)
     end
 
     def inclusive_facet_item_presenter(facet_config, facet_item, facet_field)

--- a/app/components/blacklight/document_metadata_component.rb
+++ b/app/components/blacklight/document_metadata_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   class DocumentMetadataComponent < ::ViewComponent::Base
     renders_many :fields, (lambda do |component: nil, **kwargs|
-      (component || Blacklight::MetadataFieldComponent).new(**kwargs)
+      component.new(**kwargs)
     end)
     with_collection_parameter :fields
 
@@ -18,7 +18,7 @@ module Blacklight
       return unless fields
 
       @fields.each do |field|
-        field(component: field_component(field), field: field, show: @show, view_type: @view_type)
+        field(component: field.component, field: field, show: @show, view_type: @view_type)
       end
     end
 
@@ -27,9 +27,5 @@ module Blacklight
     end
 
     attr_reader :view_type
-
-    def field_component(field)
-      field&.component || Blacklight::MetadataFieldComponent
-    end
   end
 end

--- a/app/components/blacklight/facet_field_checkboxes_component.rb
+++ b/app/components/blacklight/facet_field_checkboxes_component.rb
@@ -17,7 +17,7 @@ module Blacklight
       return to_enum(:presenters) unless block_given?
 
       @facet_field.paginator.items.each do |item|
-        yield (@facet_field.facet_field.item_presenter || Blacklight::FacetItemPresenter).new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
+        yield @facet_field.facet_field.item_presenter.new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
       end
     end
   end

--- a/app/components/blacklight/facet_field_checkboxes_component.rb
+++ b/app/components/blacklight/facet_field_checkboxes_component.rb
@@ -17,7 +17,7 @@ module Blacklight
       return to_enum(:presenters) unless block_given?
 
       @facet_field.paginator.items.each do |item|
-        yield Blacklight::FacetItemPresenter.new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
+        yield (@facet_field.facet_field.item_presenter || Blacklight::FacetItemPresenter).new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
       end
     end
   end

--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -46,8 +46,7 @@ module Blacklight
     end
 
     def facet_item_component_class(deprecated_facet_config = nil)
-      default_component = (deprecated_facet_config || facet_config).pivot ? Blacklight::FacetItemPivotComponent : Blacklight::FacetItemComponent
-      (deprecated_facet_config || facet_config).fetch(:item_component, default_component)
+      (deprecated_facet_config || facet_config).item_component
     end
 
     def facet_config

--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -42,7 +42,7 @@ module Blacklight
     end
 
     def facet_item_presenter(facet_item, deprecated_facet_config = nil, facet_field = nil)
-      (deprecated_facet_config || facet_config).fetch(:item_presenter, Blacklight::FacetItemPresenter).new(facet_item, deprecated_facet_config || facet_config, helpers, facet_field || @facet_field.key)
+      (deprecated_facet_config || facet_config).item_presenter.new(facet_item, deprecated_facet_config || facet_config, helpers, facet_field || @facet_field.key)
     end
 
     def facet_item_component_class(deprecated_facet_config = nil)

--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -42,7 +42,7 @@ module Blacklight
     end
 
     def facet_item_presenter(facet_item, deprecated_facet_config = nil, facet_field = nil)
-      Blacklight::FacetItemPresenter.new(facet_item, deprecated_facet_config || facet_config, helpers, facet_field || @facet_field.key)
+      (deprecated_facet_config || facet_config).fetch(:item_presenter, Blacklight::FacetItemPresenter).new(facet_item, deprecated_facet_config || facet_config, helpers, facet_field || @facet_field.key)
     end
 
     def facet_item_component_class(deprecated_facet_config = nil)

--- a/app/components/blacklight/facet_item_pivot_component.rb
+++ b/app/components/blacklight/facet_item_pivot_component.rb
@@ -78,7 +78,7 @@ module Blacklight
     end
 
     def facet_item_presenter(facet_item)
-      (@facet_item.facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, @facet_item.facet_config, helpers, @facet_item.facet_field, @facet_item.search_state)
+      @facet_item.facet_config.item_presenter.new(facet_item, @facet_item.facet_config, helpers, @facet_item.facet_field, @facet_item.search_state)
     end
   end
 end

--- a/app/components/blacklight/facet_item_pivot_component.rb
+++ b/app/components/blacklight/facet_item_pivot_component.rb
@@ -78,7 +78,7 @@ module Blacklight
     end
 
     def facet_item_presenter(facet_item)
-      Blacklight::FacetItemPresenter.new(facet_item, @facet_item.facet_config, helpers, @facet_item.facet_field, @facet_item.search_state)
+      (@facet_item.facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, @facet_item.facet_config, helpers, @facet_item.facet_field, @facet_item.search_state)
     end
   end
 end

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -90,7 +90,7 @@ module Blacklight::Catalog
     @response = search_service.facet_field_response(@facet.key)
     @display_facet = @response.aggregations[@facet.field]
 
-    @presenter = (@facet.presenter || Blacklight::FacetFieldPresenter).new(@facet, @display_facet, view_context)
+    @presenter = @facet.presenter.new(@facet, @display_facet, view_context)
     @pagination = @presenter.paginator
     respond_to do |format|
       format.html do

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -4,7 +4,7 @@ module Blacklight::FacetsHelperBehavior
   delegate :facet_configuration_for_field, to: :blacklight_config
 
   def facet_field_presenter(facet_config, display_facet)
-    (facet_config.presenter || Blacklight::FacetFieldPresenter).new(facet_config, display_facet, self)
+    facet_config.presenter.new(facet_config, display_facet, self)
   end
 
   private

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -18,6 +18,6 @@ module Blacklight::FacetsHelperBehavior
   end
 
   def facet_item_presenter(facet_config, facet_item, facet_field)
-    Blacklight::FacetItemPresenter.new(facet_item, facet_config, self, facet_field)
+    (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, facet_config, self, facet_field)
   end
 end

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -18,6 +18,6 @@ module Blacklight::FacetsHelperBehavior
   end
 
   def facet_item_presenter(facet_config, facet_item, facet_field)
-    (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, facet_config, self, facet_field)
+    facet_config.item_presenter.new(facet_item, facet_config, self, facet_field)
   end
 end

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -128,8 +128,7 @@ module Blacklight
     private
 
     def field_presenter(field_config, options = {})
-      presenter_class = field_config.presenter || Blacklight::FieldPresenter
-      presenter_class.new(view_context, document, field_config, options.merge(field_presenter_options))
+      field_config.presenter.new(view_context, document, field_config, options.merge(field_presenter_options))
     end
 
     def field_presenter_options

--- a/app/presenters/blacklight/index_presenter.rb
+++ b/app/presenters/blacklight/index_presenter.rb
@@ -14,7 +14,7 @@ module Blacklight
     end
 
     def field_config(field)
-      configuration.index_fields.fetch(field) { Configuration::NullField.new(field) }
+      configuration.index_fields.fetch(field) { Configuration::NullDisplayField.new(field) }
     end
   end
 end

--- a/app/presenters/blacklight/show_presenter.rb
+++ b/app/presenters/blacklight/show_presenter.rb
@@ -10,7 +10,7 @@ module Blacklight
     end
 
     def field_config(field)
-      configuration.show_fields.fetch(field) { Configuration::NullField.new(field) }
+      configuration.show_fields.fetch(field) { Configuration::NullDisplayField.new(field) }
     end
 
     def field_presenter_options

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -16,6 +16,9 @@ module Blacklight
       autoload :SearchField
       autoload :FacetField
       autoload :SortField
+      autoload :DisplayField
+      autoload :IndexField
+      autoload :ShowField
     end
 
     include Fields

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -13,6 +13,7 @@ module Blacklight
       autoload :Fields
       autoload :Field
       autoload :NullField
+      autoload :NullDisplayField
       autoload :SearchField
       autoload :FacetField
       autoload :SortField

--- a/lib/blacklight/configuration/display_field.rb
+++ b/lib/blacklight/configuration/display_field.rb
@@ -43,6 +43,7 @@ module Blacklight
     def normalize! _blacklight_config = nil
       super
       self.presenter ||= Blacklight::FieldPresenter
+      self.component ||= Blacklight::MetadataFieldComponent
     end
   end
 end

--- a/lib/blacklight/configuration/display_field.rb
+++ b/lib/blacklight/configuration/display_field.rb
@@ -2,6 +2,12 @@
 
 module Blacklight
   class Configuration::DisplayField < Blacklight::Configuration::Field
+    def initialize(*args, **kwargs, &block)
+      super
+
+      self.presenter ||= Blacklight::FieldPresenter
+      self.component ||= Blacklight::MetadataFieldComponent
+    end
     ##
     # The following is a non-exhaustive list of display field config parameters that are used
     # by Blacklight directly. Application-specific code or plugins may add or replace
@@ -38,12 +44,5 @@ module Blacklight
     #   @return [String]
     # @!attribute separator_options
     #   @return [Hash]
-
-    # @param [Blacklight::Configuration] _blacklight_config
-    def normalize! _blacklight_config = nil
-      super
-      self.presenter ||= Blacklight::FieldPresenter
-      self.component ||= Blacklight::MetadataFieldComponent
-    end
   end
 end

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -73,6 +73,7 @@ module Blacklight
       self.if = show if self.if.nil?
       self.index_range = 'A'..'Z' if index_range == true
       self.presenter ||= Blacklight::FacetFieldPresenter
+      self.item_presenter ||= Blacklight::FacetItemPresenter
       self.component = Blacklight::FacetFieldListComponent if component.nil? || component == true
 
       super

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -65,6 +65,7 @@ module Blacklight
     # @!attribute partial
     #   @return [String] Rails view partial used to render the facet field
 
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def normalize! blacklight_config = nil
       query.stringify_keys! if query
 
@@ -75,6 +76,8 @@ module Blacklight
       self.presenter ||= Blacklight::FacetFieldPresenter
       self.item_presenter ||= Blacklight::FacetItemPresenter
       self.component = Blacklight::FacetFieldListComponent if component.nil? || component == true
+      self.item_component ||= pivot ? Blacklight::FacetItemPivotComponent : Blacklight::FacetItemComponent
+      self.advanced_search_component ||= Blacklight::FacetFieldCheckboxesComponent
 
       super
 
@@ -85,5 +88,6 @@ module Blacklight
 
       self
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   end
 end

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -56,6 +56,8 @@ module Blacklight
     # Rendering:
     # @!attribute presenter
     #   @return [Blacklight::FacetFieldPresenter]
+    # @!attribute item_presenter
+    #   @return [Blacklight::FacetItemPresenter]
     # @!attribute component
     #   @return [Blacklight::FacetFieldListComponent]
     # @!attribute item_component

--- a/lib/blacklight/configuration/null_display_field.rb
+++ b/lib/blacklight/configuration/null_display_field.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Blacklight
+  # Returned if no config is defined for a display field in the Blacklight::Configuration
+  class Configuration::NullDisplayField < Blacklight::Configuration::DisplayField
+    def initialize(field_or_hash = nil)
+      case field_or_hash
+      when String, Symbol
+        super(field: field_or_hash)
+      else
+        super
+      end
+
+      normalize!
+    end
+  end
+end

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -35,6 +35,15 @@ class Blacklight::Configuration
       )
     end
 
+    # Translate an ordinary field into the expected DisplayField object
+    def title_field=(value)
+      if value.is_a?(Blacklight::Configuration::Field) && !value.is_a?(Blacklight::Configuration::DisplayField)
+        super(Blacklight::Configuration::DisplayField.new(value.to_h))
+      else
+        super
+      end
+    end
+
     class Show < ViewConfig
       # @!attribute route
       #   @return [Hash] Default route parameters for 'show' requests.

--- a/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
   let(:facet_field) do
     instance_double(
       Blacklight::FacetFieldPresenter,
-      facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+      facet_field: Blacklight::Configuration::NullField.new(key: 'field', item_component: Blacklight::FacetItemComponent, item_presenter: Blacklight::FacetItemPresenter),
       paginator: paginator,
       key: 'field',
       label: 'Field',

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
     instance_double(
       Blacklight::FacetFieldPresenter,
       paginator: paginator,
-      facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+      facet_field: facet_config,
       key: 'field',
       label: 'Field',
       active?: false,
@@ -20,6 +20,8 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       values: []
     )
   end
+
+  let(:facet_config) { Blacklight::Configuration::NullField.new(key: 'field', item_component: Blacklight::FacetItemComponent, item_presenter: Blacklight::FacetItemPresenter) }
 
   let(:paginator) do
     instance_double(Blacklight::FacetPaginator, items: [
@@ -45,7 +47,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       instance_double(
         Blacklight::FacetFieldPresenter,
         paginator: paginator,
-        facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+        facet_field: facet_config,
         key: 'field',
         label: 'Field',
         active?: true,
@@ -65,7 +67,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       instance_double(
         Blacklight::FacetFieldPresenter,
         paginator: paginator,
-        facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+        facet_field: facet_config,
         key: 'field',
         label: 'Field',
         active?: false,
@@ -91,7 +93,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       instance_double(
         Blacklight::FacetFieldPresenter,
         paginator: paginator,
-        facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+        facet_field: facet_config,
         key: 'field',
         label: 'Field',
         active?: false,
@@ -111,7 +113,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       instance_double(
         Blacklight::FacetFieldPresenter,
         paginator: paginator,
-        facet_field: Blacklight::Configuration::NullField.new(key: 'field'),
+        facet_field: facet_config,
         key: 'field',
         label: 'Field',
         active?: false,

--- a/spec/components/blacklight/facet_item_pivot_component_spec.rb
+++ b/spec/components/blacklight/facet_item_pivot_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
   let(:facet_item) do
     instance_double(
       Blacklight::FacetItemPresenter,
-      facet_config: Blacklight::Configuration::FacetField.new(key: 'z'),
+      facet_config: facet_config,
       facet_field: 'z',
       label: 'x',
       hits: 10,
@@ -24,6 +24,8 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
       items: [OpenStruct.new(value: 'x:1', hits: 5)]
     )
   end
+
+  let(:facet_config) { Blacklight::Configuration::NullField.new(key: 'z', item_component: Blacklight::FacetItemComponent, item_presenter: Blacklight::FacetItemPresenter) }
 
   it 'links to the facet and shows the number of hits' do
     expect(rendered).to have_selector 'li'
@@ -40,7 +42,7 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
     let(:facet_item) do
       instance_double(
         Blacklight::FacetItemPresenter,
-        facet_config: Blacklight::Configuration::FacetField.new,
+        facet_config: facet_config,
         facet_field: 'z',
         label: 'x',
         hits: 10,

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -194,32 +194,32 @@ RSpec.describe CatalogHelper do
 
     it "pulls data out of a document's field" do
       blacklight_config.index.display_type_field = :type
-      doc = { type: 'book' }
+      doc = { type: 'book' }.with_indifferent_access
       expect(helper.render_document_class(doc)).to eq "blacklight-book"
     end
 
     it "supports multivalued fields" do
       blacklight_config.index.display_type_field = :type
-      doc = { type: %w[book mss] }
+      doc = { type: %w[book mss] }.with_indifferent_access
       expect(helper.render_document_class(doc)).to eq "blacklight-book blacklight-mss"
     end
 
     it "supports empty fields" do
       blacklight_config.index.display_type_field = :type
-      doc = { type: [] }
+      doc = { type: [] }.with_indifferent_access
       expect(helper.render_document_class(doc)).to be_blank
     end
 
     it "supports missing fields" do
       blacklight_config.index.display_type_field = :type
-      doc = {}
+      doc = {}.with_indifferent_access
       expect(helper.render_document_class(doc)).to be_blank
     end
 
     it "supports view-specific field configuration" do
       allow(helper).to receive(:document_index_view_type).and_return(:some_view_type)
       blacklight_config.view.some_view_type(display_type_field: :other_type)
-      doc = { other_type: "document" }
+      doc = { other_type: "document" }.with_indifferent_access
       expect(helper.render_document_class(doc)).to eq "blacklight-document"
     end
   end

--- a/spec/presenters/blacklight/document_presenter_spec.rb
+++ b/spec/presenters/blacklight/document_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Blacklight::DocumentPresenter do
   describe '#fields_to_render' do
     subject { presenter.fields_to_render.to_a }
 
-    let(:field_config) { Blacklight::Configuration::Field.new(field: 'asdf') }
+    let(:field_config) { Blacklight::Configuration::DisplayField.new(field: 'asdf') }
 
     context 'when all of the fields have values' do
       before do
@@ -30,7 +30,7 @@ RSpec.describe Blacklight::DocumentPresenter do
 
   describe '#field_value' do
     let(:field_presenter) { instance_double(Blacklight::FieldPresenter, render: 'xyz') }
-    let(:field_config) { Blacklight::Configuration::Field.new }
+    let(:field_config) { Blacklight::Configuration::DisplayField.new }
     let(:options) { { a: 1 } }
 
     it 'calls the field presenter' do

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -126,16 +126,16 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
     end
 
     it "returns the value of the field" do
-      config.show.title_field = :x
-      allow(document).to receive(:has?).with(:x).and_return(true)
-      allow(document).to receive(:fetch).with(:x, nil).and_return("value")
+      config.show.title_field = 'x'
+      allow(document).to receive(:has?).with('x').and_return(true)
+      allow(document).to receive(:fetch).with('x', nil).and_return("value")
       expect(subject.heading).to eq "value"
     end
 
     it "returns the first present value" do
-      config.show.title_field = [:x, :y]
-      allow(document).to receive(:fetch).with(:x, nil).and_return(nil)
-      allow(document).to receive(:fetch).with(:y, nil).and_return("value")
+      config.show.title_field = %w[x y]
+      allow(document).to receive(:fetch).with('x', nil).and_return(nil)
+      allow(document).to receive(:fetch).with('y', nil).and_return("value")
       expect(subject.heading).to eq "value"
     end
 
@@ -160,16 +160,16 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
     end
 
     it "returns the value of the field" do
-      config.show.html_title_field = :x
-      allow(document).to receive(:has?).with(:x).and_return(true)
-      allow(document).to receive(:fetch).with(:x, nil).and_return("value")
+      config.show.html_title_field = 'x'
+      allow(document).to receive(:has?).with('x').and_return(true)
+      allow(document).to receive(:fetch).with('x', nil).and_return("value")
       expect(subject.html_title).to eq "value"
     end
 
     it "returns the first present value" do
-      config.show.html_title_field = [:x, :y]
-      allow(document).to receive(:fetch).with(:x, nil).and_return(nil)
-      allow(document).to receive(:fetch).with(:y, nil).and_return("value")
+      config.show.html_title_field = %w[x y]
+      allow(document).to receive(:fetch).with('x', nil).and_return(nil)
+      allow(document).to receive(:fetch).with('y', nil).and_return("value")
       expect(subject.html_title).to eq "value"
     end
 

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
     end
 
     it "can use explicit field configuration" do
-      config.show.title_field = Blacklight::Configuration::Field.new(field: 'x', values: ->(*_) { 'hardcoded' })
+      config.show.title_field = Blacklight::Configuration::DisplayField.new(field: 'x', values: ->(*_) { 'hardcoded' })
       expect(subject.heading).to eq 'hardcoded'
     end
 
@@ -174,7 +174,7 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
     end
 
     it "can use explicit field configuration" do
-      config.show.html_title_field = Blacklight::Configuration::Field.new(field: 'x', values: ->(*_) { 'hardcoded' })
+      config.show.html_title_field = Blacklight::Configuration::DisplayField.new(field: 'x', values: ->(*_) { 'hardcoded' })
       expect(subject.html_title).to eq 'hardcoded'
     end
   end

--- a/spec/views/catalog/_facet_index_navigation.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_index_navigation.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'catalog/_facet_index_navigation.html.erb', type: :view do
   let(:pagination) { Blacklight::Solr::FacetPaginator.new([]) }
-  let(:facet) { Blacklight::Configuration::FacetField.new(index_range: '0'..'9') }
+  let(:facet) { Blacklight::Configuration::FacetField.new(index_range: '0'..'9', presenter: Blacklight::FacetFieldPresenter) }
   let(:display_facet) { double(items: [], offset: 0, prefix: '', sort: 'index') }
   let(:blacklight_config) { Blacklight::Configuration.new }
 


### PR DESCRIPTION
Remove some magic by explicitly configuring various components and presenters, including a new `item_presenter` configuration for facet fields.

696fd29 should be ok to backport to 7.x.


