### PR TITLE
Allow constraints to wrap across lines

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -1,6 +1,8 @@
 .constraints-container {
   @extend .mb-2;
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.25rem;
 }
 
 .applied-filter {


### PR DESCRIPTION
Fixes the problem reported in #2552

After:
<img width="1226" alt="Screen Shot 2021-11-24 at 07 29 54" src="https://user-images.githubusercontent.com/111218/143267323-c0152da0-5ccb-449e-98fe-37685c448b21.png">

Before:
<img width="1190" alt="Screen Shot 2021-11-24 at 07 30 10" src="https://user-images.githubusercontent.com/111218/143267374-e04254a0-8b2a-43dc-9194-7871c6e03bbc.png">

