### PR TITLE
Pass the full response to the facet fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Metrics/ModuleLength:
   Exclude:
     - 'app/controllers/concerns/blacklight/catalog.rb'
     - 'lib/blacklight/solr/search_builder_behavior.rb'
+    - 'lib/blacklight/solr/response/facets.rb'
 
 Metrics/AbcSize:
   Exclude:

--- a/spec/models/blacklight/solr/response/facets_spec.rb
+++ b/spec/models/blacklight/solr/response/facets_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe Blacklight::Solr::Response::Facets, api: true do
         expect(subject.aggregations['my_field'].prefix).to be_nil
       end
     end
+
+    describe '#response' do
+      it 'provides access to the full solr response' do
+        expect(subject.aggregations['my_field'].response).to eq subject
+      end
+    end
   end
 
   describe "#merge_facet" do


### PR DESCRIPTION
This is useful for some downstream use cases (e.g. range limit) that may need access to the `stats` response data to fully render the facet field for the user.