### PR TITLE
Find the modal element if it's not passed as an argument

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -442,7 +442,7 @@ Blacklight.modal.checkCloseModal = function (event) {
 
 Blacklight.modal.hide = function (el) {
   if (bootstrap.Modal.VERSION >= "5") {
-    bootstrap.Modal.getOrCreateInstance(el).hide();
+    bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('hide');
   }
@@ -450,7 +450,7 @@ Blacklight.modal.hide = function (el) {
 
 Blacklight.modal.show = function (el) {
   if (bootstrap.Modal.VERSION >= "5") {
-    bootstrap.Modal.getOrCreateInstance(el).show();
+    bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('show');
   }

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -207,7 +207,7 @@ Blacklight.modal.checkCloseModal = function(event) {
 
 Blacklight.modal.hide = function(el) {
   if (bootstrap.Modal.VERSION >= "5") {
-    bootstrap.Modal.getOrCreateInstance(el).hide();
+    bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('hide');
   }
@@ -215,7 +215,7 @@ Blacklight.modal.hide = function(el) {
 
 Blacklight.modal.show = function(el) {
   if (bootstrap.Modal.VERSION >= "5") {
-    bootstrap.Modal.getOrCreateInstance(el).show();
+    bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('show');
   }


### PR DESCRIPTION
Backport of #2580
Fixes a problem with bootstrap 5