### PR TITLE
Refactor FacetGroupComponent so it has less responsibility

### DIFF
--- a/app/components/blacklight/facet_component.rb
+++ b/app/components/blacklight/facet_component.rb
@@ -6,15 +6,23 @@ module Blacklight
   # solr field used for faceting. This renders no UI of it's own, but renders
   # the component that is configured for the facet.
   class FacetComponent < ViewComponent::Base
-    with_collection_parameter :display_facet
+    with_collection_parameter :display_facet_or_field_config
 
     # @param [Blacklight::Solr::Response::Facets::FacetField] display_facet
     # @param [Blacklight::Configuration] blacklight_config
     # @param [Boolean] layout
-    def initialize(display_facet:, blacklight_config:, layout: true)
-      @display_facet = display_facet
-      @field_config = blacklight_config.facet_configuration_for_field(@display_facet.name)
-      @layout = layout
+    def initialize(display_facet_or_field_config: nil, display_facet: nil, field_config: nil, response: nil, blacklight_config: nil, **component_args)
+      if display_facet_or_field_config.is_a?(Blacklight::Configuration::Field) || field_config
+        @field_config = display_facet_or_field_config || field_config
+        @display_facet = display_facet || (response && response.aggregations[@field_config.field])
+      else
+        @display_facet = display_facet || display_facet_or_field_config
+        @field_config = field_config || blacklight_config&.facet_configuration_for_field(@display_facet.name)
+      end
+
+      raise ArgumentError, 'You must provide one of: a) display_facet and blacklight_config, or b) field_config and response' unless @display_facet && @field_config
+
+      @component_args = component_args
     end
 
     def render?
@@ -25,7 +33,7 @@ module Blacklight
       render(
         @field_config.component.new(
           facet_field: helpers.facet_field_presenter(@field_config, @display_facet),
-          layout: @layout
+          **@component_args
         )
       )
     end

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -22,6 +22,6 @@
   </div>
 
   <div id="<%= @panel_id %>" class="facets-collapse collapse">
-    <%= render Blacklight::FacetComponent.with_collection(search_facets, blacklight_config: blacklight_config) %>
+    <%= body %>
   </div>
 <% end %>

--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -4,20 +4,45 @@ module Blacklight
   module Response
     # Render a group of facet fields
     class FacetGroupComponent < ::ViewComponent::Base
+      extend Deprecation
+
       renders_one :body
 
       # @param [Blacklight::Response] response
       # @param [Array<Blacklight::Configuration::FacetField>] fields facet fields to render
       # @param [String] title the title of the facet group section
       # @param [String] id a unique identifier for the group
-      def initialize(id:, title: nil)
+      def initialize(id:, title: nil, fields: [], response: nil)
+        @groupname = id
         @id = id ? "facets-#{id}" : 'facets'
         @title = title || I18n.t("blacklight.search.#{@id}.title")
         @panel_id = id ? "facet-panel-#{id}-collapse" : 'facet-panel-collapse'
+
+        # deprecated variables
+        @fields = fields
+        @response = response
+      end
+
+      # Provide fallback behavior for rendering this object without a body slot
+      def before_render
+        set_slot(:body, nil) { default_body } unless body
       end
 
       def render?
         body.present?
+      end
+
+      private
+
+      # @deprecated
+      def default_body
+        Deprecation.warn('Rendering the Blacklight::FacetGroupComponent without a body slot is deprecated.')
+        helpers.render(Blacklight::FacetComponent.with_collection(@fields, response: @response))
+      end
+
+      # @deprecated
+      def blacklight_config
+        helpers.blacklight_config
       end
     end
   end

--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -4,44 +4,20 @@ module Blacklight
   module Response
     # Render a group of facet fields
     class FacetGroupComponent < ::ViewComponent::Base
+      renders_one :body
+
       # @param [Blacklight::Response] response
       # @param [Array<Blacklight::Configuration::FacetField>] fields facet fields to render
       # @param [String] title the title of the facet group section
       # @param [String] id a unique identifier for the group
-      def initialize(response:, fields: [], title: nil, id: nil)
-        @response = response
-        @fields = fields
-        @title = title
+      def initialize(id:, title: nil)
         @id = id ? "facets-#{id}" : 'facets'
+        @title = title || I18n.t("blacklight.search.#{@id}.title")
         @panel_id = id ? "facet-panel-#{id}-collapse" : 'facet-panel-collapse'
       end
 
       def render?
-        search_facets.any? { |display_facet| should_render_facet?(display_facet) }
-      end
-
-      # @return [Array<Blacklight::Solr::Response::Facets::FacetField>]
-      def search_facets
-        @fields.map { |field| @response.aggregations[field.field] }.compact
-      end
-
-      delegate :blacklight_config, to: :helpers
-
-      ##
-      # Determine if Blacklight should render the display_facet or not
-      #
-      # By default, only render facets with items.
-      #
-      # @param [Blacklight::Solr::Response::Facets::FacetField] display_facet
-      # @return [Boolean]
-      def should_render_facet? display_facet
-        return false if display_facet.items.blank?
-
-        helpers.should_render_field?(facet_config_for(display_facet.name), display_facet)
-      end
-
-      def facet_config_for(name)
-        @fields.select { |field| field.field == name }
+        body.present?
       end
     end
   end

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,8 +1,9 @@
 <% # container for facet groups -%>
 <% blacklight_config.facet_group_names.each do |groupname| %>
-  <%= render Blacklight::Response::FacetGroupComponent.new(id: groupname) do |component| %>
+  <% fields = blacklight_config.facet_fields_in_group(groupname) %>
+  <%= render Blacklight::Response::FacetGroupComponent.new(id: groupname, fields: fields, response: @response) do |component| %>
     <% component.body do %>
-      <%= render Blacklight::FacetComponent.with_collection(blacklight_config.facet_fields_in_group(groupname), response: @response) %>
+      <%= render Blacklight::FacetComponent.with_collection(fields, response: @response) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,8 +1,8 @@
 <% # container for facet groups -%>
 <% blacklight_config.facet_group_names.each do |groupname| %>
-  <%= render Blacklight::Response::FacetGroupComponent.new(
-    response: @response,
-    id: groupname,
-    fields: blacklight_config.facet_fields_in_group(groupname),
-    title: groupname.present? ? t("blacklight.search.facets-#{groupname}.title") : t('blacklight.search.facets.title')) %>
+  <%= render Blacklight::Response::FacetGroupComponent.new(id: groupname) do |component| %>
+    <% component.body do %>
+      <%= render Blacklight::FacetComponent.with_collection(blacklight_config.facet_fields_in_group(groupname), response: @response) %>
+    <% end %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This PR refactors the `FacetGroupComponent` so it is only responsible for providing the expand/collapse behavior and general layout for facet groups, and allows the render-er to provide any appropriate body content.

This has a couple benefits, but most particularly gets the facet group out of the business of needing to know how facets are rendered and delegates that back to the facet components where it arguably belongs.