### PR TITLE
Remove unnecessary dependency on rails-ujs

### DIFF
--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -32,7 +32,6 @@ module Blacklight
       create_file 'app/assets/javascripts/application.js' do
         <<~CONTENT
           //= require jquery3
-          //= require rails-ujs
           //= require turbolinks
           //
           // Required by Blacklight


### PR DESCRIPTION
Rails-ujs is not part of Rails 7, and Blacklight doesn't need it anyway