### PR TITLE
Separate out handling of Solr timeout errors with it's own exception class

### DIFF
--- a/lib/blacklight/exceptions.rb
+++ b/lib/blacklight/exceptions.rb
@@ -16,6 +16,8 @@ module Blacklight
 
     class ECONNREFUSED < ::Errno::ECONNREFUSED; end
 
+    class SolrTimeout < Timeout::Error; end
+
     class IconNotFound < StandardError
     end
   end

--- a/lib/blacklight/exceptions.rb
+++ b/lib/blacklight/exceptions.rb
@@ -16,7 +16,7 @@ module Blacklight
 
     class ECONNREFUSED < ::Errno::ECONNREFUSED; end
 
-    class SolrTimeout < Timeout::Error; end
+    class RepositoryTimeout < Timeout::Error; end
 
     class IconNotFound < StandardError
     end

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -77,7 +77,12 @@ module Blacklight::Solr
         Blacklight.logger&.debug("Solr response: #{solr_response.inspect}") if defined?(::BLACKLIGHT_VERBOSE_LOGGING) && ::BLACKLIGHT_VERBOSE_LOGGING
         solr_response
       end
+    rescue *[(defined?(RSolr::Error::Timeout) ? RSolr::Error::Timeout : nil)].compact => e
+      # RSolr 2.4.0+ has a RSolr::Error::Timeout that we'd like to treat specially instead of
+      # lumping into RSolr::Error::Http
+      raise Blacklight::Exceptions::SolrTimeout, "Timeout connecting to Solr instance using #{connection.inspect}: #{e.inspect}"
     rescue Errno::ECONNREFUSED => e
+      # intended for and likely to be a RSolr::Error:ConnectionRefused, specifically.
       raise Blacklight::Exceptions::ECONNREFUSED, "Unable to connect to Solr instance using #{connection.inspect}: #{e.inspect}"
     rescue RSolr::Error::Http => e
       raise Blacklight::Exceptions::InvalidRequest, e.message

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -80,7 +80,7 @@ module Blacklight::Solr
     rescue *[(defined?(RSolr::Error::Timeout) ? RSolr::Error::Timeout : nil)].compact => e
       # RSolr 2.4.0+ has a RSolr::Error::Timeout that we'd like to treat specially instead of
       # lumping into RSolr::Error::Http
-      raise Blacklight::Exceptions::SolrTimeout, "Timeout connecting to Solr instance using #{connection.inspect}: #{e.inspect}"
+      raise Blacklight::Exceptions::RepositoryTimeout, "Timeout connecting to Solr instance using #{connection.inspect}: #{e.inspect}"
     rescue Errno::ECONNREFUSED => e
       # intended for and likely to be a RSolr::Error:ConnectionRefused, specifically.
       raise Blacklight::Exceptions::ECONNREFUSED, "Unable to connect to Solr instance using #{connection.inspect}: #{e.inspect}"

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -385,7 +385,6 @@ RSpec.describe Blacklight::SearchService, api: true do
   end
 
   it "raises a Blacklight exception if RSolr raises a timeout error connecting to Solr instance" do
-    # rsolr api is mess, let's
     rsolr_timeout = RSolr::Error::Timeout.new(nil, nil)
     allow(rsolr_timeout).to receive(:to_s).and_return("mocked RSolr timeout")
 

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe Blacklight::SearchService, api: true do
     allow(rsolr_timeout).to receive(:to_s).and_return("mocked RSolr timeout")
 
     allow(blacklight_solr).to receive(:send_and_receive).and_raise(rsolr_timeout)
-    expect { service.repository.search }.to raise_exception(Blacklight::Exceptions::SolrTimeout, /Timeout connecting to Solr instance/)
+    expect { service.repository.search }.to raise_exception(Blacklight::Exceptions::RepositoryTimeout, /Timeout connecting to Solr instance/)
   end
 
   describe "#previous_and_next_documents_for_search" do

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -384,6 +384,15 @@ RSpec.describe Blacklight::SearchService, api: true do
     expect { service.repository.search }.to raise_exception(/Unable to connect to Solr instance/)
   end
 
+  it "raises a Blacklight exception if RSolr raises a timeout error connecting to Solr instance" do
+    # rsolr api is mess, let's
+    rsolr_timeout = RSolr::Error::Timeout.new(nil, nil)
+    allow(rsolr_timeout).to receive(:to_s).and_return("mocked RSolr timeout")
+
+    allow(blacklight_solr).to receive(:send_and_receive).and_raise(rsolr_timeout)
+    expect { service.repository.search }.to raise_exception(Blacklight::Exceptions::SolrTimeout, /Timeout connecting to Solr instance/)
+  end
+
   describe "#previous_and_next_documents_for_search" do
     let(:user_params) { { q: '', per_page: 100 } }
 


### PR DESCRIPTION
## context

Almost any RSolr exception is wrapped by Blacklight in a `Blacklight::Exceptions::InvalidRequest`

A Blacklight Catalog controller [rescues](https://github.com/projectblacklight/blacklight/blob/main/app/controllers/concerns/blacklight/catalog.rb#L21) this exception with a [method](https://github.com/projectblacklight/blacklight/blob/main/app/controllers/concerns/blacklight/catalog.rb#L282-L299) that just re-displays the search page, with the message "Sorry, I don't understand your search."

"Connection refused" errors are handled differently -- which is good, it would make no sense to prompt the user to search again with "Sorry, I don't understand your search" to network errors like connection refused.

What about a timeout error, where Solr did not return in a response within the timeout value RSolr had configured?  Prior to this PR, that was handled the same as any `Blacklight::Exceptions::InvalidRequest` -- redisplay search page to the user, with message "Sorry, I don't understand your search."

That is not a desirable UX, and also causes Solr timeout errors to generally not make it to many error monitoring and logging systems, since Blacklight rescues them and displays a 200.

## change

With the release of RSolr 2.4.0, RSolr uses a specific exception class to raise timeout errors, so Blacklight can rescue them and handle them differently.

After this PR, they are handled analogously to connection refused errors, with a custom exception that won't be rescued as a `Blacklight::Exceptions::InvalidRequest`.

a `defined?` check is done so Blacklight can still work with earlier versions of RSolr, and just won't do this new rescue.

## weird code in test

RSolr::Error api has some really rough edges, which requires some weirdness in setting up the test.

## to be done in future

I formatted the message of this exception just like the existing `Blacklight::Exceptions::ECONNREFUSED`... even though that formatting isn't necessarily so useful, there's a lot of stuff in there.

But I opted to do it consistently.
