### PR TITLE
Deprecate engine config keys

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: [2.7, 3.0.3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.0]
+        ruby: [3.0.3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: [2.7, 3.0.3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0.3]
+        ruby: [2.7, '3.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.0.3]
+        ruby: ['3.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0.3]
+        ruby: [2.7, '3.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -15,7 +15,7 @@ module Blacklight::Bookmarks
     before_action :verify_user
 
     blacklight_config.track_search_session = false
-    blacklight_config.http_method = Blacklight::Engine.config.bookmarks_http_method
+    blacklight_config.http_method = Blacklight::Engine.config.blacklight.bookmarks_http_method
     blacklight_config.add_results_collection_tool(:clear_bookmarks_widget)
 
     blacklight_config.show.document_actions[:bookmark].if = false if blacklight_config.show.document_actions[:bookmark]

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -294,13 +294,13 @@ module Blacklight::Catalog
   end
 
   def sms_mappings
-    Blacklight::Engine.config.sms_mappings
+    Blacklight::Engine.config.blacklight.sms_mappings
   end
 
   def validate_email_params
     if params[:to].blank?
       flash[:error] = I18n.t('blacklight.email.errors.to.blank')
-    elsif !params[:to].match(Blacklight::Engine.config.email_regexp)
+    elsif !params[:to].match(Blacklight::Engine.config.blacklight.email_regexp)
       flash[:error] = I18n.t('blacklight.email.errors.to.invalid', to: params[:to])
     end
 

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -142,7 +142,8 @@ module Blacklight
           autocomplete_suggester: 'mySuggester',
           raw_endpoint: OpenStructWithHashAccess.new(enabled: false),
           track_search_session: true,
-          advanced_search: OpenStruct.new(enabled: false)
+          advanced_search: OpenStruct.new(enabled: false),
+          enable_search_bar_autofocus: false
           }
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/blacklight/deprecations/engine_configuration.rb
+++ b/lib/blacklight/deprecations/engine_configuration.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Deprecations
+    module EngineConfiguration
+      # rubocop:disable Style/RedundantSelf, Style/HashSyntax
+      # @deprecated
+      def bookmarks_http_method
+        self.blacklight.bookmarks_http_method
+      end
+      deprecation_deprecate bookmarks_http_method: 'Moved to `blacklight.bookmarks_http_method`'
+
+      # @deprecated
+      def bookmarks_http_method=(val)
+        self.blacklight.bookmarks_http_method = val
+      end
+      deprecation_deprecate :'bookmarks_http_method=' => 'Moved to `blacklight.bookmarks_http_method=`'
+
+      # @deprecated
+      def email_regexp
+        self.blacklight.email_regexp
+      end
+      deprecation_deprecate email_regexp: 'Moved to `blacklight.email_regexp`'
+
+      # @deprecated
+      def email_regexp=(val)
+        self.blacklight.email_regexp = val
+      end
+      deprecation_deprecate :'email_regexp=' => 'Moved to `blacklight.email_regexp=`'
+
+      # @deprecated
+      def facet_missing_param
+        self.blacklight.facet_missing_param
+      end
+      deprecation_deprecate facet_missing_param: 'Moved to `blacklight.facet_missing_param`'
+
+      # @deprecated
+      def facet_missing_param=(val)
+        self.blacklight.facet_missing_param = val
+      end
+      deprecation_deprecate :'facet_missing_param=' => 'Moved to `blacklight.facet_missing_param=`'
+
+      # @deprecated
+      def sms_mappings
+        self.blacklight.sms_mappings
+      end
+      deprecation_deprecate sms_mappings: 'Moved to `blacklight.sms_mappings`'
+
+      # @deprecated
+      def sms_mappings=(val)
+        self.blacklight.sms_mappings = val
+      end
+      deprecation_deprecate :'sms_mappings=' => 'Moved to `blacklight.sms_mappings=`'
+      # rubocop:enable Style/RedundantSelf, Style/HashSyntax
+
+      def self.deprecate_in(object)
+        class << object
+          extend Deprecation
+          self.deprecation_horizon = 'blacklight 8.0'
+
+          include Blacklight::Deprecations::EngineConfiguration
+        end
+      end
+    end
+  end
+end

--- a/lib/blacklight/search_state/filter_field.rb
+++ b/lib/blacklight/search_state/filter_field.rb
@@ -46,7 +46,7 @@ module Blacklight
 
         if value == Blacklight::SearchState::FilterField::MISSING
           url_key = "-#{key}"
-          value = Blacklight::Engine.config.facet_missing_param
+          value = Blacklight::Engine.config.blacklight.facet_missing_param
         end
 
         param = :f_inclusive if value.is_a?(Array)
@@ -82,7 +82,7 @@ module Blacklight
 
         if value == Blacklight::SearchState::FilterField::MISSING
           url_key = "-#{key}"
-          value = Blacklight::Engine.config.facet_missing_param
+          value = Blacklight::Engine.config.blacklight.facet_missing_param
         end
 
         param = :f_inclusive if value.is_a?(Array)
@@ -114,7 +114,7 @@ module Blacklight
         params = search_state.params
         f = Array(params.dig(:f, key))
         f_inclusive = [params.dig(:f_inclusive, key)] if params.dig(:f_inclusive, key).present?
-        f_missing = [Blacklight::SearchState::FilterField::MISSING] if params.dig(:f, "-#{key}")&.any? { |v| v == Blacklight::Engine.config.facet_missing_param }
+        f_missing = [Blacklight::SearchState::FilterField::MISSING] if params.dig(:f, "-#{key}")&.any? { |v| v == Blacklight::Engine.config.blacklight.facet_missing_param }
 
         f + (f_inclusive || []) + (f_missing || [])
       end
@@ -133,7 +133,7 @@ module Blacklight
         if value.is_a?(Array)
           (params.dig(:f_inclusive, key) || []).to_set == value.to_set
         elsif value == Blacklight::SearchState::FilterField::MISSING
-          (params.dig(:f, "-#{key}") || []).include?(Blacklight::Engine.config.facet_missing_param)
+          (params.dig(:f, "-#{key}") || []).include?(Blacklight::Engine.config.blacklight.facet_missing_param)
         else
           (params.dig(:f, key) || []).include?(value)
         end

--- a/spec/lib/blacklight/engine_spec.rb
+++ b/spec/lib/blacklight/engine_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::Engine do
+  [:bookmarks_http_method, :email_regexp, :facet_missing_param, :sms_mappings].each do |dep_key|
+    describe "config.#{dep_key}" do
+      subject { described_class.config }
+
+      let(:unlikely_value) { 'unlikely value' }
+
+      it 'is deprecated' do
+        allow(Deprecation).to receive(:warn)
+        subject.send(dep_key)
+        expect(Deprecation).to have_received(:warn)
+      end
+
+      it 'delegates to config.blacklight' do
+        allow(subject.blacklight).to receive(dep_key).and_return(unlikely_value)
+        expect(subject.send(dep_key)).to eql(unlikely_value)
+      end
+    end
+
+    describe "config.#{dep_key}=" do
+      subject { described_class.config }
+
+      let(:unlikely_value) { 'unlikely value' }
+
+      it 'is deprecated' do
+        allow(Deprecation).to receive(:warn)
+        allow(subject.blacklight).to receive(:"#{dep_key}=").with(unlikely_value)
+        subject.send(:"#{dep_key}=", unlikely_value)
+        expect(Deprecation).to have_received(:warn)
+      end
+
+      it 'delegates to config.blacklight' do
+        allow(subject.blacklight).to receive(:"#{dep_key}=").with(unlikely_value)
+        subject.send(:"#{dep_key}=", unlikely_value)
+        expect(subject.blacklight).to have_received(:"#{dep_key}=").with(unlikely_value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Deprecation warnings for top-level config key access
- moved an erroneously excluded key behind `Blacklight::Engine.config.blacklight`
- moved the default value for a key intended to be in `Blacklight::Configuration` out of `Blacklight::Engine.config`