### PR TITLE
Support Rails 7 in Blacklight 7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6]
+        ruby: [2.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -102,6 +102,27 @@ jobs:
       env:
         RAILS_VERSION: 5.2.4.6
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+
+  test_rails7_0:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.0']
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+      env:
+        RAILS_VERSION: 7.0.0
+    - name: Run tests
+      run: bundle exec rake ci
+      env:
+        RAILS_VERSION: 7.0.0
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-keeps --skip-action-cable --skip-test'
   api_test:
     runs-on: ubuntu-latest
     strategy:

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -62,6 +62,12 @@
 
   .card-header {
     @extend .bg-success;
+
+    .btn {
+      @if function-exists(color-contrast) {
+        color: color-contrast($success);
+      }
+    }
   }
 }
 

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -7,7 +7,7 @@ module Blacklight
     renders_many :constraints
     renders_many :search_field_controls
     renders_many :search_filter_controls, (lambda do |config:, display_facet:, presenter: nil, component: nil, **kwargs|
-      presenter ||= (config.presenter || Blacklight::FacetFieldPresenter).new(config, display_facet, @view_context)
+      presenter ||= (config.presenter || Blacklight::FacetFieldPresenter).new(config, display_facet, helpers)
       component = component || config.advanced_search_component || Blacklight::FacetFieldCheckboxesComponent
 
       component.new(facet_field: presenter, **kwargs)
@@ -30,7 +30,7 @@ module Blacklight
     end
 
     def sort_fields_select
-      options = sort_fields.values.map { |field_config| [@view_context.sort_field_label(field_config.key), field_config.key] }
+      options = sort_fields.values.map { |field_config| [helpers.sort_field_label(field_config.key), field_config.key] }
       select_tag(:sort, options_for_select(options, params[:sort]), class: "form-control sort-select")
     end
 
@@ -63,11 +63,11 @@ module Blacklight
 
     def initialize_constraints
       constraint do
-        params = @view_context.search_state.params_for_search.except :page, :f_inclusive, :q, :search_field, :op, :index, :sort
+        params = helpers.search_state.params_for_search.except :page, :f_inclusive, :q, :search_field, :op, :index, :sort
 
         params.except!(*search_fields.map { |_key, field_def| field_def[:key] })
 
-        @view_context.render_search_to_s(params)
+        helpers.render_search_to_s(params)
       end
     end
 

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -21,23 +21,23 @@ module Blacklight
     def query_constraints
       Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) do
         if @search_state.query_param.present?
-          @view_context.render(
+          helpers.render(
             @query_constraint_component.new(
               search_state: @search_state,
               value: @search_state.query_param,
               label: label,
-              remove_path: @view_context.remove_constraint_url(@search_state),
+              remove_path: helpers.remove_constraint_url(@search_state),
               classes: 'query'
             )
           )
         else
           ''.html_safe
         end
-      end + @view_context.render(@facet_constraint_component.with_collection(clause_presenters.to_a))
+      end + helpers.render(@facet_constraint_component.with_collection(clause_presenters.to_a))
     end
 
     def facet_constraints
-      @view_context.render(@facet_constraint_component.with_collection(facet_item_presenters.to_a))
+      helpers.render(@facet_constraint_component.with_collection(facet_item_presenters.to_a))
     end
 
     def start_over_path
@@ -80,17 +80,17 @@ module Blacklight
       return to_enum(:clause_presenters) unless block_given?
 
       @search_state.clause_params.each do |key, clause|
-        field_config = @view_context.blacklight_config.search_fields[clause[:field]]
-        yield Blacklight::ClausePresenter.new(key, clause, field_config, @view_context)
+        field_config = helpers.blacklight_config.search_fields[clause[:field]]
+        yield Blacklight::ClausePresenter.new(key, clause, field_config, helpers)
       end
     end
 
     def facet_item_presenter(facet_config, facet_item, facet_field)
-      (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, facet_config, @view_context, facet_field)
+      (facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, facet_config, helpers, facet_field)
     end
 
     def inclusive_facet_item_presenter(facet_config, facet_item, facet_field)
-      Blacklight::InclusiveFacetItemPresenter.new(facet_item, facet_config, @view_context, facet_field)
+      Blacklight::InclusiveFacetItemPresenter.new(facet_item, facet_config, helpers, facet_field)
     end
   end
 end

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -42,19 +42,19 @@ module Blacklight
 
     def start_over_path
       Deprecation.silence(Blacklight::UrlHelperBehavior) do
-        @view_context.start_over_path
+        helpers.start_over_path
       end
     end
 
     def render?
-      Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) { @view_context.query_has_constraints? }
+      Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) { helpers.query_has_constraints? }
     end
 
     private
 
     def label
       Deprecation.silence(Blacklight::ConfigurationHelperBehavior) do
-        @view_context.constraint_query_label(@search_state.params)
+        helpers.constraint_query_label(@search_state.params)
       end
     end
 

--- a/app/components/blacklight/document/action_component.html.erb
+++ b/app/components/blacklight/document/action_component.html.erb
@@ -5,5 +5,5 @@
               class: @link_classes,
               data: {}.merge(({ blacklight_modal: "trigger" } if @action.modal != false) || {}) %>
 <% else %>
-  <%= @view_context.render(partial: @action.partial || @action.name.to_s, locals: { document: @document, document_action_config: @action }.merge(@options)) %>
+  <%= helpers.render(partial: @action.partial || @action.name.to_s, locals: { document: @document, document_action_config: @action }.merge(@options)) %>
 <% end %>

--- a/app/components/blacklight/document/action_component.rb
+++ b/app/components/blacklight/document/action_component.rb
@@ -20,12 +20,12 @@ module Blacklight
         return true if @action.component
         return false unless @action.partial == 'document_action'
 
-        @view_context.partial_from_blacklight?(@action.partial)
+        helpers.partial_from_blacklight?(@action.partial)
       end
 
       def label
         Deprecation.silence(Blacklight::ComponentHelperBehavior) do
-          @view_context.document_action_label(@action.name, @action)
+          helpers.document_action_label(@action.name, @action)
         end
       end
 

--- a/app/components/blacklight/document/action_component.rb
+++ b/app/components/blacklight/document/action_component.rb
@@ -29,9 +29,16 @@ module Blacklight
         end
       end
 
+      # Action buttons get their URLs in one of three ways:
+      # - the action configuration explicitly specifies a helper method to call
+      # - a url route is inferred for ActiveModel-compliant objects (the default;
+      #     note that, although Rails routing is available here, we still call out to
+      #     helpers regardless, because that's where applications might have overridden the
+      #     default Rails routing behavior)
+      # - calling out to an implicit helper method with a conventional name (unlikely)
       def url
         Deprecation.silence(Blacklight::ComponentHelperBehavior) do
-          @view_context.document_action_path(@action, @url_opts.merge(({ id: @document } if @document) || {}))
+          helpers.document_action_path(@action, @url_opts.merge(({ id: @document } if @document) || {}))
         end
       end
 

--- a/app/components/blacklight/document/bookmark_component.rb
+++ b/app/components/blacklight/document/bookmark_component.rb
@@ -16,11 +16,11 @@ module Blacklight
       def bookmarked?
         return @checked unless @checked.nil?
 
-        @view_context.bookmarked? @document
+        helpers.bookmarked? @document
       end
 
       def bookmark_path
-        @bookmark_path || @view_context.bookmark_path(@document)
+        @bookmark_path || helpers.bookmark_path(@document)
       end
     end
   end

--- a/app/components/blacklight/document/citation_component.rb
+++ b/app/components/blacklight/document/citation_component.rb
@@ -23,7 +23,7 @@ module Blacklight
       # @return [String]
       def title
         Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
-          @view_context.document_heading(@document)
+          helpers.document_heading(@document)
         end
       end
     end

--- a/app/components/blacklight/document/group_component.html.erb
+++ b/app/components/blacklight/document/group_component.html.erb
@@ -4,6 +4,6 @@
     <%= grouped_documents %>
   </div>
   <%- if @group_limit > 0 && @group.total > @group_limit %>
-    <%= @view_context.link_to t('blacklight.search.group.more'), add_group_facet_params_and_redirect(@group), class: 'more-in-group' %>
+    <%= helpers.link_to t('blacklight.search.group.more'), add_group_facet_params_and_redirect(@group), class: 'more-in-group' %>
   <%- end %>
 </div>

--- a/app/components/blacklight/document/group_component.rb
+++ b/app/components/blacklight/document/group_component.rb
@@ -13,7 +13,7 @@ module Blacklight
       end
 
       def grouped_documents
-        @view_context.render_document_index @group.docs
+        helpers.render_document_index @group.docs
       end
 
       def add_group_facet_params_and_redirect(group)

--- a/app/components/blacklight/document/group_component.rb
+++ b/app/components/blacklight/document/group_component.rb
@@ -18,7 +18,7 @@ module Blacklight
 
       def add_group_facet_params_and_redirect(group)
         Deprecation.silence(Blacklight::UrlHelperBehavior) do
-          @view_context.search_action_path(@view_context.add_group_facet_params_and_redirect(group))
+          helpers.search_action_path(helpers.add_group_facet_params_and_redirect(group))
         end
       end
     end

--- a/app/components/blacklight/document/more_like_this_component.rb
+++ b/app/components/blacklight/document/more_like_this_component.rb
@@ -16,7 +16,7 @@ module Blacklight
       end
 
       def link_to_document(*args)
-        @view_context.link_to_document(*args)
+        helpers.link_to_document(*args)
       end
     end
   end

--- a/app/components/blacklight/document/thumbnail_component.rb
+++ b/app/components/blacklight/document/thumbnail_component.rb
@@ -29,7 +29,7 @@ module Blacklight
       end
 
       def presenter
-        @presenter ||= @view_context.document_presenter(@document)
+        @presenter ||= helpers.document_presenter(@document)
       end
     end
   end

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -114,7 +114,7 @@ module Blacklight
     def classes
       [
         @classes,
-        @view_context.render_document_class(@document),
+        helpers.render_document_class(@document),
         'document',
         ("document-position-#{@counter}" if @counter)
       ].compact.flatten
@@ -130,7 +130,7 @@ module Blacklight
     private
 
     def presenter
-      @presenter ||= @view_context.document_presenter(@document)
+      @presenter ||= helpers.document_presenter(@document)
     end
 
     def show?

--- a/app/components/blacklight/document_title_component.rb
+++ b/app/components/blacklight/document_title_component.rb
@@ -24,7 +24,7 @@ module Blacklight
     # Content for the document title area; should be an inline element
     def title
       if @link_to_document
-        @view_context.link_to_document presenter.document, @title.presence || content.presence, counter: @counter, itemprop: 'name'
+        helpers.link_to_document presenter.document, @title.presence || content.presence, counter: @counter, itemprop: 'name'
       else
         content_tag('span', @title.presence || content.presence || presenter.heading, itemprop: 'name')
       end
@@ -39,7 +39,7 @@ module Blacklight
 
       (@has_actions_slot && get_slot(:actions)) ||
         ([@document_component&.actions] if @document_component&.actions.present?) ||
-        [@view_context.render_index_doc_actions(presenter.document, wrapping_class: 'index-document-functions col-sm-3 col-lg-2')]
+        [helpers.render_index_doc_actions(presenter.document, wrapping_class: 'index-document-functions col-sm-3 col-lg-2')]
     end
 
     def counter
@@ -53,7 +53,7 @@ module Blacklight
     private
 
     def presenter
-      @presenter ||= @view_context.document_presenter(@document)
+      @presenter ||= helpers.document_presenter(@document)
     end
   end
 end

--- a/app/components/blacklight/facet_field_checkboxes_component.rb
+++ b/app/components/blacklight/facet_field_checkboxes_component.rb
@@ -17,7 +17,7 @@ module Blacklight
       return to_enum(:presenters) unless block_given?
 
       @facet_field.paginator.items.each do |item|
-        yield (@facet_field.facet_field.item_presenter || Blacklight::FacetItemPresenter).new(item, @facet_field.facet_field, @view_context, @facet_field.key, @facet_field.search_state)
+        yield (@facet_field.facet_field.item_presenter || Blacklight::FacetItemPresenter).new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
       end
     end
   end

--- a/app/components/blacklight/facet_field_inclusive_constraint_component.html.erb
+++ b/app/components/blacklight/facet_field_inclusive_constraint_component.html.erb
@@ -1,6 +1,6 @@
 <div class="inclusive_or card card-body bg-light mb-3">
   <h5><%= t('blacklight.advanced_search.any_of') %></h5>
   <ul class="list-unstyled facet-values">
-    <%= @view_context.render(Blacklight::FacetItemComponent.with_collection(presenters.to_a)) %>
+    <%= helpers.render(Blacklight::FacetItemComponent.with_collection(presenters.to_a)) %>
   </ul>
 </div>

--- a/app/components/blacklight/facet_field_inclusive_constraint_component.rb
+++ b/app/components/blacklight/facet_field_inclusive_constraint_component.rb
@@ -22,7 +22,7 @@ module Blacklight
       return to_enum(:presenters) unless block_given?
 
       values.each do |item|
-        yield Blacklight::FacetGroupedItemPresenter.new(values, item, @facet_field.facet_field, @view_context, @facet_field.key, @facet_field.search_state)
+        yield Blacklight::FacetGroupedItemPresenter.new(values, item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
       end
     end
   end

--- a/app/components/blacklight/facet_field_list_component.html.erb
+++ b/app/components/blacklight/facet_field_list_component.html.erb
@@ -3,7 +3,7 @@
     <%= @facet_field.label %>
   <% end %>
   <% component.body do %>
-    <%= @view_context.render(Blacklight::FacetFieldInclusiveConstraintComponent.new(facet_field: @facet_field)) %>
+    <%= helpers.render(Blacklight::FacetFieldInclusiveConstraintComponent.new(facet_field: @facet_field)) %>
     <ul class="facet-values list-unstyled">
       <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
     </ul>

--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -11,7 +11,7 @@ module Blacklight
     # @private
     def render_facet_limit_list(*args)
       Deprecation.silence(Blacklight::FacetsHelperBehavior) do
-        @view_context.render_facet_limit_list(*args)
+        helpers.render_facet_limit_list(*args)
       end
     end
 

--- a/app/components/blacklight/facet_field_pagination_component.html.erb
+++ b/app/components/blacklight/facet_field_pagination_component.html.erb
@@ -1,9 +1,9 @@
 <div class="prev_next_links btn-group">
-  <%= @view_context.link_to_previous_page @facet_field.paginator, raw(t('views.pagination.previous')), params: @facet_field.search_state.to_h, param_name: param_name, class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
+  <%= helpers.link_to_previous_page @facet_field.paginator, raw(t('views.pagination.previous')), params: @facet_field.search_state.to_h, param_name: param_name, class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn' %>
   <% end %>
 
-  <%= @view_context.link_to_next_page @facet_field.paginator, raw(t('views.pagination.next')), params: @facet_field.search_state.to_h, param_name: param_name, class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
+  <%= helpers.link_to_next_page @facet_field.paginator, raw(t('views.pagination.next')), params: @facet_field.search_state.to_h, param_name: param_name, class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn' %>
   <% end %>
 </div>
@@ -11,9 +11,9 @@
 <div class="sort-options btn-group">
   <% if @facet_field.paginator.sort == 'index' -%>
     <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
-    <%= @view_context.link_to(t('blacklight.search.facets.sort.count'), sort_facet_url('count'), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>
+    <%= helpers.link_to(t('blacklight.search.facets.sort.count'), sort_facet_url('count'), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>
   <% elsif @facet_field.paginator.sort == 'count' -%>
-    <%= @view_context.link_to(t('blacklight.search.facets.sort.index'), sort_facet_url('index'), class: "sort_change az btn btn-outline-secondary",  data: { blacklight_modal: "preserve" }) %>
+    <%= helpers.link_to(t('blacklight.search.facets.sort.index'), sort_facet_url('index'), class: "sort_change az btn btn-outline-secondary",  data: { blacklight_modal: "preserve" }) %>
     <span class="active numeric btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.count') %></span>
   <% end -%>
 </div>

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -101,7 +101,7 @@ module Blacklight
     # @return [String]
     # @private
     def render_facet_count(options = {})
-      return @view_context.render_facet_count(@hits, options) unless @view_context.method(:render_facet_count).owner == Blacklight::FacetsHelperBehavior || explicit_component_configuration?
+      return helpers.render_facet_count(@hits, options) unless helpers.method(:render_facet_count).owner == Blacklight::FacetsHelperBehavior || explicit_component_configuration?
 
       return '' if @hits.blank?
 

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -87,7 +87,7 @@ module Blacklight
           # remove link
           link_to(@href, class: "remove", rel: "nofollow") do
             tag.span('✖', class: "remove-icon", aria: { hidden: true }) +
-              tag.span(@view_context.t(:'blacklight.search.facets.selected.remove'), class: 'sr-only visually-hidden')
+              tag.span(helpers.t(:'blacklight.search.facets.selected.remove'), class: 'sr-only visually-hidden')
           end
       end + render_facet_count(classes: ["selected"])
     end

--- a/app/components/blacklight/facet_item_pivot_component.rb
+++ b/app/components/blacklight/facet_item_pivot_component.rb
@@ -74,11 +74,11 @@ module Blacklight
     # with overrides of deprecated helpers. In 8.x, we can just call Component#render_in
     # and call it a day
     def render_component(component)
-      @view_context.render(component)
+      helpers.render(component)
     end
 
     def facet_item_presenter(facet_item)
-      (@facet_item.facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, @facet_item.facet_config, @view_context, @facet_item.facet_field, @facet_item.search_state)
+      (@facet_item.facet_config.item_presenter || Blacklight::FacetItemPresenter).new(facet_item, @facet_item.facet_config, helpers, @facet_item.facet_field, @facet_item.search_state)
     end
   end
 end

--- a/app/components/blacklight/metadata_field_component.rb
+++ b/app/components/blacklight/metadata_field_component.rb
@@ -17,9 +17,9 @@ module Blacklight
     def label
       Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
         if @show
-          @view_context.render_document_show_field_label @field.document, label: @field.label('show'), field: @field.key
+          helpers.render_document_show_field_label @field.document, label: @field.label('show'), field: @field.key
         else
-          @view_context.render_index_field_label @field.document, label: @field.label, field: @field.key
+          helpers.render_index_field_label @field.document, label: @field.label, field: @field.key
         end
       end
     end

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -23,7 +23,7 @@
 
   <%= content_tag :div, id: @panel_id, class: 'facets-collapse collapse' do %>
     <% Deprecation.silence(Blacklight::FacetsHelperBehavior) do %>
-      <%= @view_context.render_facet_partials @fields, response: @response %>
+      <%= helpers.render_facet_partials @fields, response: @response %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -18,7 +18,7 @@ module Blacklight
 
       def render?
         Deprecation.silence(Blacklight::FacetsHelperBehavior) do
-          @view_context.has_facet_values?(@fields, @response)
+          helpers.has_facet_values?(@fields, @response)
         end
       end
     end

--- a/app/components/blacklight/response/pagination_component.rb
+++ b/app/components/blacklight/response/pagination_component.rb
@@ -13,7 +13,7 @@ module Blacklight
       end
 
       def pagination
-        @view_context.paginate @response, **@pagination_args
+        helpers.paginate @response, **@pagination_args
       end
     end
   end

--- a/app/components/blacklight/response/sort_component.html.erb
+++ b/app/components/blacklight/response/sort_component.html.erb
@@ -1,4 +1,4 @@
-<%= @view_context.render(Blacklight::System::DropdownComponent.new(
+<%= helpers.render(Blacklight::System::DropdownComponent.new(
       param: @param,
       choices: @choices,
       id: @id,

--- a/app/components/blacklight/response/spellcheck_component.rb
+++ b/app/components/blacklight/response/spellcheck_component.rb
@@ -14,13 +14,13 @@ module Blacklight
 
       def link_to_query(query)
         Deprecation.silence(Blacklight::UrlHelperBehavior) do
-          @view_context.link_to_query(query)
+          helpers.link_to_query(query)
         end
       end
 
       def render?
         Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
-          @options&.any? && @view_context.should_show_spellcheck_suggestions?(@response)
+          @options&.any? && helpers.should_show_spellcheck_suggestions?(@response)
         end
       end
 

--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -16,7 +16,7 @@ module Blacklight
 
       def icon
         Deprecation.silence(Blacklight::CatalogHelperBehavior) do
-          @view_context.render_view_type_group_icon(@view.icon || @key)
+          helpers.render_view_type_group_icon(@view.icon || @key)
         end
       end
 
@@ -27,7 +27,7 @@ module Blacklight
       end
 
       def url
-        @view_context.url_for(@search_state.to_h.merge(view: @key))
+        helpers.url_for(@search_state.to_h.merge(view: @key))
       end
 
       def selected?

--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -22,7 +22,7 @@ module Blacklight
 
       def label
         Deprecation.silence(Blacklight::ConfigurationHelperBehavior) do
-          @view_context.view_label(@key)
+          helpers.view_label(@key)
         end
       end
 

--- a/app/components/blacklight/response/view_type_component.rb
+++ b/app/components/blacklight/response/view_type_component.rb
@@ -24,7 +24,7 @@ module Blacklight
 
       def render?
         Deprecation.silence(Blacklight::ConfigurationHelperBehavior) do
-          @view_context.has_alternative_views?
+          helpers.has_alternative_views?
         end
       end
     end

--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -57,7 +57,7 @@ module Blacklight
     end
 
     def blacklight_config
-      @view_context.blacklight_config
+      helpers.blacklight_config
     end
 
     def render_hash_as_hidden_fields(*args)

--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -62,7 +62,7 @@ module Blacklight
 
     def render_hash_as_hidden_fields(*args)
       Deprecation.silence(Blacklight::HashAsHiddenFieldsHelperBehavior) do
-        @view_context.render_hash_as_hidden_fields(*args)
+        helpers.render_hash_as_hidden_fields(*args)
       end
     end
 

--- a/app/components/blacklight/search_context_component.rb
+++ b/app/components/blacklight/search_context_component.rb
@@ -15,19 +15,19 @@ module Blacklight
 
     def item_page_entry_info
       Deprecation.silence(Blacklight::CatalogHelperBehavior) do
-        @view_context.item_page_entry_info
+        helpers.item_page_entry_info
       end
     end
 
     def link_to_previous_document(*args)
       Deprecation.silence(Blacklight::UrlHelperBehavior) do
-        @view_context.link_to_previous_document(*args)
+        helpers.link_to_previous_document(*args)
       end
     end
 
     def link_to_next_document(*args)
       Deprecation.silence(Blacklight::UrlHelperBehavior) do
-        @view_context.link_to_next_document(*args)
+        helpers.link_to_next_document(*args)
       end
     end
   end

--- a/app/components/blacklight/system/dropdown_component.rb
+++ b/app/components/blacklight/system/dropdown_component.rb
@@ -35,7 +35,7 @@ module Blacklight
 
         options(@choices.map do |option|
           text, value = option_text_and_value(option)
-          { text: text, url: @view_context.url_for(@search_state.params_for_search(@param => value)), selected: @selected == value }
+          { text: text, url: helpers.url_for(@search_state.params_for_search(@param => value)), selected: @selected == value }
         end)
       end
 

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -410,7 +410,15 @@ module Blacklight::BlacklightHelperBehavior
   end
 
   def partial_from_blacklight?(partial)
-    path = lookup_context.find_all(partial, lookup_context.prefixes + [""], true).first&.identifier
+    path = if Rails::VERSION::MAJOR >= 6
+             name = partial.split('/').last
+             prefix = partial.split('/').first if partial.include?('/')
+             logger&.debug "Looking for document index partial #{partial}"
+             prefixes = lookup_context.prefixes + [prefix, ""].compact
+             lookup_context.find_all(name, prefixes, true).first&.identifier
+           else
+             lookup_context.find_all(partial, lookup_context.prefixes + [""], true).first&.identifier
+           end
 
     path&.starts_with?(Blacklight::BlacklightHelperBehavior.blacklight_path)
   end

--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -191,9 +191,20 @@ module Blacklight::RenderPartialsHelperBehavior
     document_index_path_templates.each do |str|
       partial = format(str, index_view_type: view_type)
       logger&.debug "Looking for document index partial #{partial}"
-      template = lookup_context.find_all(partial, lookup_context.prefixes + [""], true, locals.keys + [:documents], {}).first
+
+      template = if Rails::VERSION::MAJOR >= 6
+                   name = partial.split('/').last
+                   prefix = partial.split('/').first if partial.include?('/')
+
+                   prefixes = lookup_context.prefixes + [prefix, ""].compact
+                   lookup_context.find_all(name, prefixes, true, locals.keys + [:documents], {}).first
+                 else
+                   lookup_context.find_all(partial, lookup_context.prefixes + [""], true, locals.keys + [:documents], {}).first
+                 end
+
       return template if template
     end
+
     nil
   end
 

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -12,7 +12,13 @@
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>
-    <%= javascript_include_tag "application" %>
+
+    <% if defined? Importmap %>
+      <%= javascript_importmap_tags %>
+    <% else %>
+      <%= javascript_include_tag "application" %>
+    <% end %>
+
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
   </head>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -12,12 +12,7 @@
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>
-
-    <% if defined? Importmap %>
-      <%= javascript_importmap_tags %>
-    <% else %>
-      <%= javascript_include_tag "application" %>
-    <% end %>
+    <%= javascript_include_tag "application" %>
 
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency "rails", '>= 5.1', '< 7'
+  s.add_dependency "rails", '>= 5.1', '< 8'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency "rails", '>= 5.1', '< 8'
+  s.add_dependency "rails", '>= 5.1', '< 7.1'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -23,10 +23,14 @@ module Blacklight
       end
     end
 
-    initializer "blacklight.assets.precompile" do |app|
+    initializer "blacklight.assets.precompile" do
+      # rubocop:disable Lint/ConstantDefinitionInBlock
+      PRECOMPILE_ASSETS = %w(favicon.ico blacklight/blacklight.js blacklight/blacklight.js.map).freeze
+      # rubocop:enable Lint/ConstantDefinitionInBlock
+
       # When Rails has been generated in API mode, it does not have sprockets available
-      if defined? Sprockets
-        app.config.assets.precompile += %w(favicon.ico)
+      if Rails.application.config.respond_to?(:assets)
+        Rails.application.config.assets.precompile += PRECOMPILE_ASSETS
       end
     end
 

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -24,9 +24,7 @@ module Blacklight
     end
 
     initializer "blacklight.assets.precompile" do
-      # rubocop:disable Lint/ConstantDefinitionInBlock
       PRECOMPILE_ASSETS = %w(favicon.ico blacklight/blacklight.js blacklight/blacklight.js.map).freeze
-      # rubocop:enable Lint/ConstantDefinitionInBlock
 
       # When Rails has been generated in API mode, it does not have sprockets available
       if Rails.application.config.respond_to?(:assets)

--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -27,14 +27,14 @@ module Blacklight
     ##
     # Remove the empty generated app/assets/images directory. Without doing this,
     # the default Sprockets 4 manifest will raise an exception.
-    def appease_sprockets4
-      return if !defined?(Sprockets::VERSION) || Sprockets::VERSION < '4'
+    # def appease_sprockets4
+    #   return if !defined?(Sprockets::VERSION) || Sprockets::VERSION < '4'
+    #
+    #   append_to_file 'app/assets/config/manifest.js', "\n//= link application.js"
+    #   empty_directory 'app/assets/images'
+    # end
 
-      append_to_file 'app/assets/config/manifest.js', "\n//= link application.js"
-      empty_directory 'app/assets/images'
-    end
-
-    def assets
+    def assets # rubocop:disable Metrics/MethodLength
       copy_file "blacklight.scss", "app/assets/stylesheets/blacklight.scss"
 
       # Ensure this method is idempotent

--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -27,12 +27,12 @@ module Blacklight
     ##
     # Remove the empty generated app/assets/images directory. Without doing this,
     # the default Sprockets 4 manifest will raise an exception.
-    # def appease_sprockets4
-    #   return if !defined?(Sprockets::VERSION) || Sprockets::VERSION < '4'
-    #
-    #   append_to_file 'app/assets/config/manifest.js', "\n//= link application.js"
-    #   empty_directory 'app/assets/images'
-    # end
+    def appease_sprockets4
+      return if Rails.version > '7' || !defined?(Sprockets::VERSION) || Sprockets::VERSION < '4'
+
+      append_to_file 'app/assets/config/manifest.js', "\n//= link application.js"
+      empty_directory 'app/assets/images'
+    end
 
     def assets # rubocop:disable Metrics/MethodLength
       copy_file "blacklight.scss", "app/assets/stylesheets/blacklight.scss"

--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -13,7 +13,7 @@ module Blacklight
 
     # Add sprockets javascript to Rails 6.
     def create_sprockets_javascript
-      return if Rails.version < '6.0.0'
+      return unless Rails.version.starts_with? '6'
 
       create_file 'app/assets/javascripts/application.js' do
         <<~CONTENT
@@ -101,7 +101,9 @@ module Blacklight
     end
 
     def application_js
-      IO.read(File.expand_path("app/assets/javascripts/application.js", destination_root))
+      path = File.expand_path("app/assets/javascripts/application.js", destination_root)
+
+      File.exist?(path) ? File.read(path) : ''
     end
   end
 end

--- a/spec/components/blacklight/document/action_component_spec.rb
+++ b/spec/components/blacklight/document/action_component_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Blacklight::Document::ActionComponent, type: :component do
     else
       allow(view_context).to receive(:some_tool_solr_document_path).with(document).and_return('/asdf')
     end
+
     expect(rendered).to have_link 'Some tool', href: '/asdf'
   end
 

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     CatalogController.blacklight_config.deep_copy.tap do |config|
       config.track_search_session = false
       config.index.thumbnail_field = 'thumbnail_path_ss'
-      config.index.document_actions[:bookmark].partial = '/catalog/bookmark_control.html.erb'
+      config.index.document_actions[:bookmark].partial = '/catalog/bookmark_control'
     end
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -788,7 +788,7 @@ RSpec.describe CatalogController, api: true do
   describe "#add_show_tools_partial", api: false do
     before do
       described_class.blacklight_config.add_show_tools_partial(:like, callback: :perform_like, validator: :validate_like_params)
-      allow(controller).to receive(:solr_document_url).and_return('catalog/1')
+      allow(controller).to receive(:solr_document_url).and_return('http://test.host/catalog/1')
       allow(controller).to receive(:action_documents).and_return(1)
       Rails.application.routes.draw do
         get 'catalog/like', as: :catalog_like

--- a/spec/support/controller_level_helpers.rb
+++ b/spec/support/controller_level_helpers.rb
@@ -15,4 +15,12 @@ module ControllerLevelHelpers
   def initialize_controller_helpers(helper)
     helper.extend ControllerViewHelpers
   end
+
+  # Monkeypatch to fix https://github.com/rspec/rspec-rails/pull/2521
+  def _default_render_options
+    val = super
+    return val unless val[:handlers]
+    
+    val.merge(handlers: val.fetch(:handlers).map(&:to_sym))
+  end
 end

--- a/spec/support/controller_level_helpers.rb
+++ b/spec/support/controller_level_helpers.rb
@@ -20,7 +20,7 @@ module ControllerLevelHelpers
   def _default_render_options
     val = super
     return val unless val[:handlers]
-    
+
     val.merge(handlers: val.fetch(:handlers).map(&:to_sym))
   end
 end

--- a/spec/views/catalog/_index.html.erb_spec.rb
+++ b/spec/views/catalog/_index.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 # spec for default partial to display solr document fields in catalog INDEX view
 
-RSpec.describe "/catalog/_index" do
+RSpec.describe "catalog/_index" do
   include BlacklightHelper
   include CatalogHelper
 

--- a/spec/views/catalog/_show.html.erb_spec.rb
+++ b/spec/views/catalog/_show.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 # spec for default partial to display solr document fields in catalog show view
 
-RSpec.describe "/catalog/_show" do
+RSpec.describe "catalog/_show" do
   include BlacklightHelper
   include CatalogHelper
 

--- a/spec/views/catalog/_show_sidebar.erb_spec.rb
+++ b/spec/views/catalog/_show_sidebar.erb_spec.rb
@@ -2,7 +2,7 @@
 
 # spec for sidebar partial in catalog show view
 
-RSpec.describe "/catalog/_show_sidebar.html.erb" do
+RSpec.describe "catalog/_show_sidebar.html.erb" do
   let(:blacklight_config) do
     Blacklight::Configuration.new do |config|
       config.index.title_field = 'title_tsim'

--- a/spec/views/catalog/facet.json.jbuilder_spec.rb
+++ b/spec/views/catalog/facet.json.jbuilder_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "catalog/facet.json", api: true do
   it "renders facet json" do
     assign :pagination, items: [{ value: 'Book' }]
-    render template: "catalog/facet.json", format: :json
+    render template: "catalog/facet", formats: [:json]
     hash = JSON.parse(rendered)
     expect(hash).to eq('response' => { 'facets' => { 'items' => [{ 'value' => 'Book' }] } })
   end

--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "catalog/index.json", api: true do
   let(:presenter) { Blacklight::JsonPresenter.new(response, config) }
 
   let(:hash) do
-    render template: "catalog/index.json", format: :json
+    render template: "catalog/index", formats: [:json]
     JSON.parse(rendered).with_indifferent_access
   end
 

--- a/spec/views/catalog/show.json.jbuilder_spec.rb
+++ b/spec/views/catalog/show.json.jbuilder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "catalog/show.json" do
   end
 
   let(:hash) do
-    render template: "catalog/show.json", format: :json
+    render template: "catalog/show", formats: [:json]
     JSON.parse(rendered).with_indifferent_access
   end
 


### PR DESCRIPTION
Backports #2614, except this continues to use sprockets etc instead of importmaps for Rails 7. This doesn't preclude applications from choosing to use importmaps.