### PR TITLE
Bug fix: stop the MLT ERB block from accidentally rendering

### DIFF
--- a/app/components/blacklight/document/more_like_this_component.html.erb
+++ b/app/components/blacklight/document/more_like_this_component.html.erb
@@ -2,7 +2,7 @@
   <div class="card-header">More Like This</div>
   <div class="card-body">
     <ul>
-      <%= @document.more_like_this.each do |document| %>
+      <% @document.more_like_this.each do |document| %>
         <li class="more_like_this_document">
           <span class="mlt_title"><%= link_to_document document %></span>
         </li>


### PR DESCRIPTION
Fixes #2616

### Bug
<img width="1285" alt="Screen Shot 2022-02-09 at 4 49 45 PM" src="https://user-images.githubusercontent.com/69827/153304593-cd9c8ce8-5e97-4139-b275-8f8c75e3c392.png">

### Fixed
<img width="1373" alt="Screen Shot 2022-02-09 at 4 52 01 PM" src="https://user-images.githubusercontent.com/69827/153304603-fea87b9e-4013-41dc-bec8-bdc4a16b5f71.png">

