### PR TITLE
Eagerly coerce facet values to strings coming out of FacetItemPresenter#label 

### DIFF
--- a/app/presenters/blacklight/facet_item_presenter.rb
+++ b/app/presenters/blacklight/facet_item_presenter.rb
@@ -58,7 +58,7 @@ module Blacklight
         localization_options = facet_config.date == true ? {} : facet_config.date
         I18n.l(Time.zone.parse(label_value), **localization_options)
       else
-        label_value
+        label_value.to_s
       end
     end
 

--- a/spec/presenters/blacklight/facet_item_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_item_presenter_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Blacklight::FacetItemPresenter, type: :presenter do
   end
 
   describe '#label' do
-    it "is the facet value for an ordinary facet" do
+    it "is the stringified facet value for an ordinary facet" do
       allow(facet_config).to receive_messages(query: nil, date: nil, helper_method: nil, url_method: nil)
-      expect(presenter.label).to eq facet_item
+      expect(presenter.label).to eq facet_item.to_s
     end
 
     it "allows you to pass in a :helper_method argument to the configuration" do


### PR DESCRIPTION
This should make for fewer surprises with downstream code expecting strings. The `value` method provides the original value.

The return value of `label` is used in two places within Blacklight, which expect (and required) a string value:

https://github.com/projectblacklight/blacklight/blob/main/app/components/blacklight/constraint_layout_component.html.erb#L4
https://github.com/projectblacklight/blacklight/blob/main/app/components/blacklight/facet_item_component.rb#L41


This should allow downstream consumers that are working with domain-specific classes (e.g. geoblacklight and Geoblacklight::BoundingBox) to just implement `#to_s` on their object and get reasonable out-of-the-box behavior without much trouble.

