### PR TITLE
Update #render_search_to_page_title to use search state to resolve filters

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -219,21 +219,27 @@ module Blacklight::CatalogHelperBehavior
   # Render an html <title> appropriate string for a set of search parameters
   # @param [ActionController::Parameters] params2
   # @return [String]
-  def render_search_to_page_title(params)
+  def render_search_to_page_title(search_state_or_params)
+    search_state = if search_state_or_params.is_a? Blacklight::SearchState
+                     search_state_or_params
+                   else
+                     controller.search_state_class.new(params, blacklight_config, self)
+                   end
+
     constraints = []
 
-    if params['q'].present?
-      q_label = label_for_search_field(params[:search_field]) unless default_search_field?(params[:search_field])
+    if search_state.query_param.present?
+      q_label = label_for_search_field(search_state.search_field.key) unless search_state.search_field&.key.blank? || default_search_field?(search_state.search_field.key)
 
       constraints += if q_label.present?
-                       [t('blacklight.search.page_title.constraint', label: q_label, value: params['q'])]
+                       [t('blacklight.search.page_title.constraint', label: q_label, value: search_state.query_param)]
                      else
-                       [params['q']]
+                       [search_state.query_param]
                      end
     end
 
-    if params['f'].present?
-      constraints += params['f'].to_unsafe_h.collect { |key, value| render_search_to_page_title_filter(key, Array(value)) }
+    if search_state.filters.any?
+      constraints += search_state.filters.collect { |filter| render_search_to_page_title_filter(filter.key, filter.values) }
     end
 
     constraints.join(' / ')

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name) %>
+<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(search_state), application_name: application_name) %>
 
 <% content_for(:head) do -%>
   <%= render 'catalog/opensearch_response_metadata', response: @response %>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe CatalogHelper do
   end
 
   describe "#render_search_to_page_title" do
-    subject { helper.render_search_to_page_title(params) }
+    subject { helper.render_search_to_page_title(Blacklight::SearchState.new(params, blacklight_config)) }
 
     before do
       allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
@@ -272,7 +272,11 @@ RSpec.describe CatalogHelper do
       allow(helper).to receive(:label_for_search_field).with(nil).and_return('')
     end
 
-    let(:blacklight_config) { Blacklight::Configuration.new }
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.tap do |config|
+        config.add_facet_field 'format'
+      end
+    end
 
     context 'when the f param is an array' do
       let(:params) { ActionController::Parameters.new(q: 'foobar', f: { format: ["Book"] }) }

--- a/spec/views/catalog/index.atom.builder_spec.rb
+++ b/spec/views/catalog/index.atom.builder_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "catalog/index" do
 
   before do
     @response = Blacklight::Solr::Response.new({ response: { numFound: 30 } }, start: 10, rows: 10)
+    allow(controller).to receive(:search_state_class).and_return(Blacklight::SearchState)
     allow(@response).to receive(:documents).and_return(document_list)
     params['content_format'] = 'some_format'
     allow(view).to receive(:action_name).and_return('index')


### PR DESCRIPTION
Some of this might be ripe for backporting, but if it hangs around until v9.0 🤷‍♂️ 