### PR TITLE
Use the class_methods module provided by ActiveSupport::Concern

### DIFF
--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -11,7 +11,7 @@ module Blacklight::SearchContext
     end
   end
 
-  module ClassMethods
+  class_methods do
     # Save the submitted search parameters in the search session
     def record_search_parameters opts = { only: :index }
       before_action :set_current_search_session, opts

--- a/app/models/concerns/blacklight/configurable.rb
+++ b/app/models/concerns/blacklight/configurable.rb
@@ -13,7 +13,7 @@ module Blacklight::Configurable
   end
   attr_writer :blacklight_config
 
-  module ClassMethods
+  class_methods do
     def copy_blacklight_config_from(other_class)
       self.blacklight_config = other_class.blacklight_config.inheritable_copy(self)
     end

--- a/app/models/concerns/blacklight/document.rb
+++ b/app/models/concerns/blacklight/document.rb
@@ -103,7 +103,7 @@ module Blacklight::Document
 
   # Certain class-level methods needed for the document-specific
   # extendability architecture
-  module ClassMethods
+  class_methods do
     attr_writer :unique_key
 
     def unique_key

--- a/app/models/concerns/blacklight/document/active_model_shim.rb
+++ b/app/models/concerns/blacklight/document/active_model_shim.rb
@@ -8,7 +8,7 @@ module Blacklight::Document
 
     include ::ActiveModel::Conversion
 
-    module ClassMethods
+    class_methods do
       # This is actually an ActiveRecord method starting in Rails 5.2
       def polymorphic_name
         base_class.name

--- a/app/models/concerns/blacklight/document/extensions.rb
+++ b/app/models/concerns/blacklight/document/extensions.rb
@@ -30,7 +30,7 @@ module Blacklight::Document::Extensions
     end
   end
 
-  module ClassMethods
+  class_methods do
     attr_writer :registered_extensions
 
     # Returns array of hashes of registered extensions. Each hash

--- a/app/models/concerns/blacklight/document/semantic_fields.rb
+++ b/app/models/concerns/blacklight/document/semantic_fields.rb
@@ -4,7 +4,7 @@ module Blacklight::Document
   module SemanticFields
     extend ActiveSupport::Concern
 
-    module ClassMethods
+    class_methods do
       # Class-level method for accessing/setting semantic mappings
       # for solr stored fields. Can be set by local app, key is
       # a symbol for a semantic, value is a solr _stored_ field.

--- a/lib/blacklight/configuration/fields.rb
+++ b/lib/blacklight/configuration/fields.rb
@@ -7,7 +7,7 @@ module Blacklight
     module Fields
       extend ActiveSupport::Concern
 
-      module ClassMethods
+      class_methods do
         # Add a configuration block for a collection of solr fields
         def define_field_access(key, options = {})
           key = key.to_s if respond_to? :to_s


### PR DESCRIPTION
This is the documented way of using AS::Concern, using the ClassMethods module seems to rely on an undocumented implementation detail.