### PR TITLE
Guard against bootstrap variable not being defined

### DIFF
--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -197,7 +197,7 @@ modal.receiveAjax = function (contents) {
   }
 
   modal.hide = function(el) {
-    if (bootstrap.Modal.VERSION >= "5") {
+    if (bootstrap && bootstrap.Modal && bootstrap.Modal.VERSION >= "5") {
       bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
     } else {
       $(el || modal.modalSelector).modal('hide');
@@ -205,7 +205,7 @@ modal.receiveAjax = function (contents) {
   }
 
   modal.show = function(el) {
-    if (bootstrap.Modal.VERSION >= "5") {
+    if (bootstrap && bootstrap.Modal && bootstrap.Modal.VERSION >= "5") {
       bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
     } else {
       $(el || modal.modalSelector).modal('show');


### PR DESCRIPTION
fixes #2612

- Bootstrap 5.x always creates `window.bootstrap`. 
- Bootstrap 4.x creates `window.bootstrap` if the application loads `bootstrap`
- Bootstrap 4.x injects its classes directly on the window if the application loads `bootstrap-sprockets`


