### PR TITLE
Backport #2579: Mark required fields as required

### DIFF
--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -11,7 +11,7 @@
         <%= t('blacklight.email.form.to') %>
       </label>
       <div class="col-sm-10">
-        <%= email_field_tag :to, params[:to], class: 'form-control' %>
+        <%= email_field_tag :to, params[:to], class: 'form-control', required: true %>
       </div>
     </div>
 

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -6,16 +6,16 @@
 <div class="modal-body">
   <%= render '/shared/flash_msg' %>
     <div class="form-group row">
-      <label class="control-label col-sm-2" for="to"> 
+      <label class="control-label col-sm-2" for="to">
         <%= t('blacklight.sms.form.to') %>
       </label>
       <div class="col-sm-10">
-        <%= telephone_field_tag :to, params[:to], class: 'form-control' %>
+        <%= telephone_field_tag :to, params[:to], class: 'form-control', required: true %>
       </div>
     </div>
     <div class="form-group row">
       <label class="control-label col-sm-2" for="carrier">
-        <%= t('blacklight.sms.form.carrier') %> 
+        <%= t('blacklight.sms.form.carrier') %>
       </label>
       <div class="col-sm-10">
           <%= select_tag(:carrier, options_for_select(sms_mappings.to_a.sort.unshift([t('blacklight.sms.form.carrier_prompt'),'']), params[:carrier]), class: 'form-control') %><br/>


### PR DESCRIPTION
This allows screen readers to let the users know this field is required and prevents invalid form submissions