### PR TITLE
Rails 5 already has an application.js file

### DIFF
--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -19,8 +19,11 @@ module Blacklight
       remove_file 'app/javascript/application.js'
     end
 
-    # Add sprockets javascript
+    # Add sprockets javascript if needed
     def create_sprockets_javascript
+      # Rails 5 already has an application.js file
+      return if Rails.version < '6'
+
       create_file 'app/assets/javascripts/application.js' do
         <<~CONTENT
           //= require jquery3


### PR DESCRIPTION
Apparently the generated file is good enough for our test suite, but downstream gems and applications expect that we haven't messed with it (spotlight, at least, is expecting `//= require_tree .` to still be there..) 🤷‍♂️ 