### PR TITLE
Use thread_mattr_accessor instead of deprecated ActiveSupport::PerThreadRegistry

### DIFF
--- a/lib/blacklight/runtime_registry.rb
+++ b/lib/blacklight/runtime_registry.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'active_support/per_thread_registry'
-
 module Blacklight
   class RuntimeRegistry
-    extend ActiveSupport::PerThreadRegistry
-
-    attr_accessor :connection, :connection_config
+    thread_mattr_accessor :connection, :connection_config
   end
 end


### PR DESCRIPTION
> DEPRECATION WARNING: ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1.
Use `Module#thread_mattr_accessor` instead.

`thread_mattr_accessor` was added back in Rails 5.