### PR TITLE
Backport #2649: Use thread_mattr_accessor instead of deprecated ActiveSupport::PerThreadRegistry

### DIFF
--- a/lib/blacklight/runtime_registry.rb
+++ b/lib/blacklight/runtime_registry.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'active_support/per_thread_registry'
-
 module Blacklight
   class RuntimeRegistry
-    extend ActiveSupport::PerThreadRegistry
-
-    attr_accessor :connection, :connection_config
+    thread_mattr_accessor :connection, :connection_config
   end
 end


### PR DESCRIPTION
thread_mattr_accessor was added back in Rails 5.

Backports #2649 