### PR TITLE
Bring the facebook param fix to inclusive facets as well

### DIFF
--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -39,11 +39,8 @@ module Blacklight
       end
 
       # Normalize facet parameters mangled by facebook
-      if params[:f].is_a?(Hash) && params[:f].values.any? { |x| x.is_a?(Hash) }
-        params[:f] = params[:f].transform_values do |value|
-          value.is_a?(Hash) ? value.values : value
-        end
-      end
+      params[:f] = normalize_facet_params(params[:f]) if facet_params_need_normalization(params[:f])
+      params[:f_inclusive] = normalize_facet_params(params[:f_inclusive]) if facet_params_need_normalization(params[:f_inclusive])
 
       params
     end
@@ -190,6 +187,16 @@ module Blacklight
 
     def facet_prefix
       params[facet_request_keys[:prefix]]
+    end
+
+    def self.facet_params_need_normalization(facet_params)
+      facet_params.is_a?(Hash) && facet_params.values.any? { |x| x.is_a?(Hash) }
+    end
+
+    def self.normalize_facet_params(facet_params)
+      facet_params.transform_values do |value|
+        value.is_a?(Hash) ? value.values : value
+      end
     end
 
     private

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -48,10 +48,14 @@ RSpec.describe Blacklight::SearchState do
     end
 
     context 'with facebooks badly mangled query parameters' do
-      let(:params) { { f: { field: { '0': 'first', '1': 'second' } } } }
+      let(:params) do
+        { f: { field: { '0': 'first', '1': 'second' } },
+          f_inclusive: { field: { '0': 'first', '1': 'second' } } }
+      end
 
       it 'normalizes the facets to the expected format' do
         expect(search_state.to_h).to include f: { field: %w[first second] }
+        expect(search_state.to_h).to include f_inclusive: { field: %w[first second] }
       end
     end
 


### PR DESCRIPTION
This allows users to pass in URLs in the format http://[domain]?f_inclusive[format][0]=Book

Closes #2653 