### PR TITLE
Don't allow constraint values to wrap

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -12,6 +12,7 @@
     cursor: default;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
 
     @media (max-width: breakpoint-min(sm)) {
       max-width: breakpoint-min(sm) * .5;


### PR DESCRIPTION
In #2554, we allowed the row of constraint values to wrap... but the text of each constraint shouldn't wrap and should be truncated.

Before:
![Screen Shot 2022-03-10 at 09 22 50](https://user-images.githubusercontent.com/111218/157719703-342fc9bf-555a-4f92-890d-fdb3e09a21fa.png)

After:
![Screen Shot 2022-03-10 at 09 24 04](https://user-images.githubusercontent.com/111218/157719901-a4771f32-654e-418d-b99c-0ec2970325c8.png)


