### PR TITLE
Explicitly use the top-level Deprecation class

### DIFF
--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <%= content_tag :div, id: @panel_id, class: 'facets-collapse collapse' do %>
-    <% Deprecation.silence(Blacklight::FacetsHelperBehavior) do %>
+    <% ::Deprecation.silence(Blacklight::FacetsHelperBehavior) do %>
       <%= helpers.render_facet_partials @fields, response: @response %>
     <% end %>
   <% end %>


### PR DESCRIPTION
In https://github.com/github/view_component/pull/1277, view_components 2.50 added their own `Deprecation` class that stomps on our expected class 🤷‍♂️ 