### PR TITLE
implementation ideas for #2647

### DIFF
--- a/app/components/blacklight/compiler_demonstration_component.html.erb
+++ b/app/components/blacklight/compiler_demonstration_component.html.erb
@@ -1,0 +1,1 @@
+<h1>Engine Template</h1>

--- a/app/components/blacklight/compiler_demonstration_component.rb
+++ b/app/components/blacklight/compiler_demonstration_component.rb
@@ -1,0 +1,30 @@
+# this approach has less API vulnerability but won't allow addition of sidecar files
+module Blacklight
+  class CompilerDemonstrationComponent < ::ViewComponent::Base
+    class << self
+      def compiler
+        @__vc_compiler ||= EngineCompiler.new(self)
+      end
+    end
+
+  class EngineCompiler < ::ViewComponent::Compiler
+    def templates
+      @templates ||=
+        begin
+          extensions = ActionView::Template.template_handler_extensions
+
+          component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|
+            pieces = File.basename(path).split(".")
+            app_path = "#{Rails.root}/#{path.slice(path.index(@component_class.view_component_path)..-1)}"
+
+            memo << {
+              path: File.exist?(app_path) ? app_path : path,
+              variant: pieces.second.split("+").second&.to_sym,
+              handler: pieces.last
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/blacklight/compiler_demonstration_component.rb
+++ b/app/components/blacklight/compiler_demonstration_component.rb
@@ -1,16 +1,19 @@
+# frozen_string_literal: true
+
 # this approach has less API vulnerability but won't allow addition of sidecar files
 module Blacklight
   class CompilerDemonstrationComponent < ::ViewComponent::Base
     class << self
+      # rubocop:disable Naming/MemoizedInstanceVariableName
       def compiler
         @__vc_compiler ||= EngineCompiler.new(self)
       end
+      # rubocop:enable Naming/MemoizedInstanceVariableName
     end
 
-  class EngineCompiler < ::ViewComponent::Compiler
-    def templates
-      @templates ||=
-        begin
+    class EngineCompiler < ::ViewComponent::Compiler
+      def templates
+        @templates ||= begin
           extensions = ActionView::Template.template_handler_extensions
 
           component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|

--- a/app/components/blacklight/sidecar_demonstration_component.all.yml
+++ b/app/components/blacklight/sidecar_demonstration_component.all.yml
@@ -1,0 +1,55 @@
+en:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+ar:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+de:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+es:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+fr:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+hu:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+it:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+nl:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+pt-BR:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+sq:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"
+zh:
+  application_header: "Engine Translation"
+  blacklight:
+    sidecar_demonstration_component:
+      application_header: "Engine Translation"

--- a/app/components/blacklight/sidecar_demonstration_component.html.erb
+++ b/app/components/blacklight/sidecar_demonstration_component.html.erb
@@ -1,0 +1,1 @@
+<h1 class="engine"><%= t(".application_header") %></h1>

--- a/app/components/blacklight/sidecar_demonstration_component.rb
+++ b/app/components/blacklight/sidecar_demonstration_component.rb
@@ -1,17 +1,17 @@
+# frozen_string_literal: true
+
 # This approach permits the addition of sidecar files in the installing application, but relies on less stable APIs
 module Blacklight
   class SidecarDemonstrationComponent < ::ViewComponent::Base
+    include ViewComponent::Translatable
     class << self
       def _sidecar_files(extensions)
         return [] unless source_location
+
         engine_directory = File.dirname(source_location)
         engine_sidecars = _sidecar_files_in(engine_directory, extensions)
         app_directory = "#{Rails.root}/#{engine_directory.slice(engine_directory.index(view_component_path)..-1)}"
-        if app_directory == engine_directory
-          return engine_sidecars.values
-        else
-          return engine_sidecars.merge(_sidecar_files_in(app_directory, extensions)).values
-        end
+        app_directory == engine_directory ? engine_sidecars.values : engine_sidecars.merge(_sidecar_files_in(app_directory, extensions)).values
       end
 
       # this is essentially the original _sidecar_files implementation with a parameterized directory,
@@ -48,7 +48,7 @@ module Blacklight
         sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
 
         paths = (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
-        paths.map { |path|  [path.sub(directory, ""), path]}.to_h
+        paths.index_by { |path| path.sub(directory, "") }
       end
     end
   end

--- a/app/components/blacklight/sidecar_demonstration_component.rb
+++ b/app/components/blacklight/sidecar_demonstration_component.rb
@@ -1,0 +1,55 @@
+# This approach permits the addition of sidecar files in the installing application, but relies on less stable APIs
+module Blacklight
+  class SidecarDemonstrationComponent < ::ViewComponent::Base
+    class << self
+      def _sidecar_files(extensions)
+        return [] unless source_location
+        engine_directory = File.dirname(source_location)
+        engine_sidecars = _sidecar_files_in(engine_directory, extensions)
+        app_directory = "#{Rails.root}/#{engine_directory.slice(engine_directory.index(view_component_path)..-1)}"
+        if app_directory == engine_directory
+          return engine_sidecars.values
+        else
+          return engine_sidecars.merge(_sidecar_files_in(app_directory, extensions)).values
+        end
+      end
+
+      # this is essentially the original _sidecar_files implementation with a parameterized directory,
+      # allowing lookup in the installing app if necessary. It returns a Hash to allow override via merge
+      def _sidecar_files_in(directory, extensions)
+        return {} unless directory
+
+        extensions = extensions.join(",")
+
+        # view files in a directory named like the component
+        filename = File.basename(source_location, ".rb")
+        component_name = name.demodulize.underscore
+
+        # Add support for nested components defined in the same file.
+        #
+        # for example
+        #
+        # class MyComponent < ViewComponent::Base
+        #   class MyOtherComponent < ViewComponent::Base
+        #   end
+        # end
+        #
+        # Without this, `MyOtherComponent` will not look for `my_component/my_other_component.html.erb`
+        nested_component_files =
+          if name.include?("::") && component_name != filename
+            Dir["#{directory}/#{filename}/#{component_name}.*{#{extensions}}"]
+          else
+            []
+          end
+
+        # view files in the same directory as the component
+        sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
+
+        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
+
+        paths = (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
+        paths.map { |path|  [path.sub(directory, ""), path]}.to_h
+      end
+    end
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -5,6 +5,8 @@ data:
   read:
     - config/locales/%{locale}.yml
     - config/locales/**/*.%{locale}.yml
+    - app/components/**/*.%{locale}.yml
+    - app/components/**/*.all.yml
 
   yaml:
     write:
@@ -12,6 +14,13 @@ data:
 search:
   paths:
    - app/
+  relative_roots:
+   - app/components
+   - app/controllers
+   - app/helpers
+   - app/mailers
+   - app/presenters
+   - app/views
   exclude:
     - app/assets/images
     - app/assets/fonts

--- a/lib/generators/blacklight/templates/components/blacklight/compiler_demonstration_component.html.erb
+++ b/lib/generators/blacklight/templates/components/blacklight/compiler_demonstration_component.html.erb
@@ -1,0 +1,1 @@
+<h1>Application Template</h1>

--- a/lib/generators/blacklight/templates/components/blacklight/sidecar_demonstration_component.all.yml
+++ b/lib/generators/blacklight/templates/components/blacklight/sidecar_demonstration_component.all.yml
@@ -1,0 +1,22 @@
+en:
+  application_header: "Application Translation"
+ar:
+  application_header: "Application Translation"
+de:
+  application_header: "Application Translation"
+es:
+  application_header: "Application Translation"
+fr:
+  application_header: "Application Translation"
+hu:
+  application_header: "Application Translation"
+it:
+  application_header: "Application Translation"
+nl:
+  application_header: "Application Translation"
+pt-BR:
+  application_header: "Application Translation"
+sq:
+  application_header: "Application Translation"
+zh:
+  application_header: "Application Translation"

--- a/lib/generators/blacklight/templates/components/blacklight/sidecar_demonstration_component.html.erb
+++ b/lib/generators/blacklight/templates/components/blacklight/sidecar_demonstration_component.html.erb
@@ -1,0 +1,1 @@
+<h1 class="application"><%= t(".application_header") %></h1>

--- a/lib/generators/blacklight/test_support_generator.rb
+++ b/lib/generators/blacklight/test_support_generator.rb
@@ -48,5 +48,9 @@ module Blacklight
         EOF
       end
     end
+
+    def alternate_component_templates
+      directory "components", "app/components/"
+    end
   end
 end

--- a/spec/components/blacklight/compiler_demonstration_component_spec.rb
+++ b/spec/components/blacklight/compiler_demonstration_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::CompilerDemonstrationComponent, type: :component do
+  subject(:rendered) do
+    render_inline(component)
+  end
+
+  let(:component) { described_class.new }
+
+  it 'renders from the application template' do
+    # described_class.compiler.compile
+    element = rendered.css('h1').first
+    expect(element.text).to eql "Application Template"
+  end
+end

--- a/spec/components/blacklight/sidecar_demonstration_component_spec.rb
+++ b/spec/components/blacklight/sidecar_demonstration_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::SidecarDemonstrationComponent, type: :component do
+  subject(:rendered) do
+    render_inline(component)
+  end
+
+  let(:component) { described_class.new }
+
+  it 'renders from the application template' do
+    # described_class.compiler.compile
+    element = rendered.css('h1.application').first
+    expect(element.text).to eql "Application Translation"
+  end
+end


### PR DESCRIPTION
A couple of ideas for how to implement a base view component that would allow a more familiar template override pattern to Blacklight installations not using view components, and a less labor intensive way to have only a change in template.

See also: https://github.com/github/view_component/issues/411