### PR TITLE
Allow the search button to be passed into the search bar using a slot

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -28,11 +28,7 @@
 
     <span class="input-group-append">
       <%= append(form: f) %>
-
-      <%= f.button class: 'btn btn-primary search-btn', id: "#{@prefix}search" do %>
-        <span class="submit-search-text"><%= scoped_t('submit') %></span>
-        <%= blacklight_icon :search, aria_hidden: true %>
-      <% end %>
+      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
     </span>
   </div>
 <% end %>

--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -4,6 +4,7 @@ module Blacklight
   class SearchBarComponent < ::ViewComponent::Base
     renders_one :append
     renders_one :prepend
+    renders_one :search_button
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(

--- a/app/components/blacklight/search_button_component.rb
+++ b/app/components/blacklight/search_button_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class SearchButtonComponent < ::ViewComponent::Base
+    def initialize(text:, id:)
+      @text = text
+      @id = id
+    end
+
+    def call
+      tag.button(class: 'btn btn-primary search-btn', type: 'submit', id: @id) do
+        tag.span(@text, class: "submit-search-text") +
+          blacklight_icon(:search, aria_hidden: true)
+      end
+    end
+  end
+end

--- a/spec/components/blacklight/search_bar_component_spec.rb
+++ b/spec/components/blacklight/search_bar_component_spec.rb
@@ -3,11 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::SearchBarComponent, type: :component do
-  subject(:render) { render_inline(instance) }
+  let(:instance) { described_class.new(url: search_action_url, params: params_for_search) }
 
   let(:search_action_url) { '/catalog' }
   let(:params_for_search) { { q: 'testParamValue' } }
-  let(:instance) { described_class.new(url: search_action_url, params: params_for_search) }
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
       config.view = { list: nil, abc: nil }
@@ -18,7 +17,28 @@ RSpec.describe Blacklight::SearchBarComponent, type: :component do
     allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
   end
 
-  it 'renders the field aria-label' do
-    expect(render.css("[aria-label='#{I18n.t('blacklight.search.form.search.label')}']")).to be_present
+  context 'with the default button' do
+    subject(:render) { render_inline(instance) }
+
+    it 'renders the search field and a button' do
+      expect(render.css("input[aria-label='#{I18n.t('blacklight.search.form.search.label')}']")).to be_present
+      expect(render.css("button#search")).to be_present
+    end
+  end
+
+  context 'when a button is passed in' do
+    subject(:render) do
+      render_inline(instance) do |c|
+        c.search_button do
+          controller.view_context.tag.button "hello", id: 'custom_search'
+        end
+      end
+    end
+
+    it 'renders the search field and a button' do
+      expect(render.css("input[aria-label='#{I18n.t('blacklight.search.form.search.label')}']")).to be_present
+      expect(render.css("button#search")).not_to be_present
+      expect(render.css("button#custom_search")).to be_present
+    end
   end
 end


### PR DESCRIPTION
This gives the user a way of customizing the search button without having to override the SearchBarComponent