### PR TITLE
Test on Rails 6.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -82,7 +82,7 @@ jobs:
       env:
         RAILS_VERSION: 6.0.3.4
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
-  test_rails7_0:
+  test_rails6_1:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -96,11 +96,11 @@ jobs:
     - name: Install dependencies
       run: bundle install
       env:
-        RAILS_VERSION: 7.0.0
+        RAILS_VERSION: 6.1.5
     - name: Run tests
       run: bundle exec rake ci
       env:
-        RAILS_VERSION: 7.0.0
+        RAILS_VERSION: 6.1.5
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-keeps --skip-action-cable --skip-test'
   api_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that rails 7 has been released, our tests where we don't specify a rails version is testing version 7.  We need to specifically test on Rails 6.1