### PR TITLE
Stop testing on ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6]
+        ruby: [2.7]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_from:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
   - "lib/generators/blacklight/templates/**/*"
   - "blacklight.gemspec"

--- a/app/models/concerns/blacklight/configurable.rb
+++ b/app/models/concerns/blacklight/configurable.rb
@@ -33,8 +33,8 @@ module Blacklight::Configurable
     attr_writer :blacklight_config
 
     # simply a convenience method for blacklight_config.configure
-    def configure_blacklight(*args, &block)
-      blacklight_config.configure(*args, &block)
+    def configure_blacklight(...)
+      blacklight_config.configure(...)
     end
 
     ##

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_dependency "rails", '>= 5.1', '< 8'
   s.add_dependency "globalid"

--- a/lib/blacklight/nested_open_struct_with_hash_access.rb
+++ b/lib/blacklight/nested_open_struct_with_hash_access.rb
@@ -64,8 +64,8 @@ module Blacklight
       self.class.new nested_class, @table.deep_dup
     end
 
-    def select *args, &block
-      self.class.new nested_class, to_h.select(*args, &block)
+    def select(...)
+      self.class.new nested_class, to_h.select(...)
     end
 
     ##

--- a/lib/blacklight/open_struct_with_hash_access.rb
+++ b/lib/blacklight/open_struct_with_hash_access.rb
@@ -16,16 +16,16 @@ module Blacklight
       @table
     end
 
-    def select *args, &block
-      self.class.new to_h.select(*args, &block)
+    def select(...)
+      self.class.new to_h.select(...)
     end
 
-    def sort_by *args, &block
-      self.class.new to_h.sort_by(*args, &block).to_h
+    def sort_by(...)
+      self.class.new to_h.sort_by(...).to_h
     end
 
-    def sort_by! *args, &block
-      replace to_h.sort_by(*args, &block).to_h
+    def sort_by!(...)
+      replace to_h.sort_by(...).to_h
       self
     end
 


### PR DESCRIPTION
Ruby 2.6 is no longer supported. It no longer receives security updates.  https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/