### PR TITLE
End special handling of non-200 HTTP responses from Solr

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -16,10 +16,6 @@ module Blacklight::Catalog
       helper_method :sms_mappings, :has_search_parameters?
     end
 
-    # The index action will more than likely throw this one.
-    # Example: when the standard query parser is used, and a user submits a "bad" query.
-    rescue_from Blacklight::Exceptions::InvalidRequest, with: :handle_request_error
-
     record_search_parameters
   end
 
@@ -276,25 +272,5 @@ module Blacklight::Catalog
 
   def determine_layout
     action_name == 'show' ? 'catalog_result' : super
-  end
-
-  # when a method throws a Blacklight::Exceptions::InvalidRequest, this method is executed.
-  def handle_request_error(exception)
-    # Rails own code will catch and give usual Rails error page with stack trace
-    raise exception if Rails.env.development? || Rails.env.test?
-
-    flash_notice = I18n.t('blacklight.search.errors.request_error')
-
-    # If there are errors coming from the index page, we want to trap those sensibly
-
-    if flash[:notice] == flash_notice
-      logger&.error "Cowardly aborting rsolr_request_error exception handling, because we redirected to a page that raises another exception"
-      raise exception
-    end
-
-    logger&.error exception
-
-    flash[:notice] = flash_notice
-    redirect_to search_action_url
   end
 end

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -154,7 +154,6 @@ ar:
       search_constraints_header: 'قيود البحث'
       search_results: 'نتائج البحث'
       errors:
-        request_error: "معذرة، لم أفهم ما تبحث عنه."
         invalid_solr_id: "معذرة! لقد طلبت سجلًا غير موجود."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> لكل صفحة</span>'

--- a/config/locales/blacklight.ca.yml
+++ b/config/locales/blacklight.ca.yml
@@ -144,7 +144,6 @@ ca:
       search_constraints_header: 'Filtres de la cerca'
       search_results: 'Resultats de la cerca'
       errors:
-        request_error: "No ha estat possible entendre la cerca"
         invalid_solr_id: "El registre que heu sol·licitat no existeix."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> per pàgina</span>'

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -144,7 +144,6 @@ de:
       search_constraints_header: 'Suchen'
       search_results: 'Suchergebnisse'
       errors:
-        request_error: "Entschuldigung, ich habe Ihre Suche nicht verstanden."
         invalid_solr_id: "Entschuldigung, Sie haben einen nicht vorhandenen Datensatz angefordert."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> pro Seite</span>'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -144,7 +144,6 @@ en:
       search_constraints_header: 'Search Constraints'
       search_results: 'Search Results'
       errors:
-        request_error: "Sorry, I don't understand your search."
         invalid_solr_id: "Sorry, you have requested a record that doesn't exist."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> per page</span>'

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -144,7 +144,6 @@ es:
       search_constraints_header: 'Buscar'
       search_results: 'Resultados de la búsqueda'
       errors:
-        request_error: "Lo siento, no entiendo esta búsqueda"
         invalid_solr_id: "Lo sentimos, usted ha solicitado un registro que no existe."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> por página</span>'

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -147,7 +147,6 @@ fr:
       search_constraints_header: 'Recherche'
       search_results: 'Résultats de recherche'
       errors:
-        request_error: "Pardon, nous n'avons pas compris votre recherche."
         invalid_solr_id: "Vous avez demandé une notice qui n'existe pas."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> par page</span>'

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -144,7 +144,6 @@ hu:
       search_constraints_header: 'Keresés feltételei'
       search_results: 'Keresés eredményei'
       errors:
-        request_error: "Elnézést, nem tudom értelmezni a keresést."
         invalid_solr_id: "Elnézést, de az Ön által kért rekord nem létezik."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> oldalanként</span>'

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -144,7 +144,6 @@ it:
       search_constraints_header: 'Ricerca'
       search_results: 'Risultati della ricerca'
       errors:
-        request_error: "La richiesta non è comprensibile."
         invalid_solr_id: "Il numero di scheda richiesto non esiste."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> per pagina</span>'

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -144,7 +144,6 @@ nl:
       search_constraints_header: 'Zoek filters'
       search_results: 'Zoek resultaten'
       errors:
-        request_error: "Sorry, ik kon uw zoekopdracht niet begrijpen."
         invalid_solr_id: "Sorry, u vroeg een onbestaande record op."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> per pagina</span>'

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -145,7 +145,6 @@ pt-BR:
       search_constraints_header: 'Busca'
       search_results: 'Resultados da Busca'
       errors:
-        request_error: "Desculpe, Eu não compreendi sua busca."
         invalid_solr_id: "Desculpe, você solicitou um cadastro que não existe."
       per_page:
         label: '%{count}<span class="hide-text"> por página</span>'

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -144,7 +144,6 @@ sq:
       search_constraints_header: 'Kufizimet e kërkimit'
       search_results: 'Rezultatet e kërkimit'
       errors:
-        request_error: "Na vjen keq, unë nuk e kuptoj kërkimin tuaj."
         invalid_solr_id: "Na vjen keq, ju keni kërkuar një të dhënë që nuk ekziston."
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> për faqe</span>'

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -144,7 +144,6 @@ zh:
       search_constraints_header: '搜索条件'
       search_results: '搜索结果'
       errors:
-        request_error: "抱歉，我不明白你要找什么。"
         invalid_solr_id: "抱歉，你要找的结果不存在。"
       per_page:
         label: '%{count}<span class="sr-only visually-hidden"> 每页</span>'

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -3,6 +3,12 @@ class <%= controller_name.classify %>Controller < ApplicationController
 
   include Blacklight::Catalog
 
+  # If you'd like to handle errors returned by Solr in a certain way,
+  # you can use Rails rescue_from with a method you define in this controller,
+  # uncomment:
+  #
+  # rescue_from Blacklight::Exceptions::InvalidRequest, with: :my_handling_method
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -588,31 +588,6 @@ RSpec.describe CatalogController, api: true do
         get :citation, params: { id: "bad-record-identifer" }
       end.to raise_error Blacklight::Exceptions::RecordNotFound
     end
-
-    context "when there is an invalid search", api: false do
-      let(:service) { instance_double(Blacklight::SearchService) }
-      let(:fake_error) { Blacklight::Exceptions::InvalidRequest.new }
-
-      before do
-        allow(controller).to receive(:search_service).and_return(service)
-        allow(service).to receive(:search_results) { |*_args| raise fake_error }
-        allow(Rails.env).to receive_messages(test?: false)
-      end
-
-      it "redirects the user to the root url for a bad search" do
-        expect(controller.logger).to receive(:error).with(fake_error)
-        get :index, params: { q: '+' }
-        expect(response.redirect_url).to eq root_url
-        expect(request.flash[:notice]).to eq "Sorry, I don't understand your search."
-        expect(response).not_to be_successful
-        expect(response.status).to eq 302
-      end
-
-      it "returns status 500 if the catalog path is raising an exception" do
-        allow(controller).to receive(:flash).and_return(notice: I18n.t('blacklight.search.errors.request_error'))
-        expect { get :index, params: { q: '+' } }.to raise_error Blacklight::Exceptions::InvalidRequest
-      end
-    end
   end
 
   context "without a user authentication provider" do


### PR DESCRIPTION
Closes #2660, where:

> Blacklight committer's call on 3/16/2022 consensus seems to be to stop capturing this error. We support a PR for that.
-- https://github.com/projectblacklight/blacklight/issues/2660#issuecomment-1069469039

I believe people were potentially interested in a subsequent PR to re-introduce a different kind of error handling, perhaps behind a config option.

It would be good to get this in before Blacklight 8 release, as it could be considered a backwards breaking change. It would also be good to mention it in release notes -- I'm not sure if we have a way to collect things to list in release notes, pre-release? 
