### PR TITLE
Update Github Actions to use "checkout@v3"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -33,7 +33,7 @@ jobs:
       matrix:
         ruby: [2.7, '3.0', 3.1]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -50,7 +50,7 @@ jobs:
       matrix:
         ruby: ['3.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -68,7 +68,7 @@ jobs:
       matrix:
         ruby: [2.6]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -88,7 +88,7 @@ jobs:
       matrix:
         ruby: ['3.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         ruby: [2.7, '3.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -123,6 +123,6 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build docker image
       run: docker-compose build app


### PR DESCRIPTION
Doesn't seem to actually have any pertinent changes -- just updates the node version used, which should not be a problem for our CI.

https://github.com/actions/checkout/blob/main/CHANGELOG.md

But good to keep up to date, so we are on current version of the action, so we continue to get new releases in that major version series, with possible bugfixes and such.
