### PR TITLE
Search state should only handle authorized parameters

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -253,6 +253,16 @@ module Blacklight
     # @return [Boolean]
     property :enable_search_bar_autofocus, default: false
 
+    BASIC_SEARCH_PARAMETERS = [:q, :f, :f_inclusive, :page, :per_page, :rows, :sort, :search_field, :controller, :action, :format].freeze
+    ADVANCED_SEARCH_PARAMETERS = [:clause, :op].freeze
+    # List the request parameters that compose the SearchState.
+    # If you use a plugin that adds to the search state, then you can add the parameters
+    # by modifiying this field.
+    # @!attribute search_state_fields
+    # @since v8.0.0
+    # @return [Array<Symbol>]
+    property :search_state_fields, default: BASIC_SEARCH_PARAMETERS + ADVANCED_SEARCH_PARAMETERS
+
     ##
     # Create collections of solr field configurations.
     # This will create array-like accessor methods for

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -34,6 +34,9 @@ class <%= controller_name.classify %>Controller < ApplicationController
     # items to show per page, each number in the array represent another option to choose from.
     #config.per_page = [10,20,50,100]
 
+    # Additional request parameters that compose the search state may be added
+    # config.search_state_fields += %i[some_other_field]
+
     # solr field configuration for search results/index views
     config.index.title_field = 'title_tsim'
     #config.index.display_type_field = 'format'

--- a/spec/controllers/blacklight/base_spec.rb
+++ b/spec/controllers/blacklight/base_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Blacklight::Base do
   describe "#search_state" do
     subject { controller.send(:search_state) }
 
-    let(:raw_params) { HashWithIndifferentAccess.new a: 1 }
+    let(:raw_params) { HashWithIndifferentAccess.new q: 1 }
     let(:params) { ActionController::Parameters.new raw_params }
 
     before { allow(controller).to receive_messages(params: params) }


### PR DESCRIPTION
This prevents unrelated form fields from polluting the search state.
Fixes #2683