### PR TITLE
Blacklight::Component uses a compiler that will use a template from the installing app

### DIFF
--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -2,5 +2,39 @@
 
 module Blacklight
   class Component < ViewComponent::Base
+    class << self
+      # rubocop:disable Naming/MemoizedInstanceVariableName
+      def compiler
+        @__vc_compiler ||= EngineCompiler.new(self)
+      end
+      # rubocop:enable Naming/MemoizedInstanceVariableName
+    end
+
+    class EngineCompiler < ::ViewComponent::Compiler
+      # ViewComponent::Compiler locates and caches templates from sidecar files to the component source file.
+      # While this is sensible in a Rails application, it prevents component templates defined in an Engine
+      # from being overridden by an installing application without subclassing the component, which may also
+      # require modifying any partials rendering the component. This subclass of compiler overrides the template
+      # location algorithm to take the sidecar file names from the Engine, but look to see if a file of the
+      # same name existing in the installing application (ie, under Rails.root). If the latter exists, this
+      # compiler will cache that template instead of the engine-defined file; if not, the compiler will fall
+      # back to the engine-defined file.
+      def templates
+        @templates ||= begin
+          extensions = ActionView::Template.template_handler_extensions
+
+          component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|
+            pieces = File.basename(path).split(".")
+            app_path = "#{Rails.root}/#{path.slice(path.index(component_class.view_component_path)..-1)}"
+
+            memo << {
+              path: File.exist?(app_path) ? app_path : path,
+              variant: pieces.second.split("+").second&.to_sym,
+              handler: pieces.last
+            }
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/lib/blacklight/component_spec.rb
+++ b/spec/lib/blacklight/component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::Component do
+  let(:component_class) { Blacklight::DocumentTitleComponent }
+
+  context "subclassed" do
+    it "returns our Compiler implementation" do
+      expect(component_class.ancestors).to include described_class
+      expect(component_class.compiler).to be_a Blacklight::Component::EngineCompiler
+    end
+  end
+
+  describe Blacklight::Component::EngineCompiler do
+    subject(:compiler) { described_class.new(component_class) }
+
+    let(:original_compiler) { ViewComponent::Compiler.new(component_class) }
+    let(:original_path) { original_compiler.send(:templates).first[:path] }
+    let(:resolved_path) { compiler.templates.first[:path] }
+
+    context "without overrides" do
+      it "links to engine template" do
+        expect(resolved_path).not_to include(".internal_test_app")
+        expect(resolved_path).to eql(original_path)
+      end
+    end
+
+    context "with overrides" do
+      let(:path_match) do
+        Regexp.new(Regexp.escape(File.join(".internal_test_app", component_class.view_component_path)))
+      end
+
+      before do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(path_match).and_return(true)
+      end
+
+      it "links to application template" do
+        expect(resolved_path).to include(".internal_test_app")
+        expect(resolved_path).not_to eql(original_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- this permits overriding existing sidecar files, but not the addition of new files (e.g. translations)
- port fixes #2692