### PR TITLE
Port Blacklight::SearchState only manages permitted params to main

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -253,6 +253,16 @@ module Blacklight
     # @return [Boolean]
     property :enable_search_bar_autofocus, default: false
 
+    BASIC_SEARCH_PARAMETERS = [:q, :qt, :page, :per_page, :search_field, :sort, :controller, :action, :'facet.page', :'facet.prefix', :'facet.sort', :rows, :format].freeze
+    ADVANCED_SEARCH_PARAMETERS = [:clause, :op].freeze
+    # List the request parameters that compose the SearchState.
+    # If you use a plugin that adds to the search state, then you can add the parameters
+    # by modifiying this field.
+    # @!attribute search_state_fields
+    # @since v8.0.0
+    # @return [Array<Symbol>]
+    property :search_state_fields, default: BASIC_SEARCH_PARAMETERS + ADVANCED_SEARCH_PARAMETERS
+
     ##
     # Create collections of solr field configurations.
     # This will create array-like accessor methods for

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -14,30 +14,67 @@ module Blacklight
 
     delegate :facet_configuration_for_field, to: :blacklight_config
 
+    def self.modifiable_params(params)
+      if params.respond_to?(:to_unsafe_h)
+        # This is the typical (not-ActionView::TestCase) code path.
+        params = params.to_unsafe_h
+        # In Rails 5 to_unsafe_h returns a HashWithIndifferentAccess, in Rails 4 it returns Hash
+        params = params.with_indifferent_access if params.instance_of? Hash
+      elsif params.is_a? Hash
+        # This is an ActionView::TestCase workaround for Rails 4.2.
+        params = params.dup.with_indifferent_access
+      else
+        params = params.dup.to_h.with_indifferent_access
+      end
+      params
+    end
+
     # @param [ActionController::Parameters] params
     # @param [Blacklight::Config] blacklight_config
     # @param [ApplicationController] controller used for the routing helpers
     def initialize(params, blacklight_config, controller = nil)
-      @params = self.class.normalize_params(params)
       @blacklight_config = blacklight_config
       @controller = controller
+      @params = SearchState.modifiable_params(params)
+      normalize_params! if needs_normalization?
     end
 
-    def self.normalize_params(untrusted_params = {})
-      params = untrusted_params
+    def needs_normalization?
+      return false if params.blank?
+      return true if (params.keys.map(&:to_s) - permitted_fields.map(&:to_s)).present?
 
-      params = if params.respond_to?(:to_unsafe_h)
-                 # This is the typical (not-ActionView::TestCase) code path.
-                 params.to_unsafe_h
-               else
-                 params.dup.with_indifferent_access
-               end
+      !!filters.detect { |filter| filter.values.detect { |value| filter.needs_normalization?(value) } }
+    end
 
-      # Normalize facet parameters mangled by facebook
-      params[:f] = normalize_facet_params(params[:f]) if facet_params_need_normalization(params[:f])
-      params[:f_inclusive] = normalize_facet_params(params[:f_inclusive]) if facet_params_need_normalization(params[:f_inclusive])
+    def normalize_params!
+      @params = normalize_params
+    end
 
-      params
+    def normalize_params
+      return params unless needs_normalization?
+
+      base_params = params.slice(*blacklight_config.search_state_fields)
+      normal_state = blacklight_config.facet_fields.each_value.inject(reset(base_params)) do |working_state, filter_key|
+        f = filter(filter_key)
+        next working_state unless f.any?
+
+        filter_values = f.values(except: [:inclusive_filters]).inject([]) do |memo, filter_value|
+          # flatten arrays that had been mangled into integer-indexed hashes
+          memo.concat([f.normalize(filter_value)].flatten)
+        end
+        filter_values = f.values(except: [:filters, :missing]).inject(filter_values) do |memo, filter_value|
+          memo << f.normalize(filter_value)
+        end
+        filter_values.inject(working_state) do |memo, filter_value|
+          memo.filter(filter_key).add(filter_value)
+        end
+      end
+      normal_state.params
+    end
+
+    def permitted_fields
+      filter_keys = filter_fields.inject(Set.new) { |memo, filter| memo.merge [filter.filters_key, filter.inclusive_filters_key] }
+      blacklight_config.search_state_fields + filter_keys.subtract([nil, '']).to_a
     end
 
     def to_hash
@@ -95,11 +132,7 @@ module Blacklight
     end
 
     def filters
-      @filters ||= blacklight_config.facet_fields.each_value.map do |value|
-        f = filter(value)
-
-        f if f.any?
-      end.compact
+      @filters ||= filter_fields.select(&:any?)
     end
 
     # @return [FilterField]
@@ -184,16 +217,6 @@ module Blacklight
       params[facet_request_keys[:prefix]]
     end
 
-    def self.facet_params_need_normalization(facet_params)
-      facet_params.is_a?(Hash) && facet_params.values.any? { |x| x.is_a?(Hash) }
-    end
-
-    def self.normalize_facet_params(facet_params)
-      facet_params.transform_values do |value|
-        value.is_a?(Hash) ? value.values : value
-      end
-    end
-
     private
 
     def routable_model_for(blacklight_config)
@@ -218,6 +241,10 @@ module Blacklight
     # @return [ActionController::Parameters]
     def reset_search_params
       Parameters.sanitize(params).except(:page, :counter)
+    end
+
+    def filter_fields
+      blacklight_config.facet_fields.each_value.map { |value| filter(value) }
     end
   end
 end

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -14,19 +14,14 @@ module Blacklight
 
     delegate :facet_configuration_for_field, to: :blacklight_config
 
+    # @param [ActionController::Parameters, Hash] params
     def self.modifiable_params(params)
       if params.respond_to?(:to_unsafe_h)
         # This is the typical (not-ActionView::TestCase) code path.
-        params = params.to_unsafe_h
-        # In Rails 5 to_unsafe_h returns a HashWithIndifferentAccess, in Rails 4 it returns Hash
-        params = params.with_indifferent_access if params.instance_of? Hash
-      elsif params.is_a? Hash
-        # This is an ActionView::TestCase workaround for Rails 4.2.
-        params = params.dup.with_indifferent_access
+        params.to_unsafe_h
       else
-        params = params.dup.to_h.with_indifferent_access
+        params.dup.with_indifferent_access
       end
-      params
     end
 
     # @param [ActionController::Parameters] params

--- a/spec/components/blacklight/constraints_component_spec.rb
+++ b/spec/components/blacklight/constraints_component_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
   end
 
   let(:blacklight_config) do
-    Blacklight::Configuration.new.tap do |config|
-      config.add_facet_field 'facet'
+    Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field :some_facet
     end
   end
 
@@ -49,17 +49,17 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
   end
 
   context 'with a facet' do
-    let(:query_params) { { f: { facet: ['some value'] } } }
+    let(:query_params) { { f: { some_facet: ['some value'] } } }
 
     it 'renders the query' do
-      expect(rendered).to have_selector('.constraint-value > .filter-name', text: 'Facet').and(have_selector('.constraint-value > .filter-value', text: 'some value'))
+      expect(rendered).to have_selector('.constraint-value > .filter-name', text: 'Some Facet').and(have_selector('.constraint-value > .filter-value', text: 'some value'))
     end
 
     context 'that is not configured' do
-      let(:query_params) { { f: { facet: ['some value'], missing: ['another value'] } } }
+      let(:query_params) { { f: { some_facet: ['some value'], missing: ['another value'] } } }
 
       it 'renders only the configured constraints' do
-        expect(rendered).to have_selector('.constraint-value > .filter-name', text: 'Facet').and(have_selector('.constraint-value > .filter-value', text: 'some value'))
+        expect(rendered).to have_selector('.constraint-value > .filter-name', text: 'Some Facet').and(have_selector('.constraint-value > .filter-value', text: 'some value'))
         expect(rendered).not_to have_selector('.constraint-value > .filter-name', text: 'Missing')
       end
     end
@@ -68,14 +68,14 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
   describe '.for_search_history' do
     subject(:component) { described_class.for_search_history(**params) }
 
-    let(:query_params) { { q: 'some query', f: { facet: ['some value'] } } }
+    let(:query_params) { { q: 'some query', f: { some_facet: ['some value'] } } }
 
     it 'wraps the output in a span' do
       expect(rendered).to have_selector('span .constraint')
     end
 
     it 'renders the search state as lightly-decorated text' do
-      expect(rendered).to have_selector('.constraint > .filter-values', text: 'some query').and(have_selector('.constraint', text: 'Facet:some value'))
+      expect(rendered).to have_selector('.constraint > .filter-values', text: 'some query').and(have_selector('.constraint', text: 'Some Facet:some value'))
     end
 
     it 'omits the headers' do

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -124,7 +124,12 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
       )
     end
 
-    let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, Blacklight::Configuration.new) }
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.configure do |config|
+        config.add_facet_field :field
+      end
+    end
+    let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, blacklight_config) }
     let(:params) { { f_inclusive: { field: %w[a b c] } } }
 
     it 'displays the constraint above the list' do

--- a/spec/components/blacklight/facet_item_pivot_component_spec.rb
+++ b/spec/components/blacklight/facet_item_pivot_component_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
     render_inline_to_capybara_node(described_class.new(facet_item: facet_item))
   end
 
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field :z
+    end
+  end
+
   let(:search_state) do
-    Blacklight::SearchState.new({}, Blacklight::Configuration.new)
+    Blacklight::SearchState.new({}, blacklight_config)
   end
 
   let(:facet_item) do

--- a/spec/controllers/blacklight/base_spec.rb
+++ b/spec/controllers/blacklight/base_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Blacklight::Base do
     let(:raw_params) { HashWithIndifferentAccess.new a: 1 }
     let(:params) { ActionController::Parameters.new raw_params }
 
-    before { allow(controller).to receive_messages(params: params) }
+    before do
+      controller.blacklight_config.search_state_fields << :a
+      allow(controller).to receive_messages(params: params)
+    end
 
     it "creates a path object" do
       expect(subject).to be_kind_of Blacklight::SearchState

--- a/spec/helpers/blacklight/url_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/url_helper_behavior_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Blacklight::UrlHelperBehavior do
     let(:query_params) { { q: "query", f: "facets", controller: 'catalog' } }
     let(:bookmarks_query_params) { { controller: 'bookmarks' } }
 
+    before do
+      # this is bad data but the legacy test exercises search fields, not filters
+      blacklight_config.configure do |config|
+        config.search_state_fields << :f
+      end
+    end
+
     it "builds a link tag to catalog using session[:search] for query params" do
       allow(helper).to receive(:current_search_session).and_return double(query_params: query_params)
       tag = helper.link_back_to_catalog

--- a/spec/lib/blacklight/search_state/filter_field_spec.rb
+++ b/spec/lib/blacklight/search_state/filter_field_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe Blacklight::SearchState::FilterField do
   let(:params) { { f: { some_field: %w[1 2], another_field: ['3'] } } }
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
-      config.add_facet_field 'some_field'
       config.add_facet_field 'another_field', single: true
+      simple_facet_fields.each { |simple_facet_field| config.add_facet_field simple_facet_field }
+      config.search_state_fields = config.search_state_fields + additional_search_fields
     end
   end
+  let(:simple_facet_fields) { [:some_field] }
+  let(:additional_search_fields) { [] }
   let(:controller) { double }
 
   describe '#add' do
@@ -50,6 +53,8 @@ RSpec.describe Blacklight::SearchState::FilterField do
     end
 
     context 'with a pivot facet-type item' do
+      let(:simple_facet_fields) { [:some_field, :some_other_field] }
+
       it 'includes the pivot facet fqs' do
         filter = search_state.filter('some_field')
         new_state = filter.add(OpenStruct.new(fq: { some_other_field: '5' }, value: '4'))
@@ -198,6 +203,12 @@ RSpec.describe Blacklight::SearchState::FilterField do
 
     it 'handles value indirection' do
       expect(search_state.filter('some_field').include?(OpenStruct.new(value: '1'))).to be true
+    end
+  end
+
+  describe '#needs_normalization?' do
+    it 'returns false for Blacklight::SearchState::FilterField::MISSING' do
+      expect(search_state.filter('some_field').needs_normalization?(Blacklight::SearchState::FilterField::MISSING)).to be false
     end
   end
 end

--- a/spec/presenters/blacklight/facet_field_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_field_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Blacklight::FacetFieldPresenter, type: :presenter do
   let(:display_facet) do
     instance_double(Blacklight::Solr::Response::Facets::FacetField, items: items, sort: :index, offset: 0, prefix: nil)
   end
+
   let(:items) { [] }
   let(:view_context) { controller.view_context }
   let(:search_state) { view_context.search_state }
@@ -30,15 +31,20 @@ RSpec.describe Blacklight::FacetFieldPresenter, type: :presenter do
       expect(presenter).not_to be_collapsed
     end
 
-    it "does not be collapsed if it is in the params" do
-      controller.params[:f] = ActiveSupport::HashWithIndifferentAccess.new(key: [1])
-      expect(presenter.collapsed?).to be false
+    context "it is in the params" do
+      before do
+        search_state.params[:f] = { key: [1] }
+      end
+
+      it "does not be collapsed if it is in the params" do
+        expect(presenter.collapsed?).to be false
+      end
     end
   end
 
   describe '#active?' do
     it "checks if any value is selected for a given facet" do
-      controller.params[:f] = ActiveSupport::HashWithIndifferentAccess.new(key: [1])
+      search_state.params[:f] = ActiveSupport::HashWithIndifferentAccess.new(key: [1])
       expect(presenter.active?).to be true
     end
 

--- a/spec/presenters/blacklight/facet_grouped_item_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_grouped_item_presenter_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe Blacklight::FacetGroupedItemPresenter, type: :presenter do
 
   let(:facet_item) { 'a' }
   let(:group) { %w[a b c] }
-  let(:search_state) { Blacklight::SearchState.new(params, Blacklight::Configuration.new) }
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field :key
+    end
+  end
+  let(:search_state) { Blacklight::SearchState.new(params, blacklight_config) }
   let(:params) { { f_inclusive: { key: group } } }
 
   describe '#selected' do

--- a/spec/presenters/blacklight/field_presenter_spec.rb
+++ b/spec/presenters/blacklight/field_presenter_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Blacklight::FieldPresenter, api: true do
       config.add_index_field 'alias', field: 'qwer'
       config.add_index_field 'with_default', default: 'value'
       config.add_index_field 'with_steps', steps: [custom_step]
+      config.add_facet_field :link_to_facet_true
+      config.add_facet_field :some_field
     end
   end
 

--- a/spec/views/catalog/index.json.jbuilder_spec.rb
+++ b/spec/views/catalog/index.json.jbuilder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "catalog/index.json", api: true do
   let(:config) do
     Blacklight::Configuration.new do |config|
       config.add_index_field 'title', label: 'Title', field: 'title_tsim'
+      config.add_facet_field :format
     end
   end
   let(:presenter) { Blacklight::JsonPresenter.new(response, config) }


### PR DESCRIPTION
- FilterFields are responsible for normalization of filter field data from params
- Base permitted search params are configurable in Blacklight:Configuration
- class methods for param normalization are deprecated

Co-authored-by: Justin Coyne <jcoyne@justincoyne.com>

Fixes #2691 
This is a forward-port of #2687 to main