### PR TITLE
Explicitly test that bootstrap and bootstrap.Modal are defined

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -441,7 +441,7 @@ Blacklight.modal.checkCloseModal = function (event) {
 };
 
 Blacklight.modal.hide = function (el) {
-  if (bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('hide');
@@ -449,7 +449,7 @@ Blacklight.modal.hide = function (el) {
 };
 
 Blacklight.modal.show = function (el) {
-  if (bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('show');

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -206,7 +206,7 @@ Blacklight.modal.checkCloseModal = function(event) {
 }
 
 Blacklight.modal.hide = function(el) {
-  if (bootstrap && bootstrap.Modal && bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('hide');
@@ -214,7 +214,7 @@ Blacklight.modal.hide = function(el) {
 }
 
 Blacklight.modal.show = function(el) {
-  if (bootstrap && bootstrap.Modal && bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('show');


### PR DESCRIPTION
I was attempting to upgrade my blacklight-based app to 7.x from the latest 6.x and ran into an issue where the `more >>` facet modal failed to open due to `bootstrap` not being defined.  Prior tickets and conversation seemed to point to including `bootstrap` in my sprockets asset pipeline instead of `bootstrap-sprockets`, but I was already only using the `bootstrap` include.  Adding an explicit check for `'undefined'` worked for me, but I'm unsure if there is a better way to solve this or if by doing this it is breaking the bootstrap 5+ scenario.

I ran the rollup script to compile the changes to `blacklight.js` since that is what my application was pulling in via sprockets.  I can remove these changes to `blacklight.js` if it is supposed to be handled in a different process.