### PR TITLE
Pivot filter field

### DIFF
--- a/app/presenters/blacklight/facet_item_pivot_presenter.rb
+++ b/app/presenters/blacklight/facet_item_pivot_presenter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class FacetItemPivotPresenter < FacetItemPresenter
+    ##
+    # Check if the query parameters have the given facet field with the
+    # given value.
+    def selected?
+      search_state.filter(facet_config).include?(facet_item)
+    end
+
+    def field_label
+      facet_field_presenter.label
+    end
+
+    ##
+    # Get the displayable version of a facet's value
+    #
+    # @return [String]
+    def label
+      label_source = facet_item.respond_to?(:label) ? facet_item.label : facet_item
+      if facet_config.helper_method
+        view_context.public_send(facet_config.helper_method, label_source)
+      else
+        item_fq = label_source.respond_to?(:fq) ? label_source.fq : {}
+        item_fq = item_fq.symbolize_keys
+        label_value = facet_config.pivot.map(&:to_sym).map { |k| item_fq[k] }
+        if label_source.respond_to?(:field)
+          label_value << value
+        else
+          label_value.unshift value
+        end
+        label_value.compact.join(" » ")
+      end
+    end
+
+    def value
+      if facet_item.respond_to? :value
+        facet_item.value
+      else
+        facet_item
+      end
+    end
+  end
+end

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -69,6 +69,7 @@ module Blacklight
     def normalize! blacklight_config = nil
       query.stringify_keys! if query
 
+      normalize_pivot_config! if pivot
       self.collapse = true if collapse.nil?
       self.show = true if show.nil?
       self.if = show if self.if.nil?
@@ -76,9 +77,8 @@ module Blacklight
       self.presenter ||= Blacklight::FacetFieldPresenter
       self.item_presenter ||= Blacklight::FacetItemPresenter
       self.component = Blacklight::FacetFieldListComponent if component.nil? || component == true
-      self.item_component ||= pivot ? Blacklight::FacetItemPivotComponent : Blacklight::FacetItemComponent
       self.advanced_search_component ||= Blacklight::FacetFieldCheckboxesComponent
-
+      self.item_component ||= Blacklight::FacetItemComponent
       super
 
       if single && tag.blank? && ex.blank?
@@ -89,5 +89,14 @@ module Blacklight
       self
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    private
+
+    def normalize_pivot_config!
+      self.item_presenter ||= Blacklight::FacetItemPivotPresenter
+      self.item_component ||= Blacklight::FacetItemPivotComponent
+      self.filter_class ||= Blacklight::SearchState::PivotFilterField
+      self.filter_query_builder ||= Blacklight::SearchState::PivotFilterField::QueryBuilder
+    end
   end
 end

--- a/lib/blacklight/search_state.rb
+++ b/lib/blacklight/search_state.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'blacklight/search_state/filter_field'
+require 'blacklight/search_state/pivot_filter_field'
 
 module Blacklight
   # This class encapsulates the search state as represented by the query

--- a/lib/blacklight/search_state/pivot_filter_field.rb
+++ b/lib/blacklight/search_state/pivot_filter_field.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class SearchState
+    # Modeling access to filter query parameters
+    class PivotFilterField < FilterField
+      STOP_VALUE = [:stop].freeze
+
+      # @return [Array]
+      delegate :pivot, to: :config
+
+      # @param [String,#value] item a filter item to add to the url
+      # @return [Blacklight::SearchState] new state
+      def add(item)
+        item = wrap_item(item)
+        new_state = search_state.reset_search
+        return new_state if include?(item)
+
+        pivot_values = pivot_fq(item).merge(pivot[0].to_sym => as_url_parameter(item))
+        pivot_values.inject(new_state) do |memo_state, entry|
+          url_key, value = entry
+          field_facade = FilterField.new(null_field(url_key), memo_state)
+          next memo_state if value.nil? || field_facade.include?(value)
+
+          field_facade.add(value)
+        end
+      end
+
+      # @param [String,#value] item a filter to remove from the url
+      # @return [Blacklight::SearchState] new state
+      def remove(item)
+        item = wrap_item(item)
+        new_state = search_state.reset_search
+        pivot_values = pivot_fq(item).merge(pivot[0].to_sym => as_url_parameter(item))
+        pivot_values.inject(new_state) do |memo_state, entry|
+          url_key, value = entry
+          next memo_state if value.nil?
+
+          FilterField.new(null_field(url_key), memo_state).remove(value)
+        end
+      end
+
+      # Matrix the values of the pivoted fields
+      # @return [Array] an array of applied filters
+      # rubocop:disable Lint/UnusedMethodArgument
+      def values(except: [])
+        return nil unless pivot.is_a?(Array) && pivot.present?
+
+        params = search_state.params
+        # values should have at most one terminal blank pivot
+        pivot_values = pivot.map { |k| Array(params.dig(:f, k)) || STOP_VALUE }
+        pivot_values = pivot_values[0..(pivot_values.index(STOP_VALUE) || -1)]
+        # put an explicit nil in for the matrix
+        pivot_values[-1] = [nil] if pivot_values.last == STOP_VALUE
+        top_level_values = pivot_values.shift
+        return [] if top_level_values.first.blank?
+
+        pivot_values.each { |pivot_value| pivot_value[0] ||= nil }
+        matrix_values = top_level_values.product(*pivot_values)
+        matrix_values.map do |vals|
+          PivotValue.new(value: vals.shift, fq: pivot[1..].map(&:to_sym).zip(vals).to_h)
+        end
+      end
+      # rubocop:enable Lint/UnusedMethodArgument
+
+      # @param [String, #value #fq] item a filter may represent in the url
+      # @return [Boolean] whether the provided filter is currently applied/selected
+      def include?(item)
+        return false unless pivot.is_a?(Array) && pivot.present?
+
+        params = search_state.params
+        item = wrap_item(item)
+        pivot_values = pivot_fq(item).merge(pivot[0].to_sym => as_url_parameter(item))
+        pivot_values.inject(true) do |m, entry|
+          k, v = entry
+          m && params.dig(:f, k)&.include?(as_url_parameter(v))
+        end
+      end
+
+      class PivotValue
+        attr_accessor :value, :fq
+
+        delegate :blank?, :present?, to: :value
+        alias empty? blank?
+
+        def initialize(value: nil, fq: {}, **_args) # rubocop:disable Naming/MethodParameterName
+          @value = value
+          @fq = fq
+        end
+      end
+
+      class QueryBuilder
+        # @return [Array] filter_query, subqueries
+        def self.call(search_builder, filter, solr_parameters)
+          existing = solr_parameters['fq']&.dup || []
+          queries = []
+          filter.values.reject(&:blank?).each do |value|
+            queries << search_builder.send(:facet_value_to_fq_string, filter.pivot.first, value.value)
+            value.fq.each do |entry|
+              k, v = entry
+              queries << search_builder.send(:facet_value_to_fq_string, k, v) if v
+            end
+            queries.uniq!
+          end
+          [(queries - existing)]
+        end
+      end
+
+      private
+
+      def null_field(key)
+        Blacklight::Configuration::NullField.new(key: key)
+      end
+
+      def pivot_fq(item = nil)
+        fq_keys = pivot[1..].map(&:to_sym)
+        null_values = fq_keys.index_with(nil)
+        return null_values unless item.respond_to?(:fq)
+
+        item_fq = item.fq.to_h.symbolize_keys.slice(*fq_keys)
+        null_values.merge item_fq
+      end
+
+      def wrap_item(item)
+        item = invert_item(item) if item.respond_to?(:field) && item.field.to_sym != pivot.first.to_sym
+        return item if item.respond_to? :value
+        return PivotValue.new(**item) if item.is_a? Hash
+
+        PivotValue.new(value: item, fq: pivot_fq)
+      end
+
+      # the parsed Blacklight::Solr::Response::Facets::FacetItem objects are inverted -
+      # the subordinate value is at the top, and the other values are in fq - to permit
+      # easier value labeling in the UI. To manage the search links, they need to be
+      # reinverted.
+      def invert_item(item)
+        item_fq = item.fq.symbolize_keys
+        item_value = item_fq.delete(pivot[0].to_sym)
+        item_fq = item_fq.merge(item.field.to_sym => item.value).slice(*pivot.map(&:to_sym))
+        PivotValue.new(value: item_value, fq: item_fq)
+      end
+    end
+  end
+end

--- a/spec/lib/blacklight/search_state/pivot_filter_field_spec.rb
+++ b/spec/lib/blacklight/search_state/pivot_filter_field_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::SearchState::PivotFilterField do
+  let(:value_class) { described_class::PivotValue }
+  let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, blacklight_config, controller) }
+
+  let(:params) { { f: { some_field: %w[1 2], some_other_field: ['3'] } } }
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field 'pivot_field', pivot: %w[some_field some_other_field], filter_class: described_class
+    end
+  end
+  let(:controller) { double }
+
+  describe '#add' do
+    context 'with a string value' do
+      it 'adds the parameter to the first pivot\'s filter list' do
+        filter = search_state.filter('pivot_field')
+        new_state = filter.add('4')
+
+        expect(new_state.filter('some_field').values).to eq %w[1 2 4]
+        expect(new_state.filter('pivot_field').values&.map(&:value)).to eq %w[1 2 4]
+      end
+
+      context 'without any parameters in the url' do
+        let(:params) { {} }
+
+        it 'adds the necessary structure' do
+          filter = search_state.filter('some_field')
+          new_state = filter.add('1')
+
+          expect(new_state.filter('pivot_field').values&.map(&:value)).to eq %w[1]
+          expect(new_state.params).to include(:f)
+        end
+      end
+    end
+
+    context 'with a pivot facet-type item' do
+      it 'includes the pivot facet fqs' do
+        filter = search_state.filter('pivot_field')
+        new_state = filter.add(value_class.new(fq: { some_other_field: '5' }, value: '4'))
+
+        expect(new_state.filter('some_field').values).to eq %w[1 2 4]
+        expect(new_state.filter('some_other_field').values).to eq %w[3 5]
+      end
+    end
+
+    context 'with an array' do
+      pending 'decide how inclusive facets should work with pivots'
+    end
+  end
+
+  describe '#remove' do
+    it 'returns a search state without the given filter applied' do
+      filter = search_state.filter('some_field')
+      new_state = filter.remove('1')
+
+      expect(new_state.filter('pivot_field').values&.map(&:value)).to eq ['2']
+    end
+
+    context 'with a pivot facet-type item' do
+      it 'includes the pivot facet fqs' do
+        filter = search_state.filter('pivot_field')
+        new_state = filter.remove(value_class.new(fq: { some_other_field: '3' }, value: '1'))
+
+        expect(new_state.filter('some_field').values).to eq %w[2]
+        expect(new_state.filter('some_other_field').values).to eq []
+      end
+    end
+
+    it 'removes the whole field if there are no filter left for the field' do
+      filter = search_state.filter('pivot_field')
+      new_state = filter.remove(value_class.new(fq: { some_other_field: '3' }, value: '1'))
+
+      expect(new_state.params[:f]).not_to include :some_other_field
+      expect(new_state.filter('pivot_field').values&.map(&:fq)).to eql([some_other_field: nil])
+    end
+
+    it 'removes the filter parameter entirely if there are no filters left' do
+      filter = search_state.filter('pivot_field')
+      new_state = filter.remove(value_class.new(fq: { some_other_field: '3' }, value: '1'))
+      new_state = new_state.filter('pivot_field').remove(value_class.new(fq: { some_other_field: '3' }, value: '2'))
+
+      expect(new_state.filter('pivot_field').values).to eq []
+      expect(new_state.params).not_to include :f
+    end
+
+    context 'with an array' do
+      pending 'decide how inclusive facets should work with pivots'
+    end
+
+    context "With facet.missing field" do
+      pending 'decide how facet.missing should work with pivots'
+    end
+  end
+
+  describe '#values' do
+    it 'returns the currently selected values of the filter' do
+      expect(search_state.filter('pivot_field').values.map(&:value)).to eq %w[1 2]
+    end
+
+    context 'with an array' do
+      pending 'decide how inclusive facets should work with pivots'
+    end
+  end
+
+  describe '#include?' do
+    it 'checks whether the value is currently selected' do
+      expect(search_state.filter('some_field').include?('1')).to be true
+      expect(search_state.filter('some_field').include?('3')).to be false
+    end
+
+    it 'handles value indirection' do
+      expect(search_state.filter('some_field').include?(value_class.new(value: '1'))).to be true
+    end
+  end
+end

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -402,4 +402,33 @@ RSpec.describe Blacklight::SearchState do
       expect(search_state.url_for_document(doc)).to eq doc
     end
   end
+
+  describe '#filters' do
+    context 'pivot facet config but no facet params' do
+      it 'maps no filters' do
+        blacklight_config.add_facet_field 'some_key', pivot: %w[pivot_field_1 pivot_field_2]
+        expect(search_state.filters).to eq([])
+      end
+    end
+
+    context 'pivot facet config and some pivot facet params' do
+      let(:params) { { 'f' => { 'pivot_field_1' => 'foo' } } }
+
+      it 'maps the pivot matching param pivot_field' do
+        blacklight_config.add_facet_field 'some_key', pivot: %w[pivot_field_1 pivot_field_2]
+        expect(search_state.filters.count).to eq(1)
+        expect(search_state.filters.first.key).to eq('some_key')
+      end
+    end
+
+    context 'regular facet config with params' do
+      let(:params) { { 'f' => { 'some_key' => 'foo' } } }
+
+      it 'maps the field matching param facet_field' do
+        blacklight_config.add_facet_field 'some_key'
+        expect(search_state.filters.count).to eq(1)
+        expect(search_state.filters.first.key).to eq('some_key')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is essentially implementing pivot fields as if they were a filter add-on, like range limits.

See also the conversation in #2464 , this permits use of pivot fields that are not individually configured as facets. I've included @dkinzer's tests from the other PR to make sure we have consensus about desired outcomes. 

Fixes: #2463