### PR TITLE
Use collection parameters in line with idiomatic ViewComponent behaviors

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -56,8 +56,6 @@ module Blacklight
     # Backwards compatibility
     renders_one :actions
 
-    with_collection_parameter :document
-
     # rubocop:disable Metrics/ParameterLists
     # @param document [Blacklight::Document]
     # @param presenter [Blacklight::DocumentPresenter]

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+require 'view_component/version'
+
 module Blacklight
   class DocumentComponent < Blacklight::Component
+    # ViewComponent 3 changes iteration counters to begin at 0 rather than 1
+    COLLECTION_INDEX_OFFSET = ViewComponent::VERSION::MAJOR < 3 ? 0 : 1
+
     # Content appearing before the document
     renders_one :header
 
@@ -64,7 +69,7 @@ module Blacklight
     # @param component [Symbol, String] HTML tag type to use for the root element
     # @param title_component [Symbol, String] HTML tag type to use for the title element
     # @param counter [Number, nil] a pre-computed counter for the position of this document in a search result set
-    # @param document_counter [Number, nil] a 1-indexed value provided by ViewComponent collection iteration
+    # @param document_counter [Number, nil] provided by ViewComponent collection iteration
     # @param counter_offset [Number] the offset of the start of the collection counter parameter for the component to the overall result set
     # @param show [Boolean] are we showing only a single document (vs a list of search results); used for backwards-compatibility
     def initialize(document: nil, partials: nil,
@@ -82,7 +87,7 @@ module Blacklight
 
       @counter = counter
       @document_counter = document_counter || args.fetch(self.class.collection_counter_parameter, nil)
-      @counter ||= @document_counter + counter_offset if @document_counter.present?
+      @counter ||= @document_counter + COLLECTION_INDEX_OFFSET + counter_offset if @document_counter.present?
 
       @show = show
     end

--- a/app/views/catalog/_document.atom.builder
+++ b/app/views/catalog/_document.atom.builder
@@ -21,7 +21,7 @@ xml.entry do
   with_format(:html) do
     xml.summary "type" => "html" do
       document_component = blacklight_config.view_config(:atom).summary_component
-      xml.text! render document_component.new(presenter: document_presenter(document), component: :div, show: true)
+      xml.text! render document_component.new(document_component.collection_parameter => document_presenter(document), component: :div, show: true)
     end
   end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,9 +1,4 @@
 <% # container for a single doc -%>
 <% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type) %>
-<%= render view_config.document_component.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
-  <% view_config.partials.each do |partial| %>
-    <% component.with_partial do %>
-      <%= render_document_partial document, partial, component: component, document_counter: document_counter %>
-    <% end %>
-  <% end %>
-<% end %>
+<% document_component = blacklight_config.view_config(:show).document_component -%>
+<%= render document_component.new(document_component.collection_parameter => document_presenter(document), counter: document_counter_with_offset(document_counter), partials: view_config&.partials) %>

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,5 +1,6 @@
 <% # container for all documents in index list view -%>
 <% view_config = local_assigns[:view_config] || blacklight_config&.view_config(document_index_view_type) %>
 <div id="documents" class="documents-<%= view_config&.key || document_index_view_type %>">
-  <%= render documents, as: :document, view_config: view_config %>
+  <% document_presenters = documents.map { |doc| document_presenter(doc) } -%>
+  <%= render view_config.document_component.with_collection(document_presenters, partials: view_config.partials, counter_offset: @response&.start || 0) %>
 </div>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -3,18 +3,13 @@
 <% @page_title = t('blacklight.search.show.title', document_title: document_presenter(@document).html_title, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
 
-<%= render (blacklight_config.view_config(:show).document_component).new(presenter: document_presenter(@document), component: :div, show: true) do |component| %>
+<% document_component = blacklight_config.view_config(:show).document_component -%>
+<%= render (document_component).new(document_component.collection_parameter => document_presenter(@document), component: :div, show: true, partials: blacklight_config.view_config(:show).partials) do |component| %>
   <% component.with_title(as: 'h1', classes: '', link_to_document: false, actions: false) %>
   <% component.with_footer do %>
     <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
       <!-- COinS, for Zotero among others. -->
       <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_presenter(@document).display_type) %>"></span>
-    <% end %>
-  <% end %>
-
-  <% blacklight_config.view_config(:show).partials.each do |partial| %>
-    <% component.with_partial do %>
-      <%= render_document_partial @document, partial, component: component %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -94,11 +94,13 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     end
 
     context 'with a document rendered as part of a collection' do
-      let(:attr) { { document_counter: 10, counter_offset: 100 } }
+      # ViewComponent 3 changes iteration counters to begin at 0 rather than 1
+      let(:document_counter) { ViewComponent::VERSION::MAJOR < 3 ? 11 : 10 }
+      let(:attr) { { document_counter: document_counter, counter_offset: 100 } }
 
       it 'renders a counter with the title' do
         # after ViewComponent 2.5, collection counter params are 1-indexed
-        expect(rendered).to have_selector 'header', text: '110. Title'
+        expect(rendered).to have_selector 'header', text: '111. Title'
       end
     end
 

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::DocumentComponent, type: :component do
-  subject(:component) { described_class.new(document: document, presenter: view_context.document_presenter(document), **attr) }
+  subject(:component) { described_class.new(document: document, **attr) }
 
   let(:attr) { {} }
   let(:view_context) { controller.view_context }
@@ -15,7 +15,9 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     Capybara::Node::Simple.new(render)
   end
 
-  let(:document) do
+  let(:document) { view_context.document_presenter(presented_document) }
+
+  let(:presented_document) do
     SolrDocument.new(
       id: 'x',
       thumbnail_path_ss: 'http://example.com/image.jpg',
@@ -95,7 +97,8 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
       let(:attr) { { document_counter: 10, counter_offset: 100 } }
 
       it 'renders a counter with the title' do
-        expect(rendered).to have_selector 'header', text: '111. Title'
+        # after ViewComponent 2.5, collection counter params are 1-indexed
+        expect(rendered).to have_selector 'header', text: '110. Title'
       end
     end
 

--- a/spec/views/catalog/_document.html.erb_spec.rb
+++ b/spec/views/catalog/_document.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "catalog/_document" do
     stub_template "catalog/_a_default.html.erb" => "a_partial"
     stub_template "catalog/_b_default.html.erb" => "b_partial"
     stub_template "catalog/_c_default.html.erb" => "c_partial"
-    render partial: "catalog/document", locals: { document: document, document_counter: 1 }
+    render partial: "catalog/document", locals: { document: document, document_counter: 1, view_config: blacklight_config.index }
     expect(rendered).to match /a_partial/
     expect(rendered).to match /b_partial/
     expect(rendered).to match /c_partial/

--- a/spec/views/catalog/_document_list.html.erb_spec.rb
+++ b/spec/views/catalog/_document_list.html.erb_spec.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe "catalog/_document_list", type: :view do
+  let(:view_type) { 'some-view' }
+  let(:view_config) { double(Blacklight::Configuration::ViewConfig) }
+
   before do
-    allow(view).to receive_messages(document_index_view_type: "some-view", documents: [], blacklight_config: nil)
+    allow(view_config).to receive_messages(key: view_type, document_component: Blacklight::DocumentComponent, partials: [])
+    allow(view).to receive_messages(document_index_view_type: view_type, documents: [], blacklight_config: nil)
+    assign(:response, instance_double(Blacklight::Solr::Response, start: 0))
   end
 
   it "includes a class for the current view" do
-    render
+    render(partial: "catalog/document_list", locals: { view_config: view_config })
     expect(rendered).to have_selector(".documents-some-view")
   end
 end


### PR DESCRIPTION
Remove redundant `with_collection_parameter :document` on `Blacklight::DocumentComponent` (from #2596)
Use `#{x}_counter` keyword params in the idiomatic manner for ViewComponent
- remove _document.html.erb
- fix #2697 
Use collection rendering of document_component in _document_list.html.erb