### PR TITLE
Stop using SearchBarPresenter

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -1,23 +1,23 @@
 <%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => scoped_t('submit') do %>
   <%= render_hash_as_hidden_fields(@params) %>
-  <% if @search_fields.length > 1 %>
+  <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only visually-hidden"><%= scoped_t('search_field.label') %></label>
   <% end %>
   <div class="input-group">
     <%= prepend %>
 
-    <% if @search_fields.length > 1 %>
+    <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
-                       options_for_select(@search_fields, h(@search_field)),
+                       options_for_select(search_fields, h(@search_field)),
                        title: scoped_t('search_field.title'),
                        id: "#{@prefix}search_field",
                        class: "custom-select form-select search-field") %>
-    <% elsif @search_fields.length == 1 %>
-      <%= hidden_field_tag :search_field, @search_fields.first.last %>
+    <% elsif search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, search_fields.first.last %>
     <% end %>
 
     <label for="<%= @prefix %><%= @query_param %>" class="sr-only visually-hidden"><%= scoped_t('search.label') %></label>
-    <%= text_field_tag @query_param, @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{@search_fields.length > 1 ? '0' : 'left'}", id: "#{@prefix}q", autocomplete: autocomplete_path.present? ? "off" : "", autofocus: @autofocus, data: { autocomplete_enabled: autocomplete_path.present?, autocomplete_path: autocomplete_path }  %>
+    <%= text_field_tag @query_param, @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "#{@prefix}q", autocomplete: autocomplete_path.present? ? "off" : "", autofocus: @autofocus, data: { autocomplete_enabled: autocomplete_path.present?, autocomplete_path: autocomplete_path }  %>
 
     <span class="input-group-append">
       <%= append %>
@@ -30,6 +30,6 @@
   </div>
 <% end %>
 
-<% if presenter.advanced_search_enabled? %>
+<% if advanced_search_enabled? %>
   <%= link_to t('blacklight.advanced_search.more_options'), @advanced_search_url, class: 'advanced_search btn btn-secondary'%>
 <% end %>

--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -9,10 +9,11 @@ module Blacklight
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(
-      url:, advanced_search_url: nil, params:,
-      classes: ['search-query-form'], presenter: nil, prefix: '',
+      url:, params:,
+      advanced_search_url: nil,
+      classes: ['search-query-form'], prefix: nil,
       method: 'GET', q: nil, query_param: :q,
-      search_field: nil, search_fields: [], autocomplete_path: nil,
+      search_field: nil, search_fields: nil, autocomplete_path: nil,
       autofocus: nil, i18n: { scope: 'blacklight.search.form' }
     )
       @url = url
@@ -23,7 +24,6 @@ module Blacklight
       @params = params.except(:q, :search_field, :utf8, :page)
       @prefix = prefix
       @classes = classes
-      @presenter = presenter
       @method = method
       @autocomplete_path = autocomplete_path
       @autofocus = autofocus
@@ -33,28 +33,33 @@ module Blacklight
     # rubocop:enable Metrics/ParameterLists
 
     def autocomplete_path
-      return nil unless presenter.autocomplete_enabled?
+      return nil unless blacklight_config.autocomplete_enabled
 
       @autocomplete_path
     end
 
     def autofocus
       if @autofocus.nil?
-        presenter.autofocus?
+        blacklight_config.enable_search_bar_autofocus &&
+          controller.is_a?(Blacklight::Catalog) &&
+          controller.action_name == "index" &&
+          !controller.has_search_parameters?
       else
         @autofocus
       end
     end
 
+    def search_fields
+      @search_fields ||= blacklight_config.search_fields.values
+                                          .select { |field_def| helpers.should_render_field?(field_def) }
+                                          .collect { |field_def| [helpers.label_for_search_field(field_def.key), field_def.key] }
+    end
+
+    def advanced_search_enabled?
+      blacklight_config.advanced_search.enabled
+    end
+
     private
-
-    def presenter
-      @presenter ||= presenter_class.new(controller, blacklight_config)
-    end
-
-    def presenter_class
-      blacklight_config.view_config(action_name: :index).search_bar_presenter_class
-    end
 
     def blacklight_config
       helpers.blacklight_config

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -81,6 +81,7 @@ module Blacklight::BlacklightHelperBehavior
   def render_search_bar
     search_bar_presenter.render
   end
+  deprecation_deprecate render_search_bar: "Call `render Blacklight::SearchBarComponent.new' instead"
 
   # @!group Presenter extension helpers
   ##
@@ -88,6 +89,7 @@ module Blacklight::BlacklightHelperBehavior
   def search_bar_presenter
     @search_bar ||= search_bar_presenter_class.new(controller, blacklight_config)
   end
+  deprecation_deprecate :search_bar_presenter
 
   # @!group Document helpers
   ##

--- a/app/presenters/blacklight/search_bar_presenter.rb
+++ b/app/presenters/blacklight/search_bar_presenter.rb
@@ -2,6 +2,7 @@
 
 module Blacklight
   class SearchBarPresenter
+    extend Deprecation
     attr_reader :configuration, :view_context, :controller
 
     # Set the partial this presenter draws
@@ -17,6 +18,7 @@ module Blacklight
     def render
       view_context.render partial, presenter: self
     end
+    deprecation_deprecate render: "The SearchBarPresenter has been deprecated. Call `render Blacklight::SearchBarComponent.new' instead"
 
     ##
     # @return [Boolean] should autocomplete be enabled in the UI

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,7 +1,7 @@
+<%= warn "#{__file__} is a deprecated partial." %>
 <%= render((blacklight_config&.view_config(document_index_view_type)&.search_bar_component || Blacklight::SearchBarComponent).new(
       url: search_action_url,
       advanced_search_url: search_action_url(action: 'advanced_search'),
       params: search_state.params_for_search.except(:qt),
       search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
-      presenter: presenter,
       autocomplete_path: search_action_path(action: :suggest))) %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,6 +13,10 @@
 
 <%= content_tag :div, class: 'navbar-search navbar navbar-light bg-light', role: 'navigation', aria: { label: t('blacklight.search.header') } do %>
   <div class="<%= container_classes %>">
-    <%= render_search_bar  %>
+    <%= render((blacklight_config&.view_config(document_index_view_type)&.search_bar_component ||Blacklight::SearchBarComponent).new(
+          url: search_action_url,
+          advanced_search_url: search_action_url(action: 'advanced_search'),
+          params: search_state.params_for_search.except(:qt),
+          autocomplete_path: search_action_path(action: :suggest))) %>
   </div>
 <% end %>


### PR DESCRIPTION
Now that we have view components the SearchBarPresenter is unnecessary, so it is now deprecated.
Backports #2673 with deprecations to release-7.x