### PR TITLE
Backport Presenter awareness of document counter to 7.x

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -441,7 +441,7 @@ Blacklight.modal.checkCloseModal = function (event) {
 };
 
 Blacklight.modal.hide = function (el) {
-  if (bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('hide');
@@ -449,7 +449,7 @@ Blacklight.modal.hide = function (el) {
 };
 
 Blacklight.modal.show = function (el) {
-  if (bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('show');

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -302,13 +302,14 @@ module Blacklight::BlacklightHelperBehavior
   # TODO: Move this to the controller. It can just pass a presenter or set of presenters.
   # @deprecated
   # @return [Blacklight::DocumentPresenter]
-  def presenter(document)
+  def presenter(document, document_counter: nil, counter: nil)
     Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#presenter is deprecated; use #document_presenter instead')
 
+    counter ||= document_counter_with_offset(document_counter) if document_counter.present?
     # As long as the presenter methods haven't been overridden, we can use the new behavior
     if method(:show_presenter).owner == Blacklight::BlacklightHelperBehavior &&
        method(:index_presenter).owner == Blacklight::BlacklightHelperBehavior
-      return document_presenter_class(document).new(document, self)
+      return document_presenter_class(document).new(document, self, counter: counter)
     end
 
     Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#show_presenter and/or #index_presenter have been overridden; please override #document_presenter instead')
@@ -318,16 +319,16 @@ module Blacklight::BlacklightHelperBehavior
       when 'show', 'citation'
         show_presenter(document)
       else
-        index_presenter(document)
+        index_presenter(document, counter: counter)
       end
     end
   end
 
   ##
   # Returns a document presenter for the given document
-  def document_presenter(document)
+  def document_presenter(document, document_counter: nil, counter: nil)
     Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
-      presenter(document)
+      presenter(document, document_counter: document_counter, counter: counter)
     end
   end
 
@@ -347,15 +348,16 @@ module Blacklight::BlacklightHelperBehavior
 
   # @deprecated
   # @return [Blacklight::IndexPresenter]
-  def index_presenter(document)
+  def index_presenter(document, document_counter: nil, counter: nil)
     Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter is deprecated; use #document_presenter instead')
 
     if method(:index_presenter_class).owner != Blacklight::BlacklightHelperBehavior
       Deprecation.warn(Blacklight::BlacklightHelperBehavior, '#index_presenter_class has been overridden; please override #document_presenter_class instead')
     end
 
+    counter ||= document_counter_with_offset(document_counter) if document_counter.present?
     Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
-      index_presenter_class(document).new(document, self)
+      index_presenter_class(document).new(document, self, counter: counter)
     end
   end
 

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -80,7 +80,8 @@ module Blacklight::CatalogHelperBehavior
   end
 
   ##
-  # Get the offset counter for a document
+  # Get the offset counter for a document.
+  # This should only be called on the index action because it depends on @response
   #
   # @param [Integer] idx document index
   # @param [Integer] offset additional offset to incremenet the counter by

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -206,7 +206,7 @@ Blacklight.modal.checkCloseModal = function(event) {
 }
 
 Blacklight.modal.hide = function(el) {
-  if (bootstrap && bootstrap.Modal && bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).hide();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('hide');
@@ -214,7 +214,7 @@ Blacklight.modal.hide = function(el) {
 }
 
 Blacklight.modal.show = function(el) {
-  if (bootstrap && bootstrap.Modal && bootstrap.Modal.VERSION >= "5") {
+  if (typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined' && bootstrap.Modal.VERSION >= "5") {
     bootstrap.Modal.getOrCreateInstance(el || document.querySelector(Blacklight.modal.modalSelector)).show();
   } else {
     $(el || Blacklight.modal.modalSelector).modal('show');

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -11,10 +11,12 @@ module Blacklight
     # @param [SolrDocument] document
     # @param [ActionView::Base] view_context scope for linking and generating urls
     # @param [Blacklight::Configuration] configuration
-    def initialize(document, view_context, configuration = view_context.blacklight_config)
+    # @param [Integer] counter what offset in the search result is this record (used for tracking)
+    def initialize(document, view_context, configuration = view_context.blacklight_config, counter: nil)
       @document = document
       @view_context = view_context
       @configuration = configuration
+      @counter = counter
     end
 
     # @return [Hash<String,Configuration::Field>]  all the fields for this index view that should be rendered
@@ -102,7 +104,7 @@ module Blacklight
     end
 
     def thumbnail
-      @thumbnail ||= thumbnail_presenter_class.new(document, view_context, view_config)
+      @thumbnail ||= thumbnail_presenter_class.new(document, view_context, view_config, counter: @counter)
     end
 
     ##

--- a/app/presenters/blacklight/thumbnail_presenter.rb
+++ b/app/presenters/blacklight/thumbnail_presenter.rb
@@ -8,10 +8,12 @@ module Blacklight
     # @param [ActionView::Base] view_context scope for linking and generating urls
     #                                        as well as for invoking "thumbnail_method"
     # @param [Blacklight::Configuration::ViewConfig] view_config
-    def initialize(document, view_context, view_config)
+    # @param [Integer] counter what offset in the search result is this record (used for tracking)
+    def initialize(document, view_context, view_config, counter: nil)
       @document = document
       @view_context = view_context
       @view_config = view_config
+      @counter = counter
     end
 
     def render(image_options = {})
@@ -39,6 +41,7 @@ module Blacklight
       value = thumbnail_value(image_options)
       return value if value.nil? || url_options[:suppress_link]
 
+      url_options[:counter] = @counter if @counter
       view_context.link_to_document document, value, url_options
     end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,6 +1,7 @@
 <% # container for a single doc -%>
 <% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type) %>
-<%= render (view_config.document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) do |component| %>
+<% counter = document_counter_with_offset(document_counter) %>
+<%= render (view_config.document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(document, counter: counter), counter: counter) do |component| %>
   <% component.public_send(view_config.document_component.blank? && view_config.partials.any? ? :body : :partial) do %>
     <%= render_document_partials document, view_config.partials, component: component, document_counter: document_counter %>
   <% end %>

--- a/app/views/catalog/_thumbnail.html.erb
+++ b/app/views/catalog/_thumbnail.html.erb
@@ -1,1 +1,2 @@
-<%= render Blacklight::Document::ThumbnailComponent.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter)) -%>
+<% counter = document_counter_with_offset(document_counter) %>
+<%= render Blacklight::Document::ThumbnailComponent.new(presenter: document_presenter(document, counter: counter), counter: counter) -%>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -427,26 +427,32 @@ RSpec.describe BlacklightHelper do
 
     let(:document) { double }
 
-    before do
-      allow(helper).to receive(:presenter).and_return(double(heading: "Heading"))
+    context "without explicit document" do
+      before do
+        allow(helper).to receive(:presenter).and_return(double(heading: "Heading"))
+      end
+
+      it "accepts no arguments and render the document heading" do
+        expect(helper.render_document_heading).to have_selector "h4", text: "Heading"
+      end
+
+      it "accepts the tag name as an option" do
+        expect(helper.render_document_heading(tag: "h1")).to have_selector "h1", text: "Heading"
+      end
     end
 
-    it "accepts no arguments and render the document heading" do
-      expect(helper.render_document_heading).to have_selector "h4", text: "Heading"
-    end
+    context "with explicit document" do
+      before do
+        allow(helper).to receive(:presenter).with(document, counter: nil, document_counter: nil).and_return(double(heading: "Document Heading"))
+      end
 
-    it "accepts the tag name as an option" do
-      expect(helper.render_document_heading(tag: "h1")).to have_selector "h1", text: "Heading"
-    end
+      it "accepts an explicit document argument" do
+        expect(helper.render_document_heading(document)).to have_selector "h4", text: "Document Heading"
+      end
 
-    it "accepts an explicit document argument" do
-      allow(helper).to receive(:presenter).with(document).and_return(double(heading: "Document Heading"))
-      expect(helper.render_document_heading(document)).to have_selector "h4", text: "Document Heading"
-    end
-
-    it "accepts the document with a tag option" do
-      allow(helper).to receive(:presenter).with(document).and_return(double(heading: "Document Heading"))
-      expect(helper.render_document_heading(document, tag: "h3")).to have_selector "h3", text: "Document Heading"
+      it "accepts the document with a tag option" do
+        expect(helper.render_document_heading(document, tag: "h3")).to have_selector "h3", text: "Document Heading"
+      end
     end
   end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe CatalogHelper do
 
     before do
       allow(Deprecation).to receive(:warn)
-      allow(helper).to receive(:index_presenter).with(document).and_return(index_presenter)
+      allow(helper).to receive(:index_presenter).with(document, counter: nil).and_return(index_presenter)
     end
 
     let(:document) { instance_double(SolrDocument) }

--- a/spec/views/catalog/_thumbnail.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail.html.erb_spec.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "catalog/_thumbnail" do
-  let :document_without_thumbnail_field do
-    SolrDocument.new id: 'xyz', format: 'a'
-  end
-
-  let :document_with_thumbnail_field do
-    SolrDocument.new id: 'xyz', format: 'a', thumbnail_url: 'http://localhost/logo.png'
-  end
-
   let :blacklight_config do
     Blacklight::Configuration.new do |config|
       config.index.thumbnail_field = :thumbnail_url
@@ -25,14 +17,55 @@ RSpec.describe "catalog/_thumbnail" do
     allow(view).to receive(:session_tracking_params).and_return({})
   end
 
-  it "renders the thumbnail if the document has one" do
-    render partial: "catalog/thumbnail", locals: { document: document_with_thumbnail_field, document_counter: 1 }
-    expect(rendered).to match /document-thumbnail/
-    expect(rendered).to match %r{src="http://localhost/logo.png"}
+  context 'when the document has a thumbnail' do
+    let :document_with_thumbnail_field do
+      SolrDocument.new id: 'xyz', format: 'a', thumbnail_url: 'http://localhost/logo.png'
+    end
+
+    let(:presenter) do
+      Blacklight::IndexPresenter.new(document_with_thumbnail_field, view, counter: 1)
+    end
+
+    it "renders the thumbnail" do
+      render partial: "catalog/thumbnail", locals: { document: document_with_thumbnail_field,
+                                                     document_counter: 1,
+                                                     presenter: presenter }
+      expect(rendered).to match /document-thumbnail/
+      expect(rendered).to match %r{src="http://localhost/logo.png"}
+    end
   end
 
-  it "does not render a thumbnail if the document does not have one" do
-    render partial: "catalog/thumbnail", locals: { document: document_without_thumbnail_field, document_counter: 1 }
-    expect(rendered).to eq ""
+  context 'when the document does not have a thumbnail' do
+    let :document_without_thumbnail_field do
+      SolrDocument.new id: 'xyz', format: 'a'
+    end
+    let(:presenter) do
+      Blacklight::IndexPresenter.new(document_without_thumbnail_field, view, counter: 1)
+    end
+
+    it "does not render anything" do
+      render partial: "catalog/thumbnail", locals: { document: document_without_thumbnail_field,
+                                                     document_counter: 1,
+                                                     presenter: presenter }
+      expect(rendered).to eq ""
+    end
+  end
+
+  context 'when in the "show" context' do
+    let :document_with_thumbnail_field do
+      SolrDocument.new id: 'xyz', format: 'a', thumbnail_url: 'http://localhost/logo.png'
+    end
+
+    let(:presenter) do
+      Blacklight::ShowPresenter.new(document_with_thumbnail_field, view)
+    end
+
+    it "renders the thumbnail" do
+      render partial: "catalog/thumbnail", locals: { document: document_with_thumbnail_field,
+                                                     document_counter: 1,
+                                                     presenter: presenter }
+      expect(rendered).to match /document-thumbnail/
+      expect(rendered).to match %r{src="http://localhost/logo.png"}
+    end
   end
 end


### PR DESCRIPTION
Backports #2304 to `release-7.x`, since this is probably the most applicable branch considering the `@response` ivar is no longer in `main`