### PR TITLE
Remove the _previous_next_doc.html.erb partial

### DIFF
--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,1 +1,2 @@
+<% Deprecation.warn(self, 'Deprecated partial _previous_next_doc.html.erb has been called. This functionality has been folded into _show_main_content.html.erb')
 <%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) %>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,2 +1,0 @@
-<% Deprecation.warn(self, 'Deprecated partial _previous_next_doc.html.erb has been called. This functionality has been folded into _show_main_content.html.erb')
-<%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,4 +1,4 @@
-<%= render 'previous_next_doc' if @search_context && search_session['document_id'] == @document.id %>
+<%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) if search_session['document_id'] == @document.id %>
 
 <% @page_title = t('blacklight.search.show.title', document_title: document_presenter(@document).html_title, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>


### PR DESCRIPTION
Observations have been made about how challenging it is to follow program execution through various partials, helpers and components.  I identified that the _previous_next_doc.html.erb partial does nothing but render a component. We can remove this partial and make it easier for people reading the code to follow the control flow.

This partial is not used by spotlight, blacklight-range_limit, or blacklight-advanced_search.