### PR TITLE
Remove render_document_main_content_partial helper

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -148,18 +148,6 @@ module Blacklight::CatalogHelperBehavior
   end
 
   ##
-  # Render the main content partial for a document
-  # This is widely used as by downstream apps when they override their show view.
-  # See https://github.com/search?q=render_document_main_content_partial&type=Code
-  #
-  # @param [SolrDocument] _document
-  # @return [String]
-  def render_document_main_content_partial(_document = @document)
-    render partial: 'show_main_content'
-  end
-  deprecation_deprecate render_document_main_content_partial: "Use \"render 'show_main_content'\" instead"
-
-  ##
   # Should we display the sort and per page widget?
   #
   # @param [Blacklight::Solr::Response] response

--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -157,6 +157,7 @@ module Blacklight::CatalogHelperBehavior
   def render_document_main_content_partial(_document = @document)
     render partial: 'show_main_content'
   end
+  deprecation_deprecate render_document_main_content_partial: "Use \"render 'show_main_content'\" instead"
 
   ##
   # Should we display the sort and per page widget?

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,7 +5,7 @@
   </div>
 <% end %>
 
-<%= render_document_main_content_partial %>
+<%= render 'show_main_content' %>
 
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>


### PR DESCRIPTION
All this method does is call a partial. To make the program flow easier to understand, we can just render the partial and avoid the helper call.

I don't see evidence of any open source repo on github doing anything differently with this helper: 
https://github.com/search?q=%22def+render_document_main_content_partial%22&type=Code