### PR TITLE
Deprecate the _previous_next_doc.html.erb partial in 7.x

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -181,6 +181,7 @@ module Blacklight::CatalogHelperBehavior
   def render_document_main_content_partial(_document = @document)
     render partial: 'show_main_content'
   end
+  deprecation_deprecate render_document_main_content_partial: "Use \"render 'show_main_content'\" instead"
 
   ##
   # Should we display the sort and per page widget?

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,1 +1,2 @@
+<% Deprecation.warn(self, 'The partial _previous_next_doc.html.erb will be removed in 8.0. Render Blacklight::SearchContextComponent instead.') %>
 <%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,4 +1,4 @@
-<%= render 'previous_next_doc' if @search_context && search_session['document_id'] == @document.id %>
+<%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) if search_session['document_id'] == @document.id %>
 
 <% @page_title = t('blacklight.search.show.title', document_title: Deprecation.silence(Blacklight::BlacklightHelperBehavior) { document_show_html_title }, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,7 +5,7 @@
   </div>
 <% end %>
 
-<%= render_document_main_content_partial %>
+<%= render 'show_main_content' %>
 
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>


### PR DESCRIPTION
Deprecate _previous_next_doc.html.erb partial, which does nothing but render a component.
Deprecate render_document_main_content_partial helper, which does nothing but render a partial.

Removed partial and helper in `main`/ 8.0; see also #2708 and #2709