### PR TITLE
7.x Deprecate render_document_main_content_partial helper

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -181,6 +181,7 @@ module Blacklight::CatalogHelperBehavior
   def render_document_main_content_partial(_document = @document)
     render partial: 'show_main_content'
   end
+  deprecation_deprecate render_document_main_content_partial: "Use \"render 'show_main_content'\" instead"
 
   ##
   # Should we display the sort and per page widget?

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,7 +5,7 @@
   </div>
 <% end %>
 
-<%= render_document_main_content_partial %>
+<%= render 'show_main_content' %>
 
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial @document %>


### PR DESCRIPTION
All this method does is call a partial

To make the program flow easier to understand, we can just render the partial and avoid the helper call.

The method should be removed in 8.0; see #2709