### PR TITLE
Use ActionController::Parameters to filter out non-search parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Metrics/ClassLength:
     - "lib/blacklight/configuration.rb"
     - "lib/blacklight/search_builder.rb"
     - "lib/blacklight/search_state.rb"
+    - "lib/blacklight/search_state/filter_field.rb"
 
 Layout/LineLength:
   Max: 200

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -254,7 +254,7 @@ module Blacklight
     property :enable_search_bar_autofocus, default: false
 
     BASIC_SEARCH_PARAMETERS = [:q, :qt, :page, :per_page, :search_field, :sort, :controller, :action, :'facet.page', :'facet.prefix', :'facet.sort', :rows, :format].freeze
-    ADVANCED_SEARCH_PARAMETERS = [:clause, :op].freeze
+    ADVANCED_SEARCH_PARAMETERS = [{ clause: {} }, :op].freeze
     # List the request parameters that compose the SearchState.
     # If you use a plugin that adds to the search state, then you can add the parameters
     # by modifiying this field.
@@ -262,6 +262,13 @@ module Blacklight
     # @since v8.0.0
     # @return [Array<Symbol>]
     property :search_state_fields, default: BASIC_SEARCH_PARAMETERS + ADVANCED_SEARCH_PARAMETERS
+
+    # Have SearchState filter out unknown request parameters
+    #
+    # @!attribute filter_search_state_fields
+    # @since v8.0.0
+    # @return [Boolean]
+    property :filter_search_state_fields, default: true
 
     ##
     # Create collections of solr field configurations.

--- a/lib/blacklight/parameters.rb
+++ b/lib/blacklight/parameters.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Blacklight
-  module Parameters
+  class Parameters
     ##
     # Sanitize the search parameters by removing unnecessary parameters
     # from the provided parameters.
@@ -12,5 +12,86 @@ module Blacklight
             .except(:action, :controller, :id, :commit, :utf8)
     end
     # rubocop:enable Style/CollectionCompact
+
+    # rubocop:disable Naming/MethodParameterName
+    # Merge two Rails strong_params-style permissions into a single list of permitted parameters,
+    # deep-merging complex values as needed.
+    # @param [Array<Symbol, Hash>] a
+    # @param [Array<Symbol, Hash>] b
+    # @return [Array<Symbol, Hash>]
+    def self.deep_merge_permitted_params(a, b)
+      a = [a] if a.is_a? Hash
+      b = [b] if b.is_a? Hash
+
+      complex_params_from_a, scalar_params_from_a = a.flatten.uniq.partition { |x| x.is_a? Hash }
+      complex_params_from_a = complex_params_from_a.inject({}) { |tmp, h| _deep_merge_permitted_param_hashes(h, tmp) }
+      complex_params_from_b, scalar_params_from_b = b.flatten.uniq.partition { |x| x.is_a? Hash }
+      complex_params_from_b = complex_params_from_b.inject({}) { |tmp, h| _deep_merge_permitted_param_hashes(h, tmp) }
+
+      (scalar_params_from_a + scalar_params_from_b + [_deep_merge_permitted_param_hashes(complex_params_from_a, complex_params_from_b)]).reject(&:blank?).uniq
+    end
+
+    private_class_method def self._deep_merge_permitted_param_hashes(h1, h2)
+      h1.merge(h2) do |_key, old_value, new_value|
+        if (old_value.is_a?(Hash) && old_value.empty?) || (new_value.is_a?(Hash) && new_value.empty?)
+          {}
+        elsif old_value.is_a?(Hash) && new_value.is_a?(Hash)
+          _deep_merge_permitted_param_hashes(old_value, new_value)
+        elsif old_value.is_a?(Array) || new_value.is_a?(Array)
+          deep_merge_permitted_params(old_value, new_value)
+        else
+          new_value
+        end
+      end
+    end
+    # rubocop:enable Naming/MethodParameterName
+
+    attr_reader :params, :search_state
+
+    delegate :blacklight_config, :filter_fields, to: :search_state
+
+    def initialize(params, search_state)
+      @params = params.is_a?(Hash) ? params.with_indifferent_access : params
+      @search_state = search_state
+    end
+
+    # @param [Hash] params with unknown structure (not declared in the blacklight config or filters) stripped out
+    def permit_search_params
+      # if the parameters were generated internally, we can (probably) trust that they're fine
+      return params unless params.is_a?(ActionController::Parameters)
+
+      # if the parameters were permitted already, we should be able to trust them
+      return params if params.permitted?
+
+      permitted_params = filter_fields.inject(blacklight_config.search_state_fields) do |allowlist, filter|
+        Blacklight::Parameters.deep_merge_permitted_params(allowlist, filter.permitted_params)
+      end
+
+      deep_unmangle_params!(params, permitted_params)
+
+      if blacklight_config.filter_search_state_fields
+        params.permit(*permitted_params)
+      else
+        params.deep_dup.permit!
+      end
+    end
+
+    private
+
+    # Facebook's crawler turns array query parameters into a hash with numeric keys. Once we know
+    # the expected parameter structure, we can unmangle those parameters to match our expected values.
+    def deep_unmangle_params!(params, permitted_params)
+      permitted_params.select { |p| p.is_a?(Hash) }.each do |permission|
+        permission.each do |key, permitted_value|
+          next unless params[key].is_a?(ActionController::Parameters)
+
+          if permitted_value.is_a?(Hash)
+            deep_unmangle_params!(params[key], [permitted_value])
+          elsif permitted_value.is_a?(Array) && permitted_value.empty? && params[key]&.keys&.all? { |k| k.to_s =~ /\A\d+\z/ }
+            params[key] = params[key].values
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -48,7 +48,7 @@ module Blacklight
     def where(conditions)
       params_will_change!
       @search_state = @search_state.reset(@search_state.params.merge(q: conditions))
-      @blacklight_params = @search_state.params.dup
+      @blacklight_params = @search_state.params
       @additional_filters = conditions
       self
     end

--- a/lib/blacklight/search_state/filter_field.rb
+++ b/lib/blacklight/search_state/filter_field.rb
@@ -142,12 +142,18 @@ module Blacklight
         end
       end
 
-      def needs_normalization?(value_params)
-        value_params.is_a?(Hash) && value_params != Blacklight::SearchState::FilterField::MISSING
-      end
-
-      def normalize(value_params)
-        needs_normalization?(value_params) ? value_params.values : value_params
+      def permitted_params
+        if config.pivot
+          {
+            filters_key => config.pivot.each_with_object({}) { |key, filter| filter.merge(key => [], "-#{key}" => []) },
+            inclusive_filters_key => config.pivot.each_with_object({}) { |key, filter| filter.merge(key => []) }
+          }
+        else
+          {
+            filters_key => { config.key => [], "-#{config.key}" => [] },
+            inclusive_filters_key => { config.key => [] }
+          }
+        end
       end
 
       private

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -60,17 +60,17 @@ RSpec.describe CatalogController, api: true do
       end
 
       it "shows 0 results when the user asks for an invalid value to a custom facet query", integration: true do
-        get :index, params: { f: { example_query_facet_field: 'bogus' } } # bogus custom facet value
+        get :index, params: { f: { example_query_facet_field: ['bogus'] } } # bogus custom facet value
         expect(assigns(:response).docs).to be_empty
       end
 
       it "returns results (possibly 0) when the user asks for a valid value to a custom facet query", integration: true do
-        get :index, params: { f: { example_query_facet_field: 'years_25' } } # valid custom facet value with some results
+        get :index, params: { f: { example_query_facet_field: ['years_25'] } } # valid custom facet value with some results
         expect(assigns(:response).docs).not_to be_empty
       end
 
       it "returns no results when the users asks for a value that doesn't match any" do
-        get :index, params: { f: { example_query_facet_field: 'years_5' } } # valid custom facet value with NO results
+        get :index, params: { f: { example_query_facet_field: ['years_5'] } } # valid custom facet value with NO results
         expect(assigns(:response).docs).to be_empty
       end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -283,11 +283,5 @@ RSpec.describe CatalogHelper do
 
       it { is_expected.to eq "foobar / Format: Book" }
     end
-
-    context 'when the f param is not an array' do
-      let(:params) { ActionController::Parameters.new(q: 'foobar', f: { format: 'Book' }) }
-
-      it { is_expected.to eq "foobar / Format: Book" }
-    end
   end
 end

--- a/spec/lib/blacklight/parameters_spec.rb
+++ b/spec/lib/blacklight/parameters_spec.rb
@@ -21,4 +21,88 @@ RSpec.describe Blacklight::Parameters do
       end
     end
   end
+
+  describe '.deep_merge_permitted_params' do
+    it 'merges scalar values' do
+      expect(described_class.deep_merge_permitted_params([:a], [:b])).to eq [:a, :b]
+    end
+
+    it 'appends complex values' do
+      expect(described_class.deep_merge_permitted_params([:a], { b: [] })).to eq [:a, { b: [] }]
+    end
+
+    it 'merges lists of scalar values' do
+      expect(described_class.deep_merge_permitted_params({ f: [:a, :b] }, { f: [:b, :c] })).to eq [{ f: [:a, :b, :c] }]
+    end
+
+    it 'merges complex value data structures' do
+      expect(described_class.deep_merge_permitted_params([{ f: { field1: [] } }], { f: { field2: [] } })).to eq [{ f: { field1: [], field2: [] } }]
+    end
+
+    it 'takes the most permissive value' do
+      expect(described_class.deep_merge_permitted_params([{ f: {} }], { f: { field2: [] } })).to eq [{ f: {} }]
+      expect(described_class.deep_merge_permitted_params([{ f: {} }], { f: [:some_value] })).to eq [{ f: {} }]
+    end
+  end
+
+  describe '#permit_search_params' do
+    subject(:params) { described_class.new(query_params, search_state) }
+
+    let(:query_params) { ActionController::Parameters.new(a: 1, b: 2, c: []) }
+    let(:search_state) { Blacklight::SearchState.new(query_params, blacklight_config) }
+    let(:blacklight_config) { Blacklight::Configuration.new }
+
+    context 'with facebooks badly mangled query parameters' do
+      let(:query_params) do
+        ActionController::Parameters.new(
+          f: { field: { '0': 'first', '1': 'second' } },
+          f_inclusive: { field: { '0': 'first', '1': 'second' } }
+        )
+      end
+
+      before do
+        blacklight_config.add_facet_field 'field'
+      end
+
+      it 'normalizes the facets to the expected format' do
+        expect(params.permit_search_params.to_h.with_indifferent_access).to include f: { field: %w[first second] }, f_inclusive: { field: %w[first second] }
+      end
+    end
+
+    context 'with filter_search_state_fields set to false' do
+      let(:blacklight_config) { Blacklight::Configuration.new(filter_search_state_fields: false) }
+
+      it 'allows all params' do
+        expect(params.permit_search_params.to_h.with_indifferent_access).to include(a: 1, b: 2, c: [])
+      end
+    end
+
+    context 'with filter_search_state_fields set to true' do
+      let(:blacklight_config) { Blacklight::Configuration.new(filter_search_state_fields: true) }
+
+      it 'rejects unknown params' do
+        expect(params.permit_search_params.to_h).to be_empty
+      end
+
+      context 'with some search parameters' do
+        let(:query_params) { ActionController::Parameters.new(q: 'abc', page: 5, f: { facet_field: %w[a b], unknown_field: ['a'] }) }
+
+        before do
+          blacklight_config.add_facet_field 'facet_field'
+        end
+
+        it 'allows scalar params' do
+          expect(params.permit_search_params.to_h.with_indifferent_access).to include(q: 'abc', page: 5)
+        end
+
+        it 'allows facet params' do
+          expect(params.permit_search_params.to_h.with_indifferent_access).to include(f: { facet_field: %w[a b] })
+        end
+
+        it 'removes unknown facet fields parameters' do
+          expect(params.permit_search_params.to_h.with_indifferent_access[:f]).not_to include(:unknown_field)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/blacklight/search_state/filter_field_spec.rb
+++ b/spec/lib/blacklight/search_state/filter_field_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Blacklight::SearchState::FilterField do
   let(:params) { { f: { some_field: %w[1 2], another_field: ['3'] } } }
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field 'new_field'
       config.add_facet_field 'another_field', single: true
       simple_facet_fields.each { |simple_facet_field| config.add_facet_field simple_facet_field }
       config.search_state_fields = config.search_state_fields + additional_search_fields
@@ -21,14 +22,6 @@ RSpec.describe Blacklight::SearchState::FilterField do
       new_state = filter.add('4')
 
       expect(new_state.filter('some_field').values).to eq %w[1 2 4]
-    end
-
-    it 'creates new parameter as needed' do
-      filter = search_state.filter('unknown_field')
-      new_state = filter.add('4')
-
-      expect(new_state.filter('unknown_field').values).to eq %w[4]
-      expect(new_state.params[:f]).to include(:unknown_field)
     end
 
     context 'without any parameters in the url' do
@@ -203,12 +196,6 @@ RSpec.describe Blacklight::SearchState::FilterField do
 
     it 'handles value indirection' do
       expect(search_state.filter('some_field').include?(OpenStruct.new(value: '1'))).to be true
-    end
-  end
-
-  describe '#needs_normalization?' do
-    it 'returns false for Blacklight::SearchState::FilterField::MISSING' do
-      expect(search_state.filter('some_field').needs_normalization?(Blacklight::SearchState::FilterField::MISSING)).to be false
     end
   end
 end

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -52,19 +52,6 @@ RSpec.describe Blacklight::SearchState do
       end
     end
 
-    context 'with facebooks badly mangled query parameters' do
-      let(:simple_facet_fields) { [:field] }
-      let(:params) do
-        { f: { field: { '0': 'first', '1': 'second' } },
-          f_inclusive: { field: { '0': 'first', '1': 'second' } } }
-      end
-
-      it 'normalizes the facets to the expected format' do
-        expect(search_state.to_h).to include f: { field: %w[first second] }
-        expect(search_state.to_h).to include f_inclusive: { field: %w[first second] }
-      end
-    end
-
     context 'deleting item from to_h' do
       let(:additional_search_fields) { [:q_1] }
       let(:params) { { q: 'foo', q_1: 'bar' } }
@@ -79,7 +66,7 @@ RSpec.describe Blacklight::SearchState do
     end
 
     context 'deleting deep item from to_h' do
-      let(:additional_search_fields) { [:foo] }
+      let(:additional_search_fields) { [{ foo: {} }] }
       let(:params) { { foo: { bar: [] } } }
 
       it 'does not mutate search_state to deep mutate search_state.to_h' do

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
   subject { search_builder.with(user_params) }
 
-  let(:single_facet) { { format: 'Book' } }
-  let(:multi_facets) { { format: 'Book', language_ssim: 'Tibetan' } }
+  let(:single_facet) { { format: ['Book'] } }
+  let(:multi_facets) { { format: ['Book'], language_ssim: ['Tibetan'] } }
   let(:mult_word_query) { 'tibetan history' }
   let(:subject_search_params) { { commit: "search", search_field: "subject", action: "index", controller: "catalog", rows: "10", q: "wome" } }
 
@@ -216,7 +216,9 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
         expect(subject["spellcheck.q"]).to be_blank
 
         single_facet.each_value do |value|
-          expect(subject[:fq]).to include("{!term f=#{single_facet.keys[0]}}#{value}")
+          value.each do |v|
+            expect(subject[:fq]).to include("{!term f=#{single_facet.keys[0]}}#{v}")
+          end
         end
       end
     end

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Blacklight::SearchService, api: true do
     end
 
     describe "for All Docs Query and Bad Facet" do
-      let(:bad_facet) { { format: '666' } }
+      let(:bad_facet) { { format: ['666'] } }
       let(:user_params) { { q: all_docs_query, f: bad_facet } }
 
       it 'has no results and not raise error' do


### PR DESCRIPTION
Here's a proposal for a less-impactful alternative to #2694 that can be backported to 7.x without causing significant backwards incompatibility and provide a way to provide deprecation warnings about unexpected parameters.

Instead of filtering out unknown keys and rebuilding facet fields, describe the permitted parameters using Rails' strong_parameters syntax. This allows a slightly richer description of our query parameters, and should let facets declare their supported parameter structure without needing to look at the query parameters in the first place.

For backporting, we'd want to:
- default the `filter_search_state_fields` configuration to `false`
- consider adding deprecation messages that that configuration will change (and describe what parameters won't be permitted?)
- consider "de-mangling" the scalar facet values (e.g. `f[field]=value`). we're not producing data like that outside of tests, but perhaps it exists in the real world?
