### PR TITLE
Backport unpermitted params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Metrics/ClassLength:
     - "lib/blacklight/configuration.rb"
     - "lib/blacklight/search_builder.rb"
     - "lib/blacklight/search_state.rb"
+    - "lib/blacklight/search_state/filter_field.rb"
 
 Layout/LineLength:
   Max: 200

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", '>= 1.7.0' # added named parameters
   s.add_dependency "ostruct", '>= 0.3.2'
   s.add_dependency "view_component", '~> 2.43'
+  s.add_dependency 'hashdiff'
 
   s.add_development_dependency "rsolr", ">= 1.0.6", "< 3"  # Library for interacting with rSolr.
   s.add_development_dependency "rspec-rails", "~> 5.0"

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -296,7 +296,7 @@ module Blacklight
     property :enable_search_bar_autofocus, default: false
 
     BASIC_SEARCH_PARAMETERS = [:q, :qt, :page, :per_page, :search_field, :sort, :controller, :action, :'facet.page', :'facet.prefix', :'facet.sort', :rows, :format].freeze
-    ADVANCED_SEARCH_PARAMETERS = [:clause, :op].freeze
+    ADVANCED_SEARCH_PARAMETERS = [{ clause: {} }, :op].freeze
     # List the request parameters that compose the SearchState.
     # If you use a plugin that adds to the search state, then you can add the parameters
     # by modifiying this field.
@@ -304,6 +304,13 @@ module Blacklight
     # @since v8.0.0
     # @return [Array<Symbol>]
     property :search_state_fields, default: BASIC_SEARCH_PARAMETERS + ADVANCED_SEARCH_PARAMETERS
+
+    # Have SearchState filter out unknown request parameters
+    #
+    # @!attribute filter_search_state_fields
+    # @since v8.0.0
+    # @return [Boolean]
+    property :filter_search_state_fields, default: false
 
     ##
     # Create collections of solr field configurations.

--- a/lib/blacklight/parameters.rb
+++ b/lib/blacklight/parameters.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Blacklight
-  module Parameters
+  class Parameters
     ##
     # Sanitize the search parameters by removing unnecessary parameters
     # from the provided parameters.
@@ -8,6 +8,89 @@ module Blacklight
     def self.sanitize params
       params.reject { |_k, v| v.nil? }
             .except(:action, :controller, :id, :commit, :utf8)
+    end
+
+    # rubocop:disable Naming/MethodParameterName
+    # Merge two Rails strong_params-style permissions into a single list of permitted parameters,
+    # deep-merging complex values as needed.
+    # @param [Array<Symbol, Hash>] a
+    # @param [Array<Symbol, Hash>] b
+    # @return [Array<Symbol, Hash>]
+    def self.deep_merge_permitted_params(a, b)
+      a = [a] if a.is_a? Hash
+      b = [b] if b.is_a? Hash
+
+      complex_params_from_a, scalar_params_from_a = a.flatten.uniq.partition { |x| x.is_a? Hash }
+      complex_params_from_a = complex_params_from_a.inject({}) { |tmp, h| _deep_merge_permitted_param_hashes(h, tmp) }
+      complex_params_from_b, scalar_params_from_b = b.flatten.uniq.partition { |x| x.is_a? Hash }
+      complex_params_from_b = complex_params_from_b.inject({}) { |tmp, h| _deep_merge_permitted_param_hashes(h, tmp) }
+
+      (scalar_params_from_a + scalar_params_from_b + [_deep_merge_permitted_param_hashes(complex_params_from_a, complex_params_from_b)]).reject(&:blank?).uniq
+    end
+
+    private_class_method def self._deep_merge_permitted_param_hashes(h1, h2)
+      h1.merge(h2) do |_key, old_value, new_value|
+        if (old_value.is_a?(Hash) && old_value.empty?) || (new_value.is_a?(Hash) && new_value.empty?)
+          {}
+        elsif old_value.is_a?(Hash) && new_value.is_a?(Hash)
+          _deep_merge_permitted_param_hashes(old_value, new_value)
+        elsif old_value.is_a?(Array) || new_value.is_a?(Array)
+          deep_merge_permitted_params(old_value, new_value)
+        else
+          new_value
+        end
+      end
+    end
+    # rubocop:enable Naming/MethodParameterName
+
+    attr_reader :params, :search_state
+
+    delegate :blacklight_config, :filter_fields, to: :search_state
+
+    def initialize(params, search_state)
+      @params = params.is_a?(Hash) ? params.with_indifferent_access : params
+      @search_state = search_state
+    end
+
+    # @param [Hash] params with unknown structure (not declared in the blacklight config or filters) stripped out
+    def permit_search_params
+      # if the parameters were generated internally, we can (probably) trust that they're fine
+      return params unless params.is_a?(ActionController::Parameters)
+
+      # if the parameters were permitted already, we should be able to trust them
+      return params if params.permitted?
+
+      permitted_params = filter_fields.inject(blacklight_config.search_state_fields) do |allowlist, filter|
+        Blacklight::Parameters.deep_merge_permitted_params(allowlist, filter.permitted_params)
+      end
+
+      deep_unmangle_params!(params, permitted_params)
+
+      if blacklight_config.filter_search_state_fields
+        params.permit(*permitted_params)
+      else
+        params.deep_dup.permit!
+      end
+    end
+
+    private
+
+    # Facebook's crawler turns array query parameters into a hash with numeric keys. Once we know
+    # the expected parameter structure, we can unmangle those parameters to match our expected values.
+    def deep_unmangle_params!(params, permitted_params)
+      permitted_params.select { |p| p.is_a?(Hash) }.each do |permission|
+        permission.each do |key, permitted_value|
+          if params[key].is_a?(ActionController::Parameters) && permitted_value.is_a?(Hash)
+            deep_unmangle_params!(params[key], [permitted_value])
+          elsif permitted_value.is_a?(Array) && permitted_value.empty?
+            if params[key].is_a?(ActionController::Parameters) && params[key]&.keys&.all? { |k| k.to_s =~ /\A\d+\z/ }
+              params[key] = params[key].values
+            elsif params[key].is_a?(String)
+              params[key] = Array(params[key])
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -48,7 +48,7 @@ module Blacklight
       Deprecation.warn(Blacklight::SearchBuilder, "SearchBuilder#where must be called with a hash, received #{conditions.inspect}.") unless conditions.is_a? Hash
       params_will_change!
       @search_state = @search_state.reset(@search_state.params.merge(q: conditions))
-      @blacklight_params = @search_state.params.dup
+      @blacklight_params = @search_state.params
       @additional_filters = conditions
       self
     end

--- a/lib/blacklight/search_state/filter_field.rb
+++ b/lib/blacklight/search_state/filter_field.rb
@@ -159,12 +159,18 @@ module Blacklight
         end
       end
 
-      def needs_normalization?(value_params)
-        value_params&.is_a?(Hash) && value_params != Blacklight::SearchState::FilterField::MISSING
-      end
-
-      def normalize(value_params)
-        needs_normalization?(value_params) ? value_params.values : value_params
+      def permitted_params
+        if config.pivot
+          {
+            filters_key => config.pivot.each_with_object({}) { |key, filter| filter.merge(key => [], "-#{key}" => []) },
+            inclusive_filters_key => config.pivot.each_with_object({}) { |key, filter| filter.merge(key => []) }
+          }
+        else
+          {
+            filters_key => { config.key => [], "-#{config.key}" => [] },
+            inclusive_filters_key => { config.key => [] }
+          }
+        end
       end
 
       private

--- a/spec/helpers/blacklight/render_constraints_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/render_constraints_helper_behavior_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Blacklight::RenderConstraintsHelperBehavior do
     let(:params) { ActionController::Parameters.new(q: 'foobar', f: { type: 'journal' }) }
 
     it "has a link relative to the current url" do
-      expect(subject).to have_link 'Remove constraint', href: '/catalog?f%5Btype%5D=journal'
+      expect(subject).to have_link 'Remove constraint', href: '/catalog?f%5Btype%5D%5B%5D=journal'
     end
   end
 

--- a/spec/lib/blacklight/parameters_spec.rb
+++ b/spec/lib/blacklight/parameters_spec.rb
@@ -21,4 +21,88 @@ RSpec.describe Blacklight::Parameters do
       end
     end
   end
+
+  describe '.deep_merge_permitted_params' do
+    it 'merges scalar values' do
+      expect(described_class.deep_merge_permitted_params([:a], [:b])).to eq [:a, :b]
+    end
+
+    it 'appends complex values' do
+      expect(described_class.deep_merge_permitted_params([:a], { b: [] })).to eq [:a, { b: [] }]
+    end
+
+    it 'merges lists of scalar values' do
+      expect(described_class.deep_merge_permitted_params({ f: [:a, :b] }, { f: [:b, :c] })).to eq [{ f: [:a, :b, :c] }]
+    end
+
+    it 'merges complex value data structures' do
+      expect(described_class.deep_merge_permitted_params([{ f: { field1: [] } }], { f: { field2: [] } })).to eq [{ f: { field1: [], field2: [] } }]
+    end
+
+    it 'takes the most permissive value' do
+      expect(described_class.deep_merge_permitted_params([{ f: {} }], { f: { field2: [] } })).to eq [{ f: {} }]
+      expect(described_class.deep_merge_permitted_params([{ f: {} }], { f: [:some_value] })).to eq [{ f: {} }]
+    end
+  end
+
+  describe '#permit_search_params' do
+    subject(:params) { described_class.new(query_params, search_state) }
+
+    let(:query_params) { ActionController::Parameters.new(a: 1, b: 2, c: []) }
+    let(:search_state) { Blacklight::SearchState.new(query_params, blacklight_config) }
+    let(:blacklight_config) { Blacklight::Configuration.new }
+
+    context 'with facebooks badly mangled query parameters' do
+      let(:query_params) do
+        ActionController::Parameters.new(
+          f: { field: { '0': 'first', '1': 'second' } },
+          f_inclusive: { field: { '0': 'first', '1': 'second' } }
+        )
+      end
+
+      before do
+        blacklight_config.add_facet_field 'field'
+      end
+
+      it 'normalizes the facets to the expected format' do
+        expect(params.permit_search_params.to_h.with_indifferent_access).to include f: { field: %w[first second] }, f_inclusive: { field: %w[first second] }
+      end
+    end
+
+    context 'with filter_search_state_fields set to false' do
+      let(:blacklight_config) { Blacklight::Configuration.new(filter_search_state_fields: false) }
+
+      it 'allows all params' do
+        expect(params.permit_search_params.to_h.with_indifferent_access).to include(a: 1, b: 2, c: [])
+      end
+    end
+
+    context 'with filter_search_state_fields set to true' do
+      let(:blacklight_config) { Blacklight::Configuration.new(filter_search_state_fields: true) }
+
+      it 'rejects unknown params' do
+        expect(params.permit_search_params.to_h).to be_empty
+      end
+
+      context 'with some search parameters' do
+        let(:query_params) { ActionController::Parameters.new(q: 'abc', page: 5, f: { facet_field: %w[a b], unknown_field: ['a'] }) }
+
+        before do
+          blacklight_config.add_facet_field 'facet_field'
+        end
+
+        it 'allows scalar params' do
+          expect(params.permit_search_params.to_h.with_indifferent_access).to include(q: 'abc', page: 5)
+        end
+
+        it 'allows facet params' do
+          expect(params.permit_search_params.to_h.with_indifferent_access).to include(f: { facet_field: %w[a b] })
+        end
+
+        it 'removes unknown facet fields parameters' do
+          expect(params.permit_search_params.to_h.with_indifferent_access[:f]).not_to include(:unknown_field)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/blacklight/parameters_spec.rb
+++ b/spec/lib/blacklight/parameters_spec.rb
@@ -72,8 +72,11 @@ RSpec.describe Blacklight::Parameters do
     context 'with filter_search_state_fields set to false' do
       let(:blacklight_config) { Blacklight::Configuration.new(filter_search_state_fields: false) }
 
-      it 'allows all params' do
+      it 'allows all params, but warns about the behavior' do
+        allow(Deprecation).to receive(:warn)
         expect(params.permit_search_params.to_h.with_indifferent_access).to include(a: 1, b: 2, c: [])
+
+        expect(Deprecation).to have_received(:warn).with(described_class, /including: a, b, and c/).at_least(:once)
       end
     end
 

--- a/spec/lib/blacklight/search_state/filter_field_spec.rb
+++ b/spec/lib/blacklight/search_state/filter_field_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Blacklight::SearchState::FilterField do
   let(:params) { { f: { some_field: %w[1 2], another_field: ['3'] } } }
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field 'new_field'
       config.add_facet_field 'another_field', single: true
       simple_facet_fields.each { |simple_facet_field| config.add_facet_field simple_facet_field }
       config.search_state_fields = config.search_state_fields + additional_search_fields
@@ -21,14 +22,6 @@ RSpec.describe Blacklight::SearchState::FilterField do
       new_state = filter.add('4')
 
       expect(new_state.filter('some_field').values).to eq %w[1 2 4]
-    end
-
-    it 'creates new parameter as needed' do
-      filter = search_state.filter('unknown_field')
-      new_state = filter.add('4')
-
-      expect(new_state.filter('unknown_field').values).to eq %w[4]
-      expect(new_state.params[:f]).to include(:unknown_field)
     end
 
     context 'without any parameters in the url' do
@@ -203,12 +196,6 @@ RSpec.describe Blacklight::SearchState::FilterField do
 
     it 'handles value indirection' do
       expect(search_state.filter('some_field').include?(OpenStruct.new(value: '1'))).to eq true
-    end
-  end
-
-  describe '#needs_normalization?' do
-    it 'returns false for Blacklight::SearchState::FilterField::MISSING' do
-      expect(search_state.filter('some_field').needs_normalization?(Blacklight::SearchState::FilterField::MISSING)).to be false
     end
   end
 end

--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -54,19 +54,6 @@ RSpec.describe Blacklight::SearchState do
       end
     end
 
-    context 'with facebooks badly mangled query parameters' do
-      let(:simple_facet_fields) { [:field] }
-      let(:params) do
-        { f: { field: { '0': 'first', '1': 'second' } },
-          f_inclusive: { field: { '0': 'first', '1': 'second' } } }
-      end
-
-      it 'normalizes the facets to the expected format' do
-        expect(search_state.to_h).to include f: { field: %w[first second] }
-        expect(search_state.to_h).to include f_inclusive: { field: %w[first second] }
-      end
-    end
-
     context 'deleting item from to_h' do
       let(:additional_search_fields) { [:q_1] }
       let(:params) { { q: 'foo', q_1: 'bar' } }
@@ -81,7 +68,7 @@ RSpec.describe Blacklight::SearchState do
     end
 
     context 'deleting deep item from to_h' do
-      let(:additional_search_fields) { [:foo] }
+      let(:additional_search_fields) { [{ foo: {} }] }
       let(:params) { { foo: { bar: [] } } }
 
       it 'does not mutate search_state to deep mutate search_state.to_h' do

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -216,7 +216,9 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
         expect(subject["spellcheck.q"]).to be_blank
 
         single_facet.each_value do |value|
-          expect(subject[:fq]).to include("{!term f=#{single_facet.keys[0]}}#{value}")
+          Array(value).each do |v|
+            expect(subject[:fq]).to include("{!term f=#{single_facet.keys[0]}}#{v}")
+          end
         end
       end
     end


### PR DESCRIPTION
Backport of #2717.

To maintain backwards compatibility, defaults `blacklight_config.filter_search_state_fields` to `false`, which means we only warn about the parameters instead of filtering them out. This gives plugins and downstream apps a chance to add either `permitted_params` for a custom FilterField, or add configuration to `search_state_fields`.