### PR TITLE
configured search_state_class propagates to search builder

### DIFF
--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -17,6 +17,10 @@ module Blacklight
       search_builder_class.new(self)
     end
 
+    def search_state_class
+      @search_state.class
+    end
+
     # a solr query method
     # @yield [search_builder] optional block yields configured SearchBuilder, caller can modify or create new SearchBuilder to be used. Block should return SearchBuilder to be used.
     # @return [Blacklight::Solr::Response] the solr response object

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -27,7 +27,8 @@ module Blacklight
       end
 
       @blacklight_params = {}
-      @search_state = Blacklight::SearchState.new(@blacklight_params, @scope&.blacklight_config, @scope)
+      search_state_class = @scope&.search_state_class || Blacklight::SearchState
+      @search_state = search_state_class.new(@blacklight_params, @scope&.blacklight_config, @scope)
       @additional_filters = {}
       @merged_params = {}
       @reverse_merged_params = {}

--- a/spec/models/blacklight/search_builder_spec.rb
+++ b/spec/models/blacklight/search_builder_spec.rb
@@ -5,13 +5,22 @@ RSpec.describe Blacklight::SearchBuilder, api: true do
 
   let(:processor_chain) { [] }
   let(:blacklight_config) { Blacklight::Configuration.new }
-  let(:scope) { double blacklight_config: blacklight_config }
+  let(:scope) { double blacklight_config: blacklight_config, search_state_class: nil }
 
   context "with default processor chain" do
     subject { described_class.new scope }
 
     it "uses the class-level default_processor_chain" do
       expect(subject.processor_chain).to eq []
+    end
+  end
+
+  context "with scope search_state_class" do
+    let(:state_class) { Class.new(Blacklight::SearchState) }
+    let(:scope) { double blacklight_config: blacklight_config, search_state_class: state_class }
+
+    it "uses the class-level default_processor_chain" do
+      expect(subject.search_state).to be_a state_class
     end
   end
 


### PR DESCRIPTION
see also #2716 

SearchBuilder always uses the default SearchState implementation, regardless of application configuration. This PR allows the SearchBuilder scope to indicate the class to use for search states.