### PR TITLE
Render the search bar component in the deprecated helper.

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -81,7 +81,7 @@ module Blacklight::BlacklightHelperBehavior
   def render_search_bar
     if search_bar_presenter_class == Blacklight::SearchBarPresenter && partial_from_blacklight?(Blacklight::SearchBarPresenter.partial)
       component_class = blacklight_config&.view_config(document_index_view_type)&.search_bar_component || Blacklight::SearchBarComponent
-      component_class.new(
+      render component_class.new(
         url: search_action_url,
         advanced_search_url: search_action_url(action: 'advanced_search'),
         params: search_state.params_for_search.except(:qt),


### PR DESCRIPTION
Otherwise you end up rendering the class, e.g.

```
      <div class="navbar-right navbar-nav exhibit-search-form mt-3 mt-md-0">
        #&lt;Blacklight::SearchBarComponent:0x00007ffa06b3deb0&gt;
      </div>
```