### PR TITLE
Render adv search constraints even in the deprecated helpers

### DIFF
--- a/app/helpers/blacklight/render_constraints_helper_behavior.rb
+++ b/app/helpers/blacklight/render_constraints_helper_behavior.rb
@@ -35,7 +35,7 @@ module Blacklight::RenderConstraintsHelperBehavior
                              end
 
     Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) do
-      render_constraints_query(params_or_search_state) + render_constraints_filters(params_or_search_state)
+      render_constraints_query(params_or_search_state) + render_constraints_clauses(params_or_search_state) + render_constraints_filters(params_or_search_state)
     end
   end
 
@@ -59,6 +59,24 @@ module Blacklight::RenderConstraintsHelperBehavior
                                 remove: remove_constraint_url(search_state))
     end
   end
+
+  ##
+  # Render the query constraints
+  #
+  # @deprecated
+  # @param [Blacklight::SearchState,ActionController::Parameters] params_or_search_state query parameters
+  # @return [String]
+  def render_constraints_clauses(params_or_search_state = search_state)
+    search_state = convert_to_search_state(params_or_search_state)
+
+    clause_presenters = search_state.clause_params.map do |key, clause|
+      field_config = blacklight_config.search_fields[clause[:field]]
+      Blacklight::ClausePresenter.new(key, clause, field_config, self, search_state)
+    end
+
+    render(Blacklight::ConstraintComponent.with_collection(clause_presenters))
+  end
+  deprecation_deprecate :render_constraints_clauses
 
   ##
   # Provide a url for removing a particular constraint. This can be overriden

--- a/app/presenters/blacklight/clause_presenter.rb
+++ b/app/presenters/blacklight/clause_presenter.rb
@@ -25,7 +25,7 @@ module Blacklight
     end
 
     def remove_href(path = search_state)
-      view_context.search_action_path(path.reset_search(clause: path.clause_params.except(key)))
+      view_context.search_action_path(path.reset_search(clause: path.clause_params.except(key)).to_h)
     end
 
     private

--- a/spec/helpers/blacklight/render_constraints_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/render_constraints_helper_behavior_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Blacklight::RenderConstraintsHelperBehavior do
   let(:config) do
     Blacklight::Configuration.new do |config|
       config.add_facet_field 'type'
+      config.add_search_field 'title'
     end
   end
 
@@ -28,6 +29,21 @@ RSpec.describe Blacklight::RenderConstraintsHelperBehavior do
 
     it "has a link relative to the current url" do
       expect(subject).to have_link 'Remove constraint', href: '/catalog?f%5Btype%5D%5B%5D=journal'
+    end
+  end
+
+  describe '#render_constraints_clauses' do
+    subject { helper.render_constraints_clauses(params) }
+
+    let(:my_engine) { double("Engine") }
+    let(:params) { ActionController::Parameters.new(clause: { "0": { field: 'title', query: 'nature' } }, f: { type: 'journal' }) }
+
+    it 'renders the clause constraint' do
+      expect(subject).to have_selector '.constraint-value', text: /Title\s+nature/
+    end
+
+    it "has a link relative to the current url" do
+      expect(subject).to have_link 'Remove constraint Title: nature', href: '/catalog?f%5Btype%5D%5B%5D=journal'
     end
   end
 


### PR DESCRIPTION
This may be a nice(r) stepping stone for applications that have constraint display overrides and haven't fully adopted the component-based approach.