### PR TITLE
Inherit from ApplicationMailer for easy default setting

### DIFF
--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Only works for documents with a #to_marc right now.
-class RecordMailer < ActionMailer::Base
+class RecordMailer < ApplicationMailer
   def email_record(documents, details, url_gen_params)
     title = begin
       title_field = details[:config].email.title_field


### PR DESCRIPTION
Rails 5+ creates an ApplicationMailer class which inherits from ActionMailer::Base. This, like the ApplicationModel and ApplicationController pattern gives local apps an easy place to hang code.