### PR TITLE
Stop an internal deprecation warning in search_action_url

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -253,6 +253,7 @@ module Blacklight::Catalog
   # By default, any search action from a Blacklight::Catalog controller
   # should use the current controller when constructing the route.
   def search_action_url options = {}
+    options = options.to_h if options.is_a? Blacklight::SearchState
     url_for(options.reverse_merge(action: 'index'))
   end
 


### PR DESCRIPTION
Backport the fix from #2458 

```
     ActionView::Template::Error:
       DEPRECATION WARNING: Calling `reverse_merge` on Blacklight::SearchState is deprecated and will be removed in Blacklight 8. Call #to_h first if you  need to use hash methods (or, preferably, use your own SearchState implementation). (called from search_action_url at ruby/gems/3.1.0/gems/blacklight-7.27.0/app/controllers/concerns/blacklight/catalog.rb:256)
```