### PR TITLE
Update the search bar component to use bootstrap5-style input groups …

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_form.scss
+++ b/app/assets/stylesheets/blacklight/_search_form.scss
@@ -1,7 +1,23 @@
 // bootstrap does flex-grow: 1 by default which makes the
 // text input roughly the same size as the select in many cases
-.input-group > .form-control {
-  &.search-q {
-    flex-grow: 3;
+.input-group>.search-q {
+  flex-grow: 4;
+}
+
+.input-group > .search-autocomplete-wrapper {
+  @extend .form-control;
+  flex-grow: 4;
+  padding: 0;
+
+  .search-q {
+    border: 0;
+    height: 100%;
+    width: 100%;
   }
+}
+
+.search-btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  display: flex;
 }

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -18,7 +18,7 @@
 
     <%= f.label @query_param, scoped_t('search.label'), class: 'sr-only visually-hidden' %>
     <% if autocomplete_path.present? %>
-      <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup">
+      <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
         <%= f.text_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
         <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>"></ul>
       </auto-complete>
@@ -26,10 +26,8 @@
       <%= f.text_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
     <% end %>
 
-    <span class="input-group-append">
-      <%= append(form: f) %>
-      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
-    </span>
+    <%= append(form: f) %>
+    <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
   </div>
 <% end %>
 


### PR DESCRIPTION
…for better alignment in bootstrap 5.

Part of #2781 

Before:

![](https://user-images.githubusercontent.com/111218/180102872-f37d1c71-e63d-4873-a60b-398de8728274.png)


After:

Bootstrap 5.2:
![Screen Shot 2022-07-21 at 07 11 42](https://user-images.githubusercontent.com/111218/180234952-de593468-514a-46fc-a740-2d0ac5ebc97c.png)

Bootstrap 4:
![Screen Shot 2022-07-21 at 07 11 51](https://user-images.githubusercontent.com/111218/180234980-702e1e60-eee6-4a17-8fd5-31ec4dfa396e.png)

