### PR TITLE
Re-do facets as bootstrap 5 accordions

### DIFF
--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -7,21 +7,42 @@
   border-bottom: 0;
 
   button {
+    @extend .accordion-button !optional;
     font-weight: $headings-font-weight;
 
-    &::after {
-      content: "❯";
-      float: right;
-      transform: rotate(90deg);
-    }
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
 
     &.collapsed {
       border-bottom: 0;
+    }
+  }
+}
 
+.facets-collapse {
+  .accordion-item {
+    --bs-accordion-btn-icon-transform: rotate(0deg);
+    border-top: var(--bs-card-border-width) solid var(--bs-card-border-color);
+
+    button {
       &::after {
-        transform: rotate(0deg);
-        transition: transform 0.1s ease;
+        transform: rotate(-90deg);
       }
+      &:not(.collapsed) {
+        &::after {
+          transform: rotate(0deg);
+        }
+      }
+    }
+    border-radius: var(--bs-accordion-border-radius);
+
+    .accordion-button {
+      &.collapsed {
+        border-radius: var(--bs-accordion-border-radius);
+      }
+
+      border-top-left-radius: var(--bs-accordion-border-radius);
+      border-top-right-radius: var(--bs-accordion-border-radius);
     }
   }
 }

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -57,24 +57,6 @@
   }
 }
 
-.facet-limit-active {
-  border-color: $facet-active-border !important;
-
-  .card-header {
-    background-color: $facet-active-bg !important;
-
-    .btn {
-      @if function-exists(color-contrast) {
-        color: color-contrast($facet-active-bg);
-      }
-
-      @if function-exists(color-yiq) {
-        color: color-yiq($facet-active-bg);
-      }
-    }
-  }
-}
-
 .facet-values {
   display: table;
   table-layout: fixed;
@@ -83,6 +65,10 @@
 
   li {
     display: table-row;
+
+    a {
+      text-decoration: none;
+    }
 
     .selected {
       color: $facet-active-item-color !important;
@@ -96,7 +82,7 @@
     text-decoration: none;
 
     &:hover {
-      color: theme-color("danger");
+      @extend .text-danger;
       text-decoration: none;
     }
   }
@@ -148,17 +134,6 @@
   .prev-next-links {
     float:left;
   }
-}
-
-.facet-field-heading {
-  @extend .h6;
-
-  a {
-    color: inherit;
-  }
-
-  /* This prevents the contained stretch link from covering the panel body */
-  position: relative
 }
 
 /* Sidenav

--- a/app/components/blacklight/facet_field_component.html.erb
+++ b/app/components/blacklight/facet_field_component.html.erb
@@ -1,8 +1,8 @@
-<div class="card facet-limit blacklight-<%= @facet_field.key %> <%= 'facet-limit-active' if @facet_field.active? %>">
-  <h3 class="card-header p-0 facet-field-heading" id="<%= header_html_id %>">
+<div class="card facet-limit accordion-item blacklight-<%= @facet_field.key %> <%= 'facet-limit-active' if @facet_field.active? %>">
+  <h3 class="card-header accordion-header p-0 facet-field-heading" id="<%= header_html_id %>">
     <button
       type="button"
-      class="btn w-100 d-block btn-block p-2 text-start text-left collapse-toggle <%= "collapsed" if @facet_field.collapsed? %>"
+      class="accordion-button collapse-toggle <%= "collapsed" if @facet_field.collapsed? %>"
       data-toggle="collapse"
       data-bs-toggle="collapse"
       data-target="#<%= html_id %>"
@@ -12,8 +12,8 @@
       <%= label %>
     </button>
   </h3>
-  <div id="<%= html_id %>" aria-labelledby="<%= header_html_id %>" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
-    <div class="card-body">
+  <div id="<%= html_id %>" aria-labelledby="<%= header_html_id %>" class="panel-collapse accordion-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
+    <div class="card-body accordion-body">
       <%= body %>
 
       <% if @facet_field.modal_path %>

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -21,7 +21,7 @@
     <% end %>
   </div>
 
-  <div id="<%= @panel_id %>" class="facets-collapse collapse">
+  <div id="<%= @panel_id %>" class="accordion facets-collapse collapse">
     <%= body %>
   </div>
 <% end %>


### PR DESCRIPTION
Part of #2781 

Accordions seem to have most of the relevant styling... we just need to fight the upstream code a little because we put spacing between the items 🤷‍♂️ 


![Screen Shot 2022-07-22 at 06 53 33](https://user-images.githubusercontent.com/111218/180454003-75e58450-568f-4695-96b1-29c9b05f901e.png)

TODO:
- [ ] fix up the tests
- [ ] fix up bootstrap 4
- [ ] consider how this could be backported