### PR TITLE
Improve modal styling

### DIFF
--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -29,3 +29,11 @@
 .page-link {
   white-space: nowrap;
 }
+
+.modal {
+  // override bootstrap .modal class default display: none
+  // since we aren't using bootstrap JS that sets and unsets the display
+  display: flex;
+  background: none;
+  border: none;
+}

--- a/app/assets/stylesheets/blacklight/_modal.scss
+++ b/app/assets/stylesheets/blacklight/_modal.scss
@@ -1,6 +1,4 @@
 .modal-dialog {
-  padding: 0;
-  border: 0;
   border-radius: 5px;
 }
 
@@ -17,6 +15,10 @@
 
   .blacklight-modal-close {
     display: block;
+  }
+
+  .prev_next_links.btn-group .btn {
+    border: 0;
   }
 }
 

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <% component.footer do %>
-    <div class="facet-pagination bottom row justify-content-between">
+    <div class="facet-pagination bottom flex-row justify-content-between">
       <%= render :partial=>'facet_pagination' %>
     </div>
   <% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,4 +1,6 @@
-<dialog id="blacklight-modal" class="modal-dialog modal-lg fixed">
-  <div class="modal-content">
+<dialog id="blacklight-modal" class="modal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+    </div>
   </div>
 </dialog>


### PR DESCRIPTION
This PR is related to https://github.com/projectblacklight/blacklight/issues/2781

It improves broken modal styling. We were implicitly relying on bootstrap style variables [defined under the `.modal` class ](https://github.com/twbs/bootstrap/blob/46bb9e78d74e0c7f4fa6f6fa611f3d9f8f28860b/scss/_modal.scss#L10) but we were never using `.modal`. So I added that class.

![Screen Shot 2022-07-22 at 16 11 24](https://user-images.githubusercontent.com/1328900/180579440-f17e7e88-f714-4ce3-b8f5-4d55918fb148.png)

before:
![Screen Shot 2022-07-22 at 16 18 17](https://user-images.githubusercontent.com/1328900/180579774-49cb8748-c631-4263-a398-6ce736c07108.png)

after:
![Screen Shot 2022-07-22 at 15 57 50](https://user-images.githubusercontent.com/1328900/180579099-03f93ac6-e416-49ec-a2e3-56383c61830e.png)

