### PR TITLE
Don't require the SearchBuilder scope to implement search_state_class

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -27,7 +27,7 @@ module Blacklight
       end
 
       @blacklight_params = {}
-      search_state_class = @scope&.search_state_class || Blacklight::SearchState
+      search_state_class = @scope.try(:search_state_class) || Blacklight::SearchState
       @search_state = search_state_class.new(@blacklight_params, @scope&.blacklight_config, @scope)
       @additional_filters = {}
       @merged_params = {}


### PR DESCRIPTION
Some contexts (e.g. in hyrax: https://github.com/samvera/hyrax/blob/main/app/services/hyrax/collection_member_service.rb#L32) don't even deal with user parameters at all. 