### PR TITLE
Use `$border-color` when we're outside of a table context

### DIFF
--- a/app/assets/stylesheets/blacklight/_group.scss
+++ b/app/assets/stylesheets/blacklight/_group.scss
@@ -1,5 +1,5 @@
 .group-key {
-  border-bottom: 1px solid darken($table-border-color, 60%);
+  border-bottom: 1px solid darken($border-color, 60%);
   clear: right;
 }
 


### PR DESCRIPTION
This adds compatibility with bootstrap 5.2

Backport #2780 