### PR TITLE
Don't require the SearchBuilder scope to implement search_state_class

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -28,7 +28,7 @@ module Blacklight
       end
 
       @blacklight_params = {}
-      search_state_class = @scope&.search_state_class || Blacklight::SearchState
+      search_state_class = @scope.try(:search_state_class) || Blacklight::SearchState
       @search_state = search_state_class.new(@blacklight_params, @scope&.blacklight_config, @scope)
       @additional_filters = {}
       @merged_params = {}


### PR DESCRIPTION
In 8.x, I think we'd be fine requiring the scope to define `search_state_class`, but I also think forward-porting this is fine too.  The samvera community has a lot of non-controller scopes 🤷‍♂️ 