### PR TITLE
Search styles

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_history.scss
+++ b/app/assets/stylesheets/blacklight/_search_history.scss
@@ -1,7 +1,16 @@
 /* Search History */
 .search-history {
+
+  td {
+    padding: $spacer
+  }
+
+  .constraints-container {
+    @extend .mb-0;
+  }
+
   .constraint {
-    @extend .px-3;
+    @extend .px-4;
     display: block;
     text-indent: -1 * map-get($spacers, 3);
   }

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -40,7 +40,7 @@ module Blacklight
       search_fields.values.each.with_index do |field, i|
         search_field_control do
           fields_for('clause[]', i, include_id: false) do |f|
-            content_tag(:div, class: 'form-group advanced-search-field row') do
+            content_tag(:div, class: 'form-group advanced-search-field row mb-3') do
               f.label(:query, field.display_label('search'), class: "col-sm-3 col-form-label text-md-right") +
                 content_tag(:div, class: 'col-sm-9') do
                   f.hidden_field(:field, value: field.key) +

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -31,7 +31,7 @@ module Blacklight
       options = sort_fields.values.map { |field_config| [helpers.sort_field_label(field_config.key), field_config.key] }
       return unless options.any?
 
-      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-control sort-select w-auto")
+      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-select custom-select sort-select w-auto")
     end
 
     private

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -5,7 +5,7 @@
 
   <p>
     <%= link_to 'Read the Documentation', 'https://github.com/projectblacklight/blacklight/wiki', class: 'btn btn-primary' %>
-    <%= link_to 'See Examples', 'http://projectblacklight.org', class: 'btn btn-light' %>
+    <%= link_to 'See Examples', 'http://projectblacklight.org', class: 'btn btn-secondary' %>
   </p>
 </div>
 


### PR DESCRIPTION
Three small changes related to #2781 

edit: also fix the button bg color mention in the issue.

### Search history text spacing

before
![Screen Shot 2022-07-25 at 11 42 29](https://user-images.githubusercontent.com/1328900/180851160-52705ed6-353e-4198-83d2-30e767a32146.png)

after
![Screen Shot 2022-07-25 at 11 42 07](https://user-images.githubusercontent.com/1328900/180851169-51525d61-7724-4523-9a2e-5f78a0ea5cae.png)

### Advanced search field margins

before
![Screen Shot 2022-07-25 at 11 44 02](https://user-images.githubusercontent.com/1328900/180851300-f978022f-742b-43c5-8995-739a5f1670d2.png)

after
![Screen Shot 2022-07-25 at 11 41 58](https://user-images.githubusercontent.com/1328900/180851318-80441f25-6ae0-40ea-8e80-b8dd30a698c6.png)

### Arrow on select dropdown

before
![Screen Shot 2022-07-25 at 11 44 06](https://user-images.githubusercontent.com/1328900/180851373-4379963e-6e20-4883-af4e-4f81aa84d627.png)

after
![Screen Shot 2022-07-25 at 11 41 54](https://user-images.githubusercontent.com/1328900/180851346-84adfbbe-5ebe-463d-abfe-0bed09d8e049.png)

