### PR TITLE
Silence deprecation on search_fields within the blacklight code

### DIFF
--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -67,14 +67,16 @@ json.included do
     end
   end
 
-  json.array! search_fields do |(label, key)|
-    json.type 'search_field'
-    json.id key
-    json.attributes do
-      json.label label
-    end
-    json.links do
-      json.self url_for(search_state.to_h.merge(search_field: key, only_path: false))
+  Deprecation.silence(Blacklight::ConfigurationHelperBehavior) do
+    json.array! search_fields do |(label, key)|
+      json.type 'search_field'
+      json.id key
+      json.attributes do
+        json.label label
+      end
+      json.links do
+        json.self url_for(search_state.to_h.merge(search_field: key, only_path: false))
+      end
     end
   end
 


### PR DESCRIPTION
This silences deprecation warnings downstream.
refs https://github.com/projectblacklight/blacklight/commit/009a4266771eab2c5713bc54a4c7996ef803ed5a