### PR TITLE
Replace deprecation gem with ActiveSupport's deprecation behavior

### DIFF
--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -2,9 +2,6 @@
 
 module Blacklight
   class FacetFieldListComponent < Blacklight::Component
-    extend Deprecation
-    self.deprecation_horizon = 'blacklight 9.0'
-
     def initialize(facet_field:, layout: nil)
       @facet_field = facet_field
       @layout = layout == false ? FacetFieldNoLayoutComponent : Blacklight::FacetFieldComponent
@@ -26,7 +23,7 @@ module Blacklight
 
       render(facet_item_component_class(facet_config).with_collection(collection, wrapping_element: wrapping_element))
     end
-    deprecation_deprecate render_facet_limit_list: 'Call e.g. `render facet_items` instead'
+    Blacklight.deprecation.deprecate_methods(self, render_facet_limit_list: 'Call e.g. `render facet_items` instead')
 
     def facet_items(wrapping_element: :li, **item_args)
       facet_item_component_class.with_collection(facet_item_presenters, wrapping_element: wrapping_element, **item_args)

--- a/app/components/blacklight/icons/legacy_icon_component.rb
+++ b/app/components/blacklight/icons/legacy_icon_component.rb
@@ -3,11 +3,9 @@
 module Blacklight
   module Icons
     class LegacyIconComponent < ::ViewComponent::Base
-      extend Deprecation
-
       def initialize(name:, classes: '', aria_hidden: false, label: true, role: 'img', additional_options: {})
         @name = name
-        Deprecation.warn(self, "Calling the LegacyIconComponent with \"#{name}\" is deprecated. Instead create a component for this icon.")
+        Blacklight.deprecation.warn("Calling the LegacyIconComponent with \"#{name}\" is deprecated. Instead create a component for this icon.")
         @classes = classes
         @aria_hidden = aria_hidden
         @icon = Blacklight::Icon.new(name, classes: classes, label: label, role: role, additional_options: additional_options)

--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -4,8 +4,6 @@ module Blacklight
   module Response
     # Render a group of facet fields
     class FacetGroupComponent < Blacklight::Component
-      extend Deprecation
-
       renders_one :body
 
       # @param [Blacklight::Response] response
@@ -36,7 +34,7 @@ module Blacklight
 
       # @deprecated
       def default_body
-        Deprecation.warn('Rendering the Blacklight::FacetGroupComponent without a body slot is deprecated.')
+        Blacklight.deprecation.warn('Rendering the Blacklight::FacetGroupComponent without a body slot is deprecated.')
         helpers.render(Blacklight::FacetComponent.with_collection(@fields, response: @response))
       end
 

--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -106,9 +106,9 @@ module Blacklight::SearchContext
   def nonpersisted_search_session_params
     unless method(:blacklisted_search_session_params).source_location.first.end_with?('deprecation/method_wrappers.rb')
       # The blacklisted_search_session_params was overridden, so call it.
-      Deprecation.warn(self, "blacklisted_search_session_params was overriden in your app, " \
-                             "but that method should be renamed to `nonpersisted_search_session_params'. " \
-                             "The original behavior will be removed in the next major release.")
+      Blacklight.deprecation.warn(self, "blacklisted_search_session_params was overriden in your app, " \
+                                        "but that method should be renamed to `nonpersisted_search_session_params'. " \
+                                        "The original behavior will be removed in the next major release.")
       return blacklisted_search_session_params
     end
     [:commit, :counter, :total, :search_id, :page, :per_page]
@@ -117,7 +117,7 @@ module Blacklight::SearchContext
   def blacklisted_search_session_params
     nonpersisted_search_session_params
   end
-  deprecation_deprecate blacklisted_search_session_params: 'use nonpersisted_search_session_params instead'
+  Blacklight.deprecation.deprecate_methods(self, blacklisted_search_session_params: 'use nonpersisted_search_session_params instead')
 
   # calls setup_previous_document then setup_next_document.
   # used in the show action for single view pagination.

--- a/app/helpers/blacklight/render_partials_helper_behavior.rb
+++ b/app/helpers/blacklight/render_partials_helper_behavior.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module Blacklight::RenderPartialsHelperBehavior
-  extend Deprecation
-  self.deprecation_horizon = 'blacklight 9.0'
-
   ##
   # Render the document index view
   #
@@ -25,8 +22,8 @@ module Blacklight::RenderPartialsHelperBehavior
       render_document_partial(doc, action_name, locals)
     end, "\n")
   end
-  deprecation_deprecate render_document_partials: 'Replace this call with: "document_component = blacklight_config.view_config(:atom).summary_component
-render document_component.new(presenter: document_presenter(document), component: :div, show: true)"'
+  Blacklight.deprecation.deprecate_methods(self, render_document_partials: 'Replace this call with: "document_component = blacklight_config.view_config(:atom).summary_component
+render document_component.new(presenter: document_presenter(document), component: :div, show: true)"')
 
   ##
   # Return the list of xml for a given solr document. Doesn't safely escape for HTML.

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results
-  s.add_dependency "deprecation"
   s.add_dependency "i18n", '>= 1.7.0' # added named parameters
   s.add_dependency "ostruct", '>= 0.3.2'
   s.add_dependency "view_component", '~> 2.43'

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'kaminari'
-require 'deprecation'
 require 'blacklight/open_struct_with_hash_access'
 require 'blacklight/nested_open_struct_with_hash_access'
 require 'jbuilder'
@@ -131,5 +130,9 @@ module Blacklight
   # returns the full path the the blacklight plugin installation
   def self.root
     @root ||= File.expand_path(File.dirname(File.dirname(__FILE__)))
+  end
+
+  def self.deprecation
+    @deprecation ||= ActiveSupport::Deprecation.new('9.0', 'Blacklight')
   end
 end


### PR DESCRIPTION
The `deprecation` gem was initially extracted from Rails before support for other gems landed (in Rails 5.x). This will require some minor tweaks to downstream applications that used `Deprecation.silence` etc, but the Rails versions are generally similar (if not better) anyway.