### PR TITLE
Use the latest bundler when running tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
+        bundler: 'latest'
     - name: Install dependencies
       run: bundle install
     - name: Run linter
@@ -60,6 +61,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
+        bundler: 'latest'
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: bundle install


### PR DESCRIPTION
`ruby-setup/ruby` changed its default behavior to just used the ruby-bundled version of bundler.