### PR TITLE
Add spec for Blacklight::SearchState#filters [Backport]

### DIFF
--- a/spec/lib/blacklight/search_state_spec.rb
+++ b/spec/lib/blacklight/search_state_spec.rb
@@ -549,4 +549,46 @@ RSpec.describe Blacklight::SearchState do
       expect(search_state.facet_prefix).to eq 'A'
     end
   end
+
+  describe '#filters' do
+    context 'pivot facet config but no facet params' do
+      let(:params) { {} }
+
+      it 'maps no filters' do
+        blacklight_config.add_facet_field 'some_key', pivot: %w[pivot_field_1 pivot_field_2]
+        expect(search_state.filters).to eq([])
+      end
+    end
+
+    context 'Fully configured pivot facets and some pivot facet params' do
+      let(:params) { { 'f' => { 'pivot_field_1' => 'foo' } } }
+
+      it 'maps the pivot matching param pivot_field' do
+        blacklight_config.add_facet_field "pivot_field_1", show: false
+        blacklight_config.add_facet_field "pivot_field_2", show: false
+        blacklight_config.add_facet_field 'some_key', pivot: %w[pivot_field_1 pivot_field_2]
+        expect(search_state.filters.first.key).to eq('pivot_field_1')
+        expect(search_state.filters.first.values).to eq(['foo'])
+      end
+    end
+
+    context 'Not fully configured pivot facets and some pivot facet params' do
+      let(:params) { { 'f' => { 'pivot_field_1' => 'foo' } } }
+
+      it 'maps no filters' do
+        blacklight_config.add_facet_field 'some_key', pivot: %w[pivot_field_1 pivot_field_2]
+        expect(search_state.filters).to eq([])
+      end
+    end
+
+    context 'regular facet config with params' do
+      let(:params) { { 'f' => { 'some_key' => 'foo' } } }
+
+      it 'maps the field matching param facet_field' do
+        blacklight_config.add_facet_field 'some_key'
+        expect(search_state.filters.first.key).to eq('some_key')
+        expect(search_state.filters.first.values).to eq(['foo'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Documents via spec the `filters` method with regards to configured pivot
fields.

REF #2463

Backport of #2798