### PR TITLE
typeahead styling

### DIFF
--- a/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
+++ b/app/assets/stylesheets/blacklight/_twitter_typeahead.scss
@@ -9,6 +9,7 @@
 
   input.tt-hint.form-control {
     width: 100%;
+    filter: opacity(0.33);
   }
 
   .tt-menu {
@@ -26,5 +27,11 @@
   .tt-suggestion {
     font-size: 14px;
     padding: 5px 5px 5px 10px;
+  }
+
+  .tt-suggestion:hover {
+    background-color: $dropdown-link-hover-bg;
+    color: $dropdown-link-hover-color;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
 - make it clearer (with opacity) that the hint is not prefilled automatically
 - pointer and 'highlight' (different bg) when moving mouse over the suggestions

before:
![image](https://user-images.githubusercontent.com/1842385/189147157-9baca3b2-f295-41a0-a4db-95e91db44441.png)

----

after:
![image](https://user-images.githubusercontent.com/1842385/189147231-36333e25-926b-40bb-b7eb-1700497739d1.png)

The mouse/pointer is not visible in the screenshots; but it's positioned on the first suggested item
