### PR TITLE
Get the facet styling under Bootstrap 5.2 looking better; part of #2781

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -76,6 +76,11 @@
 }
 
 .facet-values {
+  margin-bottom: 0;
+
+  a {
+    text-decoration: none;
+  }
 
   li {
     display: flex;


### PR DESCRIPTION
After:
![Screen Shot 2022-09-27 at 10 54 56](https://user-images.githubusercontent.com/111218/192601119-071ecfe5-02ff-45b2-8a16-e29c65a4c4e1.png)

Before:
![Screen Shot 2022-09-27 at 10 55 15](https://user-images.githubusercontent.com/111218/192601186-8f6c34dd-e079-40fa-9a65-5e48eaefea5a.png)
