### PR TITLE
Allow missing view icons

### DIFF
--- a/app/components/blacklight/icons/icon_component.rb
+++ b/app/components/blacklight/icons/icon_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # This is the list icon for the search button.
+    # You can override the default svg by setting:
+    #   Blacklight::Icons::ListComponent.svg = '<svg>your SVG here</svg>'
+    class IconComponent < ::ViewComponent::Base
+      def initialize(svg: nil)
+        self.svg = svg if svg
+      end
+
+      def call
+        svg&.html_safe # rubocop:disable Rails/OutputSafety
+      end
+
+      class_attribute :svg
+    end
+  end
+end

--- a/app/components/blacklight/icons/legacy_icon_component.rb
+++ b/app/components/blacklight/icons/legacy_icon_component.rb
@@ -5,22 +5,25 @@ module Blacklight
     class LegacyIconComponent < ::ViewComponent::Base
       def initialize(name:, classes: '', aria_hidden: false, label: true, role: 'img', additional_options: {})
         @name = name
-        Blacklight.deprecation.warn("Calling the LegacyIconComponent with \"#{name}\" is deprecated. Instead create a component for this icon.")
         @classes = classes
         @aria_hidden = aria_hidden
         @icon = Blacklight::Icon.new(name, classes: classes, label: label, role: role, additional_options: additional_options)
       end
 
       def call
-        tag.span(svg.html_safe,  # rubocop:disable Rails/OutputSafety
+        tag.span(svg&.html_safe || default_icon,  # rubocop:disable Rails/OutputSafety
                  class: "blacklight-icons blacklight-icon-#{@name} #{@classes}".strip,
                  'aria-hidden': (true if @aria_hidden))
       end
 
       def svg
         Rails.cache.fetch([:blacklight_icon_svg, @name]) do
-          @icon.svg
+          @icon.svg if @icon.present?
         end
+      end
+
+      def default_icon
+        @icon.icon_label
       end
     end
   end

--- a/app/components/blacklight/icons/list_component.rb
+++ b/app/components/blacklight/icons/list_component.rb
@@ -5,12 +5,8 @@ module Blacklight
     # This is the list icon for the search button.
     # You can override the default svg by setting:
     #   Blacklight::Icons::ListComponent.svg = '<svg>your SVG here</svg>'
-    class ListComponent < ::ViewComponent::Base
-      def call
-        svg.html_safe # rubocop:disable Rails/OutputSafety
-      end
-
-      class_attribute :svg, default: <<~SVG
+    class ListComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="24" height="24" viewBox="0 0 24 24">
           <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z"/><path d="M0 0h24v24H0z" fill="none"/>
         </svg>

--- a/app/components/blacklight/icons/search_component.rb
+++ b/app/components/blacklight/icons/search_component.rb
@@ -5,12 +5,8 @@ module Blacklight
     # This is the magnifing glass icon for the search button.
     # You can override the default svg by setting:
     #   Blacklight::Icons::SearchComponent.svg = '<svg>your SVG here</svg>'
-    class SearchComponent < ::ViewComponent::Base
-      def call
-        svg.html_safe # rubocop:disable Rails/OutputSafety
-      end
-
-      class_attribute :svg, default: <<~SVG
+    class SearchComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="24" height="24" viewBox="0 0 24 24">
           <path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
         </svg>

--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -15,6 +15,9 @@ module Blacklight
       end
 
       def icon
+        return render(@view.icon.new) if @view.icon.is_a?(Class)
+        return render(@view.icon) if @view.icon.is_a?(ViewComponent::Base)
+
         helpers.blacklight_icon(@view.icon || @key)
       end
 

--- a/app/helpers/blacklight/icon_helper_behavior.rb
+++ b/app/helpers/blacklight/icon_helper_behavior.rb
@@ -12,6 +12,10 @@ module Blacklight::IconHelperBehavior
   def blacklight_icon(icon_name, _options = {})
     render "Blacklight::Icons::#{icon_name.to_s.camelize}Component".constantize.new
   rescue NameError
+    Blacklight.deprecation.warn(
+      "Falling back on the LegacyIconComponent with \"#{icon_name}\" is deprecated. Instead create the component `Blacklight::Icons::#{icon_name.to_s.camelize}Component` for this icon."
+    )
+
     render Blacklight::Icons::LegacyIconComponent.new(name: icon_name)
   end
 end

--- a/app/models/blacklight/icon.rb
+++ b/app/models/blacklight/icon.rb
@@ -4,6 +4,8 @@ module Blacklight
   class Icon
     attr_reader :icon_name, :aria_hidden, :label, :role, :additional_options
 
+    delegate :present?, to: :file
+
     ##
     # @param [String, Symbol] icon_name
     # @param [String] classes additional classes separated by a string

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -15,7 +15,7 @@ class Blacklight::Configuration
     # @!attribute display_type_field
     #   @return [String, Symbol] solr field to use to render format-specific partials
     # @!attribute icon
-    #   @return [String, Symbol] icon file to use in the view picker
+    #   @return [String, Symbol, Blacklight::Icons::IconComponent] icon file to use in the view picker
     # @!attribute document_actions
     #   @return [NestedOpenStructWithHashAccess{Symbol => Blacklight::Configuration::ToolConfig}] 'tools' to render for each document
     # @!attribute facet_group_component

--- a/spec/components/blacklight/response/view_type_component_spec.rb
+++ b/spec/components/blacklight/response/view_type_component_spec.rb
@@ -24,6 +24,36 @@ RSpec.describe Blacklight::Response::ViewTypeComponent, type: :component do
     end
   end
 
+  context 'with a icon component class' do
+    let(:views) do
+      { abc: Blacklight::Configuration::ViewConfig.new(icon: Blacklight::Icons::ListComponent), def: view_config }
+    end
+
+    it 'draws the icon' do
+      expect(render.css('.view-type-abc svg')).to be_present
+    end
+  end
+
+  context 'with a icon component instance' do
+    let(:views) do
+      { abc: Blacklight::Configuration::ViewConfig.new(icon: Blacklight::Icons::ListComponent.new), def: view_config }
+    end
+
+    it 'draws the icon' do
+      expect(render.css('.view-type-abc svg')).to be_present
+    end
+  end
+
+  context 'with a icon with the svg given in-line' do
+    let(:views) do
+      { abc: Blacklight::Configuration::ViewConfig.new(icon: Blacklight::Icons::IconComponent.new(svg: 'blah')), def: view_config }
+    end
+
+    it 'draws the icon' do
+      expect(render.css('.view-type-abc').text).to include 'blah'
+    end
+  end
+
   describe "when no views exist" do
     let(:views) do
       {}

--- a/spec/components/blacklight/response/view_type_component_spec.rb
+++ b/spec/components/blacklight/response/view_type_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Blacklight::Response::ViewTypeComponent, type: :component do
 
   let(:response) { instance_double(Blacklight::Solr::Response, empty?: false) }
   let(:search_state) { instance_double(Blacklight::SearchState, to_h: { controller: 'catalog', action: 'index' }) }
-  let(:view_config) { Blacklight::Configuration::ViewConfig.new(icon: 'list') }
+  let(:view_config) { Blacklight::Configuration::ViewConfig.new }
 
   describe "when some views exist" do
     let(:views) do


### PR DESCRIPTION
Instead of blowing up with an error, we can just fall back on the view name:

![Screen Shot 2022-09-28 at 14 43 21](https://user-images.githubusercontent.com/111218/192894092-dd8a8a73-5af1-4c61-98f4-1b81240e0d01.png)
