### PR TITLE
Defer resolving Blacklight::Configuration default properties so we can use auto-loaded classes 

### DIFF
--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -14,6 +14,10 @@ module Blacklight
       end
     end
 
+    config.after_initialize do
+      Blacklight::Configuration.initialize_default_configuration
+    end
+
     # This makes our rake tasks visible.
     rake_tasks do
       Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..'))) do


### PR DESCRIPTION
if property default values are not defined under lib, they may not be available until application is loaded, causing issues for downstream apps running generators.

This shouldn't be necessary, but it's difficult for plugins (and e.g. arclight which uses blacklight + some plugins) to convince zeitwerk to get the load order right. 

Fixes #2705

(also see discussion from #2720) 