### PR TITLE
Update the route to the autocomplete suggestion endpoint

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -4,4 +4,4 @@
       advanced_search_url: search_action_url(action: 'advanced_search'),
       params: search_state.params_for_search.except(:qt),
       presenter: presenter,
-      autocomplete_path: search_action_path(action: :suggest))) %>
+      autocomplete_path: suggest_index_catalog_path)) %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -17,6 +17,6 @@
           url: search_action_url,
           advanced_search_url: search_action_url(action: 'advanced_search'),
           params: search_state.params_for_search.except(:qt),
-          autocomplete_path: search_action_path(action: :suggest))) %>
+          autocomplete_path: suggest_index_catalog_path)) %>
   </div>
 <% end %>


### PR DESCRIPTION
Calling `search_action_path(action: :suggest)` returns `/catalog` which is not what we want. The `action:` parameter is stripped off here: https://github.com/projectblacklight/blacklight/blob/f6d2888f9b1e61b81539d21f84f88dc31b4ef9a2/app/controllers/concerns/blacklight/controller.rb#L69