### PR TITLE
Restore the wrapping blacklight-icons span to componentized icons

### DIFF
--- a/app/components/blacklight/icons/icon_component.rb
+++ b/app/components/blacklight/icons/icon_component.rb
@@ -6,15 +6,27 @@ module Blacklight
     # You can override the default svg by setting:
     #   Blacklight::Icons::ListComponent.svg = '<svg>your SVG here</svg>'
     class IconComponent < ::ViewComponent::Base
-      def initialize(svg: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(svg: nil, tag: :span, name: nil, label: nil, aria_hidden: nil, classes: nil, **options)
         self.svg = svg if svg
+        @classes = Array(classes) + ['blacklight-icons', "blacklight-icons-#{name}"]
+        @name = name
+        @tag = tag
+        @options = options.merge(aria: options.fetch(:aria, {}).reverse_merge(label: label, hidden: aria_hidden))
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def call
-        svg&.html_safe # rubocop:disable Rails/OutputSafety
+        tag.public_send(@tag, svg&.html_safe, # rubocop:disable Rails/OutputSafety
+                        class: @classes,
+                        **@options)
       end
 
       class_attribute :svg
+
+      def name
+        @name ||= self.class.name.demodulize.underscore.sub('_component', '')
+      end
     end
   end
 end

--- a/app/helpers/blacklight/icon_helper_behavior.rb
+++ b/app/helpers/blacklight/icon_helper_behavior.rb
@@ -9,13 +9,13 @@ module Blacklight::IconHelperBehavior
   # the svg everytime.
   # @param [String, Symbol] icon_name
   # @return [String]
-  def blacklight_icon(icon_name, _options = {})
-    render "Blacklight::Icons::#{icon_name.to_s.camelize}Component".constantize.new
+  def blacklight_icon(icon_name, **kwargs)
+    render "Blacklight::Icons::#{icon_name.to_s.camelize}Component".constantize.new(**kwargs)
   rescue NameError
     Blacklight.deprecation.warn(
       "Falling back on the LegacyIconComponent with \"#{icon_name}\" is deprecated. Instead create the component `Blacklight::Icons::#{icon_name.to_s.camelize}Component` for this icon."
     )
 
-    render Blacklight::Icons::LegacyIconComponent.new(name: icon_name)
+    render Blacklight::Icons::LegacyIconComponent.new(name: icon_name, **kwargs)
   end
 end

--- a/spec/helpers/blacklight/icon_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/icon_helper_behavior_spec.rb
@@ -2,10 +2,22 @@
 
 RSpec.describe Blacklight::IconHelperBehavior do
   describe '#blacklight_icon' do
-    subject(:icon) { helper.blacklight_icon(:search) }
+    subject(:icon) { helper.blacklight_icon(:search, classes: 'custom-class') }
 
     it 'returns the svg' do
-      expect(icon).to have_css 'svg'
+      expect(icon).to have_css '.blacklight-icons svg'
+    end
+
+    it 'adds classes to the wrappering element' do
+      expect(icon).to have_css '.custom-class svg'
+    end
+
+    context 'with backwards compatible arguments' do
+      subject(:icon) { helper.blacklight_icon(:search, aria_hidden: true, label: 'blah') }
+
+      it 'adds aria attributes' do
+        expect(icon).to have_css '[aria-hidden="true"][aria-label="blah"]'
+      end
     end
   end
 end


### PR DESCRIPTION
In #2670 , we added support for component-supplied icons to avoid a hard dependency on sprockets (which... turns out not to be going away,  🤷‍♂️ ). I'm not sure why the wrapping `.blackight-icons` span was dropped, but it's heavily used in e.g. arclight, so it seems like it'd be nice to bring back (and allow us to backport icon components to 7.x)