### PR TITLE
Remove unused bloodhound-js dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
-    "bloodhound-js": "^1.2.3",
     "bootstrap": ">=4.3.1 <6.0.0",
     "jquery": "^3.5.1",
     "typeahead.js": "^0.11.1"


### PR DESCRIPTION
Pre-existing code is using a `Bloodhound` object actually from alternate `typeahead.js` package, see:

https://github.com/projectblacklight/blacklight/blob/v7.31.0/app/javascript/blacklight/autocomplete.js#L2

     import Bloodhound from 'typeahead.js/dist/bloodhound.js'

That is importing Bloodhound from typeahead.js package, not from bloodhound-js package. As far as I can tell, no use of `bloodhound-js` package is actually being made, so the dependency is unnecessary. Eliminating it will keep blacklight-consuming builds faster and smaller with simpler dependency trees.

This is not relevant to `main` branch/BL8, which has already removed both of these dependencies at https://github.com/projectblacklight/blacklight/commit/76e8833ffa858f1473e6a88c11a35d839e0fe95c . So it is a PR directly to release-7.x branch for future 7.x releases only. 

I could use confirmation of this from someone else who understands `blacklight-frontend` better, it's new to me. @jcoyne and I discussed it a bit here: https://code4lib.slack.com/archives/C54TB5WDQ/p1666105410283619?thread_ts=1666038752.456159&cid=C54TB5WDQ




