### PR TITLE
Allow the logo width to be adjusted as a variable

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -12,10 +12,10 @@
 .navbar-logo {  /* The main logo image for the Blacklight instance */
   @if $logo-image {
     background: transparent $logo-image no-repeat top left;
+    background-size: $logo-width 50px;
   }
-
   display: inline-block;
-  flex: 0 0 150px;
+  flex: 0 0 $logo-width;
   height: 50px;
   margin-right:20px;
   margin-top: -0.4rem;
@@ -24,7 +24,7 @@
   padding-right: 0;
   text-indent: 100%;
   white-space: nowrap;
-  width: 150px;
+  width: $logo-width;
 }
 
 .navbar-search {

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -1,6 +1,7 @@
 /* Warning! If you want to change these, just copy them into your own theme css. But you want to remove the !default, which only will set them if not already set. */
 
 $logo-image: image_url('blacklight/logo.png') !default;
+$logo-width: 150px !default;
 
 /* label (field names) */
 $field_name_color: $text-muted !default;


### PR DESCRIPTION
This allows us to use an SVG image and scale it appropriately. Without this we need to override the CSS like this:

```css
.navbar-logo {
  background-size: 200px 55px;
  width: 200px;
  flex: 0 0 200px;
}
```