### PR TITLE
Visually hide search button text on xs devices

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -40,18 +40,6 @@
     @extend .col-lg-8;
     padding-left: 0;
   }
-
-  .submit-search-text {
-    // hide 'search' label at very small screens
-    @media screen and (max-width: breakpoint-max(xs)) {
-      @if mixin-exists(sr-only) {
-        @include sr-only();
-      }
-      @if mixin-exists(visually-hidden) {
-        @include visually-hidden();
-      }
-    }
-  }
 }
 
 #skip-link {

--- a/app/assets/stylesheets/blacklight/_mixins.scss
+++ b/app/assets/stylesheets/blacklight/_mixins.scss
@@ -13,3 +13,23 @@
     fill: #fff;
   }
 }
+
+// define a visually-hidden class that applies to a given breakpoint and below
+// https://getbootstrap.com/docs/5.2/helpers/visually-hidden/
+@if mixin-exists(visually-hidden) {
+  @each $infix, $breakpoint in $grid-breakpoints {
+    .visually-hidden-#{$infix} {
+      @include media-breakpoint-down($breakpoint) {
+        @include visually-hidden;
+      }
+    }
+  }
+} @else if mixin-exists(sr-only) {  // Bootstrap 4 version
+  @each $infix, $breakpoint in $grid-breakpoints {
+    .visually-hidden-#{$infix} {
+      @include media-breakpoint-down($breakpoint) {
+        @include sr-only;
+      }
+    }
+  }
+}

--- a/app/components/blacklight/search_button_component.rb
+++ b/app/components/blacklight/search_button_component.rb
@@ -9,7 +9,7 @@ module Blacklight
 
     def call
       tag.button(class: 'btn btn-primary search-btn', type: 'submit', id: @id) do
-        tag.span(@text, class: "submit-search-text") +
+        tag.span(@text, class: "visually-hidden-sm me-sm-1 submit-search-text") +
           render(Blacklight::Icons::SearchComponent.new)
       end
     end


### PR DESCRIPTION
* Create visually-hidden-* helpers using bootstrap 5 API
* Add bootstrap 4 support using @sr-only
* Apply visually-hidden-xs to search button text
* Adjust padding in button slightly

This helps with the lack of space on very small screens. It seems like there were already styles to do this, but they aren't working at the moment (maybe markup has changed since they were written?)