### PR TITLE
Move searchbar prepend/append outside input group

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -3,8 +3,8 @@
   <% if search_fields.length > 1 %>
     <%= f.label :search_field, scoped_t('search_field.label'), class: 'sr-only visually-hidden' %>
   <% end %>
+  <%= prepend %>
   <div class="input-group">
-    <%= prepend %>
 
     <% if search_fields.length > 1 %>
       <%= f.select(:search_field,
@@ -26,9 +26,9 @@
       <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
     <% end %>
 
-    <%= append %>
     <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
   </div>
+  <%= append %>
 <% end %>
 
 <% if advanced_search_enabled? %>


### PR DESCRIPTION
Bootstrap `.input-group`s seem to be mostly used for adding a small bit of text on either end of an input, as we do for the search dropdown and search button. Prepending or appending arbitrary HTML inside the search input's group doesn't seem like something a downstream consumer would usually want to do — it seems more likely that they would instead want to prepend or append more inputs, buttons, etc. inside the search form, as siblings of the search input.

Case in point is arclight, which uses the prepend to insert a whole other input group (for a dropdown) inside the search input's group:
https://github.com/projectblacklight/arclight/blob/29d268a0e04d3560984c22f7f2cef6eb0767df7d/app/components/arclight/search_bar_component.html.erb#L1-L14

This PR allows you to avoid nesting and have the input groups be siblings, which is more in line with how the Bootstrap docs describe them. Merging it would fix the nesting in Arclight.