### PR TITLE
Revert "Move searchbar prepend/append outside input group"

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -3,8 +3,8 @@
   <% if search_fields.length > 1 %>
     <%= f.label :search_field, scoped_t('search_field.label'), class: 'sr-only visually-hidden' %>
   <% end %>
-  <%= prepend %>
   <div class="input-group">
+    <%= prepend %>
 
     <% if search_fields.length > 1 %>
       <%= f.select(:search_field,
@@ -26,9 +26,9 @@
       <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
     <% end %>
 
+    <%= append %>
     <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
   </div>
-  <%= append %>
 <% end %>
 
 <% if advanced_search_enabled? %>


### PR DESCRIPTION
This reverts commit dcb2b1d8956d7d0338ae67462f669c824f301994 (#2862), which took away functionality used by (or intended for use by) some search bar overrides. 


- BTAA (https://geo.btaa.org) appends "advanced" within the search bar
- https://exhibits.stanford.edu prepends a dropdown element on the home page

etc.
