### PR TITLE
Allow the component for actions to be specified

### DIFF
--- a/app/helpers/blacklight/component_helper_behavior.rb
+++ b/app/helpers/blacklight/component_helper_behavior.rb
@@ -18,28 +18,26 @@ module Blacklight
     # (normally renders next to title in the list view)
     #
     # @param [SolrDocument] document
-    # @param [Hash] options
-    # @option options [String] :wrapping_class
+    # @param [String] wrapping_class ("index-document-functions")
+    # @param [Class] component (Blacklight::Document::ActionsComponent)
     # @return [String]
-    def render_index_doc_actions(document, options = {})
-      actions = filter_partials(blacklight_config.view_config(document_index_view_type).document_actions, { document: document }.merge(options)).map { |_k, v| v }
-      wrapping_class = options.delete(:wrapping_class) || "index-document-functions"
+    def render_index_doc_actions(document, wrapping_class: "index-document-functions", component: Blacklight::Document::ActionsComponent)
+      actions = filter_partials(blacklight_config.view_config(document_index_view_type).document_actions, { document: document }).map { |_k, v| v }
 
-      render(Blacklight::Document::ActionsComponent.new(document: document, actions: actions, options: options, classes: wrapping_class))
+      render(component.new(document: document, actions: actions, classes: wrapping_class))
     end
 
     ##
     # Render "collection actions" area for search results view
     # (normally renders next to pagination at the top of the result set)
     #
-    # @param [Hash] options
-    # @option options [String] :wrapping_class
+    # @param [String] wrapping_class ("search-widgets")
+    # @param [Class] component (Blacklight::Document::ActionsComponent)
     # @return [String]
-    def render_results_collection_tools(options = {})
-      actions = filter_partials(blacklight_config.view_config(document_index_view_type).collection_actions, options).map { |_k, v| v }
-      wrapping_class = options.delete(:wrapping_class) || "search-widgets"
+    def render_results_collection_tools(wrapping_class: "search-widgets", component: Blacklight::Document::ActionsComponent)
+      actions = filter_partials(blacklight_config.view_config(document_index_view_type).collection_actions, {}).map { |_k, v| v }
 
-      render(Blacklight::Document::ActionsComponent.new(actions: actions, options: options, classes: wrapping_class))
+      render(component.new(actions: actions, classes: wrapping_class))
     end
 
     def show_doc_actions?(document = @document, options = {})


### PR DESCRIPTION
On render_index_doc_actions and render_results_collection_tools helpers