### PR TITLE
The default inspect can be so long that it's hard to read

### DIFF
--- a/app/models/concerns/blacklight/document.rb
+++ b/app/models/concerns/blacklight/document.rb
@@ -26,6 +26,8 @@ module Blacklight::Document
     extend ActiveModel::Naming
     include Blacklight::Document::Extensions
     include GlobalID::Identification
+
+    class_attribute :inspector_fields, default: [:_source]
   end
 
   attr_reader :response, :_source
@@ -80,6 +82,11 @@ module Blacklight::Document
 
   def first key
     Array(self[key]).first
+  end
+
+  def inspect
+    fields = inspector_fields.map { |field| "#{field}: #{public_send(field)}" }.join(", ")
+    "#<#{self.class.name}:#{object_id} #{fields}>"
   end
 
   def to_partial_path

--- a/app/presenters/blacklight/document_presenter.rb
+++ b/app/presenters/blacklight/document_presenter.rb
@@ -125,6 +125,11 @@ module Blacklight
       configuration.view_config(:show)
     end
 
+    def inspect
+      fields = "document:#{document.inspect}"
+      "#<#{self.class.name}:#{object_id} #{fields}>"
+    end
+
     private
 
     def render_field?(field_config)

--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -17,6 +17,21 @@ module Blacklight
       alias sidecar_files _sidecar_files unless ViewComponent::Base.respond_to? :sidecar_files
     end
 
+    EXCLUDE_VARIABLES = [
+      :@lookup_context, :@view_renderer, :@view_flow, :@view_context,
+      :@tag_builder, :@current_template,
+      :@__vc_set_slots, :@__vc_original_view_context,
+      :@__vc_variant, :@__vc_content_evaluated,
+      :@__vc_render_in_block, :@__vc_content, :@__vc_helpers
+    ].freeze
+
+    def inspect
+      # Exclude variables added by render_in
+      render_variables = instance_variables - EXCLUDE_VARIABLES
+      fields = render_variables.map { |ivar| "#{ivar}:#{instance_variable_get(ivar).inspect}" }.join(', ')
+      "#<#{self.class.name}:#{object_id} #{fields}>"
+    end
+
     class EngineCompiler < ::ViewComponent::Compiler
       # ViewComponent::Compiler locates and caches templates from sidecar files to the component source file.
       # While this is sensible in a Rails application, it prevents component templates defined in an Engine

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe SolrDocument, api: true do
     end
   end
 
+  describe '.inspect' do
+    subject(:inspect) { document.inspect }
+
+    let(:document) do
+      described_class.new(id: '123',
+                          title_tesim: ['Good Omens'])
+    end
+
+    it { is_expected.to end_with "_source: {\"id\"=>\"123\", \"title_tesim\"=>[\"Good Omens\"]}>" }
+  end
+
   describe '.attribute' do
     subject(:title) { document.title }
 

--- a/spec/presenters/blacklight/document_presenter_spec.rb
+++ b/spec/presenters/blacklight/document_presenter_spec.rb
@@ -60,4 +60,10 @@ RSpec.describe Blacklight::DocumentPresenter do
       expect(presenter.thumbnail).to be_a_kind_of custom_presenter_class
     end
   end
+
+  describe '#inspect' do
+    subject(:inspect) { presenter.inspect }
+
+    it { is_expected.to start_with '#<Blacklight::DocumentPresenter:' }
+  end
 end


### PR DESCRIPTION
This makes it short by default and allows the users to override it

Backport #2872 