### PR TITLE
Extract a logo_link method on the TopNavbarComponent

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
   <div class="<%= container_classes %>">
-    <%= link_to application_name, blacklight_config.logo_link, class: 'mb-0 navbar-brand navbar-logo' %>
+    <%= logo_link %>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/app/components/blacklight/top_navbar_component.rb
+++ b/app/components/blacklight/top_navbar_component.rb
@@ -9,5 +9,9 @@ module Blacklight
     attr_reader :blacklight_config
 
     delegate :application_name, :container_classes, to: :helpers
+
+    def logo_link(title: application_name)
+      link_to title, blacklight_config.logo_link, class: 'mb-0 navbar-brand navbar-logo'
+    end
   end
 end

--- a/spec/components/blacklight/header_component_spec.rb
+++ b/spec/components/blacklight/header_component_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::HeaderComponent, type: :component do
+  before do
+    with_controller_class(CatalogController) do
+      allow(controller).to receive(:current_user).and_return(nil)
+      allow(controller).to receive(:search_action_url).and_return('/search')
+      render
+    end
+  end
+
+  context 'with no slots' do
+    let(:render) { render_inline(described_class.new(blacklight_config: CatalogController.blacklight_config)) }
+
+    it 'draws the topbar' do
+      expect(page).to have_css 'nav.topbar'
+      expect(page).to have_link 'Blacklight', href: '/'
+    end
+  end
+end


### PR DESCRIPTION
This allows you specify the logo text on the component if you don't want it to be the same as the `application_name`. This also gives you the flexibility to override the link method in a downstream component without having to copy the whole template.