### PR TITLE
Make some CSS tweaks for non-js users

### DIFF
--- a/app/assets/stylesheets/blacklight/_autocomplete.scss
+++ b/app/assets/stylesheets/blacklight/_autocomplete.scss
@@ -19,3 +19,7 @@ auto-complete {
     padding: 0.25rem 1.5rem;
   }
 }
+
+.no-js #autocomplete-popup {
+  display: none;
+}

--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -23,19 +23,12 @@
   cursor: pointer;
 }
 
-.no-js .sort-pagination {
-  & {
-    @extend .clearfix;
+.no-js {
+  .btn-group:focus-within {
+    .dropdown-menu {
+      @extend .show;
+    }
   }
-  .dropdown-menu {
-    background: none;
-    box-shadow: none;
-    border: none;
-    position: relative;
-    display: block;
-    float: none;
-  }
-
 }
 
 .view-type {

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -37,6 +37,30 @@
   }
 }
 
+.no-js {
+  @include media-breakpoint-down(lg) {
+    #sidebar {
+      order: 6 !important;
+    }
+  }
+
+  .facet-content.collapse {
+    display: block;
+  }
+
+  .facet-toggle-handle {
+    display: none;
+  }
+
+  .pivot-facet.collapse {
+    display: block;
+  }
+
+  .facets-collapse.collapse {
+    display: block;
+  }
+}
+
 .facets-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
- Reveal all collapsed facet panels
- hide unusable controls
- hide the autocomplete popup
- use :focus-within to provide a better dropdown-like fallback
 
![Screen Shot 2022-11-15 at 12 04 09](https://user-images.githubusercontent.com/111218/202014754-96a739b8-d3ed-4dd7-862b-575ed8120594.png)
