### PR TITLE
Revert "Remove unused method"

### DIFF
--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -67,9 +67,6 @@ module Blacklight
 
   def defaults_version
     @defaults_version ||= blacklight_yml['load_defaults'] ||
-                          # this config parameter was introduced in Blacklight 7.11, so to be safe,
-                          # we pin any 7.x app to the 7.10 behavior
-                          (Blacklight::VERSION.starts_with?('7') && '7.10.0') ||
                           Blacklight::VERSION
 
     @defaults_version == 'latest' ? Blacklight::VERSION : @defaults_version

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -65,6 +65,16 @@ module Blacklight
     Blacklight::RuntimeRegistry.connection_config = value
   end
 
+  def defaults_version
+    @defaults_version ||= blacklight_yml['load_defaults'] ||
+                          # this config parameter was introduced in Blacklight 7.11, so to be safe,
+                          # we pin any 7.x app to the 7.10 behavior
+                          (Blacklight::VERSION.starts_with?('7') && '7.10.0') ||
+                          Blacklight::VERSION
+
+    @defaults_version == 'latest' ? Blacklight::VERSION : @defaults_version
+  end
+
   def self.blacklight_yml
     require 'erb'
     require 'yaml'


### PR DESCRIPTION
This reverts commit 6ba04a395adec98606355fa2a5776ed66a55b3ba.

Going to Blacklight 8, we got rid of the calling code.. but I think it's still a good pattern to keep around if/when we need to change configuration defaults.