### PR TITLE
Revert "Expose the original, uncompiled assets in importmaps"

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-pin_all_from File.expand_path("../app/javascript", __dir__)
+pin_all_from File.expand_path("../app/javascript/blacklight", __dir__)

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -39,11 +39,7 @@ module Blacklight
     end
 
     initializer "blacklight.importmap", before: "importmap" do |app|
-      if app.config.respond_to?(:importmap)
-        app.config.assets.precompile += Dir.glob(Engine.root.join("app/javascript/**/*.js"))
-        app.config.assets.paths << Engine.root.join('app', 'javascript')
-        app.config.importmap.paths << Engine.root.join("config/importmap.rb")
-      end
+      app.config.importmap.paths << Engine.root.join("config/importmap.rb") if app.config.respond_to?(:importmap)
     end
 
     bl_global_config = OpenStructWithHashAccess.new

--- a/lib/generators/blacklight/assets/importmap_generator.rb
+++ b/lib/generators/blacklight/assets/importmap_generator.rb
@@ -16,6 +16,7 @@ module Blacklight
           <<~CONTENT
             pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/dist/umd/popper.min.js"
             pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@#{(defined?(Bootstrap) && Bootstrap::VERSION) || '5.2.2'}/dist/js/bootstrap.js"
+            pin "blacklight", to: "blacklight/blacklight.js"
             pin "dialog-polyfill", to: "https://ga.jspm.io/npm:dialog-polyfill@0.5.6/dist/dialog-polyfill.js"
           CONTENT
         end
@@ -25,7 +26,7 @@ module Blacklight
         append_to_file 'app/javascript/application.js' do
           <<~CONTENT
             import bootstrap from "bootstrap"
-            import Blacklight from "blacklight"
+            import "blacklight"
             import dialogPolyfill from "dialog-polyfill"
             Blacklight.onLoad(() => {
               const dialog = document.querySelector('dialog')


### PR DESCRIPTION
This reverts commit b682c57a73b4953146a96a1a1c3fce79537e031e.


The uncompiled assets make relative imports like:
```javascript
import CheckboxSubmit from './checkbox_submit'
```

When this is used in a live site we would want it to be:
```javascript
import CheckboxSubmit from 'blacklight/checkbox_submit'
```

So there would still be some needed precompilation step before importmap could use the individual modules.