### PR TITLE
update blacklight-frontend npm package version to 7.32.0 for subsequent release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacklight-frontend",
-  "version": "7.25.0",
+  "version": "7.32.0",
   "description": "[![Build Status](https://travis-ci.com/projectblacklight/blacklight.png?branch=main)](https://travis-ci.com/projectblacklight/blacklight) [![Gem Version](https://badge.fury.io/rb/blacklight.png)](http://badge.fury.io/rb/blacklight) [![Coverage Status](https://coveralls.io/repos/github/projectblacklight/blacklight/badge.svg?branch=main)](https://coveralls.io/github/projectblacklight/blacklight?branch=main)",
   "main": "app/assets/javascripts/blacklight",
   "scripts": {


### PR DESCRIPTION
There are unreleased blacklight-frontend changes, and 7.32.0 is most recent gem release, @jcoyne suggested in slack that 7.x frontend release to include these changes should be 7.32.0.
