### PR TITLE
Extract a sidebar component for the search

### DIFF
--- a/app/components/blacklight/search/sidebar_component.html.erb
+++ b/app/components/blacklight/search/sidebar_component.html.erb
@@ -1,0 +1,8 @@
+<% facet_group_names.each do |groupname| %>
+  <% fields = facet_fields_in_group(groupname) %>
+  <%= render group_component_class.new(id: groupname, fields: fields, response: response) do |component| %>
+    <% component.body do %>
+      <%= render Blacklight::FacetComponent.with_collection(fields, response: response) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/blacklight/search/sidebar_component.rb
+++ b/app/components/blacklight/search/sidebar_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Search
+    class SidebarComponent < Blacklight::Component
+      def initialize(blacklight_config:, response:, view_config:)
+        @blacklight_config = blacklight_config
+        @response = response
+        @group_component_class = view_config.facet_group_component || Blacklight::Response::FacetGroupComponent
+      end
+
+      attr_reader :group_component_class, :response
+
+      delegate :facet_group_names, :facet_fields_in_group, to: :@blacklight_config
+    end
+  end
+end

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,9 +1,5 @@
-<% # container for facet groups -%>
-<% blacklight_config.facet_group_names.each do |groupname| %>
-  <% fields = blacklight_config.facet_fields_in_group(groupname) %>
-  <%= render (blacklight_config&.view_config(document_index_view_type)&.facet_group_component || Blacklight::Response::FacetGroupComponent).new(id: groupname, fields: fields, response: @response) do |component| %>
-    <% component.body do %>
-      <%= render Blacklight::FacetComponent.with_collection(fields, response: @response) %>
-    <% end %>
-  <% end %>
-<% end %>
+<% # this partial is deprecated.  catalog/index now renders the component %>
+<% conf = blacklight_config.view_config(document_index_view_type) %>
+<%= render conf.sidebar_component.new(blacklight_config: blacklight_config,
+                                      response: @response,
+                                      view_config: conf) %>

--- a/app/views/catalog/_search_sidebar.html.erb
+++ b/app/views/catalog/_search_sidebar.html.erb
@@ -1,1 +1,5 @@
-<%= render 'facets' %>
+<% # this partial is deprecated.  catalog/index now renders the component %>
+<% conf = blacklight_config.view_config(document_index_view_type) %>
+<%= render conf.sidebar_component.new(blacklight_config: blacklight_config,
+                                      response: @response,
+                                      view_config: conf) %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,5 +1,8 @@
 <% content_for(:sidebar) do %>
-  <%= render 'search_sidebar' %>
+  <% conf = blacklight_config.view_config(document_index_view_type) %>
+  <%= render conf.sidebar_component.new(blacklight_config: blacklight_config,
+                                        response: @response,
+                                        view_config: conf) %>
 <% end %>
 
 <% unless has_search_parameters? %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -141,6 +141,7 @@ module Blacklight
         document_presenter_class: nil,
         # component class used to render a document
         document_component: Blacklight::DocumentComponent,
+        sidebar_component: Blacklight::Search::SidebarComponent,
         # solr field to use to render a document title
         title_field: nil,
         # solr field to use to render format-specific partials

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -4,15 +4,16 @@ RSpec.describe "catalog/index.html.erb" do
   describe "with no search parameters" do
     before do
       allow(view).to receive(:has_search_parameters?).and_return(false)
-      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+      @response = instance_double(Blacklight::Solr::Response, empty?: true, total: 11, start: 1, limit_value: 10, aggregations: {})
     end
 
     let(:sidebar) { view.content_for(:sidebar) }
 
-    it "renders the search_sidebar partial" do
-      stub_template "catalog/_search_sidebar.html.erb" => "sidebar_content"
+    it "renders the Search::SidebarComponent component" do
       render
-      expect(sidebar).to match /sidebar_content/
+
+      expect(sidebar).to match /Limit your search/
     end
   end
 


### PR DESCRIPTION
This follows the pattern we already have for the document show page to have a sidebar component. This enables downstream consumers to override the blacklight search sidebar and customize it as needed