### PR TITLE
Use container_classes from helpers rather than views

### DIFF
--- a/app/components/blacklight/search_navbar_component.rb
+++ b/app/components/blacklight/search_navbar_component.rb
@@ -8,6 +8,8 @@ module Blacklight
 
     attr_reader :blacklight_config
 
+    delegate :container_classes, to: :helpers
+
     def search_bar
       render search_bar_component
     end

--- a/app/components/blacklight/top_navbar_component.rb
+++ b/app/components/blacklight/top_navbar_component.rb
@@ -7,5 +7,7 @@ module Blacklight
     end
 
     attr_reader :blacklight_config
+
+    delegate :container_classes, to: :helpers
   end
 end


### PR DESCRIPTION
This allows consuming app to override the helper.
Fixes #2935