### PR TITLE
Don't include helpers on the views

### DIFF
--- a/app/components/blacklight/top_navbar_component.rb
+++ b/app/components/blacklight/top_navbar_component.rb
@@ -8,6 +8,6 @@ module Blacklight
 
     attr_reader :blacklight_config
 
-    delegate :container_classes, to: :helpers
+    delegate :application_name, :container_classes, to: :helpers
   end
 end

--- a/app/controllers/concerns/blacklight/controller.rb
+++ b/app/controllers/concerns/blacklight/controller.rb
@@ -13,6 +13,7 @@ module Blacklight::Controller
 
     # handle basic authorization exception with #access_denied
     rescue_from Blacklight::Exceptions::AccessDenied, with: :access_denied
+    helper BlacklightHelper
 
     if respond_to? :helper_method
       helper_method :current_user_session, :current_user, :current_or_guest_user

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -6,14 +6,6 @@ module Blacklight
   class Engine < Rails::Engine
     engine_name "blacklight"
 
-    # BlacklightHelper is needed by all helpers, so we inject it
-    # into action view base here.
-    initializer 'blacklight.helpers' do
-      config.after_initialize do
-        ActionView::Base.include BlacklightHelper
-      end
-    end
-
     config.after_initialize do
       Blacklight::Configuration.initialize_default_configuration
     end


### PR DESCRIPTION
This causes blacklight to pollute views that do not need these methods and it makes it confusing if a user is trying to override the helper methods, but they do not also override the views