### PR TITLE
Provide a deprecation for calling show_fields_for with a scalar value

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -577,9 +577,13 @@ module Blacklight
                         document_or_display_types
                       end
 
+      unless display_types.respond_to?(:each)
+        Deprecation.warn self, "Calling show_fields_for with a scalar value is deprecated. It must receive an Enumerable."
+        display_types = Array.wrap(display_types)
+      end
       fields = {}.with_indifferent_access
 
-      Array.wrap(display_types).each do |display_type|
+      display_types.each do |display_type|
         fields = fields.merge(for_display_type(display_type).show_fields)
       end
 


### PR DESCRIPTION
It should be called with an Array.  I found this bug when upgrading Argo, which called show_fields_for with a Symbol.  This no longer worked in Blacklight 8

Fixes #2934