### PR TITLE
Compile javascript for jsbundling-rails tests

### DIFF
--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -46,6 +46,10 @@ desc "Run test suite"
 task :ci do
   with_solr do
     Rake::Task['blacklight:internal:seed'].invoke
+    within_test_app do
+      # Precompiles the javascript
+      system "bin/rake spec:prepare"
+    end
     Rake::Task['blacklight:coverage'].invoke
   end
 end


### PR DESCRIPTION
This is needed for the jsbunding-rails support (Propshaft build) now that 1.1.0 is out. This change https://github.com/rails/jsbundling-rails/pull/128 means the build is no longer triggered on `rake db:test:prepare`