### PR TITLE
Don't populate the q parameter unless a q parameter was provided

### DIFF
--- a/lib/blacklight/solr/request.rb
+++ b/lib/blacklight/solr/request.rb
@@ -19,6 +19,8 @@ class Blacklight::Solr::Request < ActiveSupport::HashWithIndifferentAccess
   end
 
   def append_query(query)
+    return if query.nil?
+
     if self['q'] || dig(:json, :query, :bool)
       self[:json] ||= { query: { bool: { must: [] } } }
       self[:json][:query] ||= { bool: { must: [] } }

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -191,6 +191,14 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       end
     end
 
+    describe "for a missing string search" do
+      let(:user_params) { { q: nil } }
+
+      it "does not populate the q parameter in solr parameters" do
+        expect(subject).not_to have_key :q
+      end
+    end
+
     describe "for an empty string search" do
       let(:user_params) { { q: "" } }
 


### PR DESCRIPTION
I'm not sure I understand why populating the `q` parameter with an empty string is important, but populating it with `nil` isn't something we need or want to do.