### PR TITLE
On modals, flash messages display once

### DIFF
--- a/app/builders/blacklight/action_builder.rb
+++ b/app/builders/blacklight/action_builder.rb
@@ -34,7 +34,7 @@ module Blacklight
 
               send(#{callback}, @documents)
 
-              flash[:success] ||= I18n.t("blacklight.#{name}.success", default: nil)
+              flash.now[:success] ||= I18n.t("blacklight.#{name}.success", default: nil)
 
               respond_to do |format|
                 format.html do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -535,7 +535,10 @@ RSpec.describe CatalogController, api: true do
         post :email, xhr: true, params: { id: doc_id, to: 'test_email@projectblacklight.org' }
         expect(request).to render_template 'email_success'
         expect(request.flash[:success]).to eq "Email Sent"
-        expect(flash.instance_variable_get("@discard").first).to eq("success")
+        allow(search_service).to receive(:search_results)
+        # When we go to another page, the flash message should no longer display
+        get :index
+        expect(request.flash[:success]).to be_nil
       end
     end
 
@@ -590,8 +593,10 @@ RSpec.describe CatalogController, api: true do
         post :sms, xhr: true, params: { id: doc_id, to: '5555555555', carrier: 'txt.att.net' }
         expect(request).to render_template 'sms_success'
         expect(request.flash[:success]).to eq "SMS Sent"
-        # The flash message should only be good for this action
-        expect(flash.instance_variable_get("@discard").first).to eq("success")
+        allow(search_service).to receive(:search_results)
+        # When we go to another page, the flash message should no longer display
+        get :index
+        expect(request.flash[:success]).to be_nil
       end
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -535,6 +535,7 @@ RSpec.describe CatalogController, api: true do
         post :email, xhr: true, params: { id: doc_id, to: 'test_email@projectblacklight.org' }
         expect(request).to render_template 'email_success'
         expect(request.flash[:success]).to eq "Email Sent"
+        expect(flash.instance_variable_get("@discard").first).to eq("success")
       end
     end
 
@@ -589,6 +590,8 @@ RSpec.describe CatalogController, api: true do
         post :sms, xhr: true, params: { id: doc_id, to: '5555555555', carrier: 'txt.att.net' }
         expect(request).to render_template 'sms_success'
         expect(request.flash[:success]).to eq "SMS Sent"
+        # The flash message should only be good for this action
+        expect(flash.instance_variable_get("@discard").first).to eq("success")
       end
     end
   end


### PR DESCRIPTION
This PR only needs to be merged into the release-7.x branch, since the main branch uses a different implementation for flash messages.

### On initial submit
![Bookmark page displays success flash message](https://user-images.githubusercontent.com/45948126/214409167-2390aac6-2ddb-40cb-8679-55e4ecdf2a8c.png)

### After dismissing first modal
![Bookmark page with no flash message](https://user-images.githubusercontent.com/45948126/214409446-92b3ae54-ad79-4518-8448-e50e88335ee4.png)

### After dismissing and doing a new search
![Search results page with no flash message](https://user-images.githubusercontent.com/45948126/214409699-ddcb7d83-e2fc-4dbe-aa72-11da281cbe45.png)


Closes #2960