### PR TITLE
Component template override

### DIFF
--- a/app/components/blacklight/response/sort_component.rb
+++ b/app/components/blacklight/response/sort_component.rb
@@ -2,7 +2,7 @@
 
 module Blacklight
   module Response
-    class SortComponent < ViewComponent::Base
+    class SortComponent < Blacklight::Component
       def initialize(search_state:, param: 'sort', choices: {}, id: 'sort-dropdown', classes: [], selected: nil)
         @param = param
         @choices = choices

--- a/app/components/blacklight/response/spellcheck_component.rb
+++ b/app/components/blacklight/response/spellcheck_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   module Response
     # Render spellcheck results for a search query
-    class SpellcheckComponent < ViewComponent::Base
+    class SpellcheckComponent < Blacklight::Component
       # @param [Blacklight::Response] response
       # @param [Array<String>] options explicit spellcheck options to render
       def initialize(response:, options: nil)

--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   module Response
     # Render spellcheck results for a search query
-    class ViewTypeButtonComponent < ViewComponent::Base
+    class ViewTypeButtonComponent < Blacklight::Component
       with_collection_parameter :view
       # @param [Blacklight::Configuration::View] view
       def initialize(view:, key: nil, selected: false, search_state: nil, classes: 'btn btn-outline-secondary btn-icon')

--- a/app/components/blacklight/response/view_type_component.rb
+++ b/app/components/blacklight/response/view_type_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   module Response
     # Render spellcheck results for a search query
-    class ViewTypeComponent < ViewComponent::Base
+    class ViewTypeComponent < Blacklight::Component
       renders_many :views, 'Blacklight::Response::ViewTypeButtonComponent'
 
       # @param [Blacklight::Response] response

--- a/app/components/blacklight/system/dropdown_component.rb
+++ b/app/components/blacklight/system/dropdown_component.rb
@@ -2,7 +2,7 @@
 
 module Blacklight
   module System
-    class DropdownComponent < ViewComponent::Base
+    class DropdownComponent < Blacklight::Component
       renders_one :button, (lambda do |classes:, label:|
         button_tag class: classes, aria: { expanded: false }, data: { toggle: 'dropdown', 'bs-toggle': 'dropdown' } do
           safe_join([label, content_tag(:span, '', class: 'caret')])

--- a/app/components/blacklight/system/flash_message_component.rb
+++ b/app/components/blacklight/system/flash_message_component.rb
@@ -2,7 +2,7 @@
 
 module Blacklight
   module System
-    class FlashMessageComponent < ViewComponent::Base
+    class FlashMessageComponent < Blacklight::Component
       renders_one :message
 
       with_collection_parameter :message

--- a/app/components/blacklight/system/modal_component.rb
+++ b/app/components/blacklight/system/modal_component.rb
@@ -2,7 +2,7 @@
 
 module Blacklight
   module System
-    class ModalComponent < ViewComponent::Base
+    class ModalComponent < Blacklight::Component
       renders_one :prefix
       renders_one :header
       renders_one :title

--- a/spec/features/component_template_override_spec.rb
+++ b/spec/features/component_template_override_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Generated test application template at default path' do
+  it 'unobtrusively overrides default top navbar component template' do
+    visit root_path
+    expect(page).to have_css 'nav[data-template-override="top_navbar_component"]'
+  end
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -34,4 +34,12 @@ class TestAppGenerator < Rails::Generators::Base
 
     run "yarn add #{Blacklight::Engine.root}"
   end
+
+  def add_component_template_override
+    src_template = File.join(Blacklight::Engine.root, 'app', 'components', 'blacklight', 'top_navbar_component.html.erb')
+    target_template = File.join('app', 'components', 'blacklight', 'top_navbar_component.html.erb')
+    create_file(target_template) do
+      File.read(src_template).gsub('role="navigation"', 'role="navigation" data-template-override="top_navbar_component"')
+    end
+  end
 end


### PR DESCRIPTION
fixes #2978 

Remaining components with default templates should inherit from `Blacklight::Component`

This should be transparent, but this PR also adds a small feature spec to exercise template overrides.