### PR TITLE
Backport #2950

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -20,7 +20,6 @@ module Blacklight
       autoload :ShowField
     end
 
-
     class_attribute :default_values, default: {}
 
     # Set up Blacklight::Configuration.default_values to contain the basic, required Blacklight fields
@@ -28,7 +27,29 @@ module Blacklight
       def property(key, default: nil)
         default_values[key] = default
       end
+
+      def default_configuration(&block)
+        @default_configurations ||= []
+
+        if block
+          @default_configurations << block
+
+          block.call if @default_configuration_initialized
+        end
+
+        @default_configurations
+      end
+
+      def initialize_default_configuration
+        @default_configurations&.map(&:call)
+        @default_configuration_initialized = true
+      end
+
+      def initialized_default_configuration?
+        @default_configuration_initialized
+      end
     end
+
     # === Search request configuration
 
     # @!attribute http_method
@@ -356,6 +377,8 @@ module Blacklight
     define_field_access :email_field, Blacklight::Configuration::DisplayField
 
     def initialize(hash = {})
+      self.class.initialize_default_configuration unless self.class.initialized_default_configuration?
+
       super(self.class.default_values.deep_dup.merge(hash))
       yield(self) if block_given?
 

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -20,14 +20,13 @@ module Blacklight
       autoload :ShowField
     end
 
+
+    class_attribute :default_values, default: {}
+
     # Set up Blacklight::Configuration.default_values to contain the basic, required Blacklight fields
     class << self
       def property(key, default: nil)
         default_values[key] = default
-      end
-
-      def default_values
-        @default_values ||= {}
       end
     end
     # === Search request configuration

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -14,6 +14,10 @@ module Blacklight
       end
     end
 
+    config.after_initialize do
+      Blacklight::Configuration.initialize_default_configuration
+    end
+
     # This makes our rake tasks visible.
     rake_tasks do
       Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..'))) do

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -723,4 +723,26 @@ RSpec.describe "Blacklight::Configuration", api: true do
       expect { config.view.a = '123' }.to raise_error(FrozenError)
     end
   end
+
+  describe '.default_configuration' do
+    it 'adds additional default configuration properties' do
+      Blacklight::Configuration.default_configuration do
+        Blacklight::Configuration.default_values[:a] = '123'
+      end
+
+      Blacklight::Configuration.default_configuration do
+        Blacklight::Configuration.default_values[:b] = 'abc'
+      end
+
+      expect(Blacklight::Configuration.default_values[:a]).to eq '123'
+      expect(Blacklight::Configuration.default_values[:b]).to eq 'abc'
+    ensure
+      # reset the default configuration
+      Blacklight::Configuration.default_values.delete(:a)
+      Blacklight::Configuration.default_values.delete(:b)
+
+      Blacklight::Configuration.default_configuration.delete_at(1)
+      Blacklight::Configuration.default_configuration.delete_at(2)
+    end
+  end
 end


### PR DESCRIPTION
and a partial backport of #2826 (without deferring the initial defaults in order to preserve compatibility)

This adds `Blacklight::Configuration.default_configuration` that allows e.g. plugins to initialize global defaults for all configurations.