### PR TITLE
Backport #2804

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,8 @@ Naming/MethodParameterName:
     - id
     - q
     - as
+    - of
+    - by
 
 Naming/PredicateName:
   ForbiddenPrefixes:

--- a/app/models/concerns/blacklight/document/attributes.rb
+++ b/app/models/concerns/blacklight/document/attributes.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'active_model/conversion'
+
+module Blacklight::Document
+  module Attributes
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :attribute_types, instance_accessor: false
+      self.attribute_types = Hash.new(Blacklight::Types::Value)
+    end
+
+    class_methods do
+      # Define an attribute reader on a document model
+      # @param [Symbol] name the name of the attribute to define
+      # @param [Symbol, Class] type the type of the attribute to define
+      # @param [String] field the name of the document's field to use for this attribute
+      # @param [any, Proc] default the default value for the attribute
+      # @example
+      #   class SolrDocument
+      #     include Blacklight::Solr::Document
+      #     attribute :title, Blacklight::Types::String, 'title_tesim'
+      #   end
+      #
+      #   doc = SolrDocument.new(title_tesim: ["One flew over the cuckoo's nest"])
+      #   doc.title
+      #   #=> "One flew over the cuckoo's nest"
+      def attribute(name, type = :value, deprecated_field = name, field: nil, default: Blacklight::Document::NO_DEFAULT_PROVIDED, **kwargs)
+        field ||= deprecated_field
+
+        define_method name do
+          if type.respond_to?(:coerce) && !(type < Blacklight::Types::Value)
+            # deprecated behavior using a bespoke api
+            type.coerce(fetch(field, default))
+          else
+            # newer behavior better aligned with ActiveModel::Type
+            instance = Blacklight::Types.lookup(type, **kwargs) if type.is_a? Symbol
+            instance ||= type.new(**kwargs)
+
+            instance.cast(fetch(field, default))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/blacklight/document/attributes.rb
+++ b/app/models/concerns/blacklight/document/attributes.rb
@@ -20,6 +20,9 @@ module Blacklight::Document
       # @example
       #   class SolrDocument
       #     include Blacklight::Solr::Document
+      #     attribute :title, :string, 'title_tesim'
+      #
+      #     Deprecated syntax:
       #     attribute :title, Blacklight::Types::String, 'title_tesim'
       #   end
       #

--- a/app/models/concerns/blacklight/document/attributes.rb
+++ b/app/models/concerns/blacklight/document/attributes.rb
@@ -29,7 +29,7 @@ module Blacklight::Document
       #   doc = SolrDocument.new(title_tesim: ["One flew over the cuckoo's nest"])
       #   doc.title
       #   #=> "One flew over the cuckoo's nest"
-      def attribute(name, type = :value, deprecated_field = name, field: nil, default: Blacklight::Document::NO_DEFAULT_PROVIDED, **kwargs)
+      def attribute(name, type = :value, deprecated_field = name, field: nil, default: nil, **kwargs)
         field ||= deprecated_field
 
         define_method name do

--- a/app/presenters/blacklight/rendering/join.rb
+++ b/app/presenters/blacklight/rendering/join.rb
@@ -5,7 +5,7 @@ module Blacklight
     class Join < AbstractStep
       def render
         options = config.separator_options || {}
-        next_step(values.map { |x| html_escape(x) }.to_sentence(options).html_safe)
+        next_step(values.map { |x| x.html_safe? ? x : html_escape(x) }.to_sentence(options).html_safe)
       end
 
       private

--- a/app/values/blacklight/types.rb
+++ b/app/values/blacklight/types.rb
@@ -1,31 +1,115 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 module Blacklight
   # These are data types that blacklight can use to coerce values from the index
   module Types
-    class Array
-      def self.coerce(input)
-        ::Array.wrap(input)
-      end
+    @registry = ActiveModel::Type::Registry.new
+
+    class << self
+      delegate :lookup, :register, to: :@registry
     end
 
-    class String
+    class Value
       def self.coerce(input)
-        ::Array.wrap(input).first
+        new.cast(input)
       end
-    end
 
-    class Date
-      def self.coerce(input)
-        field = String.coerce(input)
-        return if field.blank?
-
-        begin
-          ::Date.parse(field)
-        rescue ArgumentError
-          Rails.logger&.info "Unable to parse date: #{field.first.inspect}"
+      def cast(input)
+        if input.is_a?(::Array)
+          input.first
+        else
+          input
         end
       end
     end
+
+    class Array < Value
+      def initialize(of: nil, **kwargs)
+        @of = of
+        @kwargs = kwargs
+      end
+
+      def cast(input)
+        ::Array.wrap(input).map do |value|
+          lookup_type.cast(value)
+        end
+      end
+
+      private
+
+      def lookup_type
+        return Blacklight::Types::Value.new(**@kwargs) if @of.nil?
+
+        @lookup_type ||= Blacklight::Types.lookup(@of, **@kwargs)
+      end
+    end
+
+    class String < Value
+      def cast(input)
+        super.to_s
+      end
+    end
+
+    class Date < Value
+      def cast(input)
+        value = super
+        return if value.blank?
+
+        begin
+          ::Date.parse(value.to_s)
+        rescue ArgumentError
+          Rails.logger&.info "Unable to parse date: #{value.inspect}"
+        end
+      end
+    end
+
+    class Boolean < Value
+      def cast(input)
+        ActiveModel::Type::Boolean.new.cast(super)
+      end
+    end
+
+    class JsonValue < Value
+      def cast(input)
+        value = super
+
+        return value unless value.is_a?(String)
+
+        JSON.parse(value)
+      end
+    end
+
+    class Selector < Array
+      def initialize(by: nil, block: nil, **kwargs)
+        super(**kwargs)
+        @by = by
+        @block = block
+      end
+
+      def cast(input)
+        return super.public_send(@by) unless @block
+
+        super.public_send(@by, &@block)
+      end
+    end
+
+    # rubocop:disable Rails/OutputSafety
+    class Html < String
+      def cast(input)
+        super&.html_safe
+      end
+    end
+    # rubocop:enable Rails/OutputSafety
+
+    register :boolean, Boolean
+    register :string, String
+    register :date, Date
+    register :array, Array
+    register :json, JsonValue
+    register :html, Html
+    register :select, Selector
+    register :value, Value
   end
 end

--- a/app/values/blacklight/types.rb
+++ b/app/values/blacklight/types.rb
@@ -48,7 +48,7 @@ module Blacklight
 
     class String < Value
       def cast(input)
-        super.to_s
+        super&.to_s
       end
     end
 

--- a/app/values/blacklight/types.rb
+++ b/app/values/blacklight/types.rb
@@ -16,6 +16,10 @@ module Blacklight
         new.cast(input)
       end
 
+      def initialize(**kwargs)
+        @kwargs = kwargs
+      end
+
       def cast(input)
         if input.is_a?(::Array)
           input.first

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -45,9 +45,11 @@ RSpec.describe SolrDocument, api: true do
 
     let(:doc_class) do
       Class.new(SolrDocument) do
-        attribute :title, Blacklight::Types::String, 'title_tesim'
-        attribute :author, Blacklight::Types::Array, 'author_tesim'
-        attribute :date, Blacklight::Types::Date, 'date_dtsi'
+        attribute :title, :string, 'title_tesim'
+        attribute :author, :array, 'author_tesim', of: :string
+        attribute :first_author, :select, 'author_tesim', by: :min
+        attribute :date, :date, field: 'date_dtsi'
+        attribute :whatever, :string, default: ->(*) { 'default_value' }
       end
     end
     let(:document) do
@@ -60,7 +62,9 @@ RSpec.describe SolrDocument, api: true do
     it "casts the attributes" do
       expect(document.title).to eq 'Good Omens'
       expect(document.author).to eq ['Neil Gaiman', 'Terry Pratchett']
+      expect(document.first_author).to eq 'Neil Gaiman'
       expect(document.date).to eq Date.new(1990)
+      expect(document.whatever).to eq 'default_value'
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -66,5 +66,19 @@ RSpec.describe SolrDocument, api: true do
       expect(document.date).to eq Date.new(1990)
       expect(document.whatever).to eq 'default_value'
     end
+
+    context 'with missing data' do
+      let(:document) { doc_class.new(id: '123') }
+
+      it 'returns nil for scalar values' do
+        expect(document.title).to be_nil
+        expect(document.first_author).to be_nil
+        expect(document.date).to be_nil
+      end
+
+      it 'returns an array for array values' do
+        expect(document.author).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
This makes document attributes more expressive (with additional types) and capture some additional use cases (ways of converting multivalued fields down to single values)

Perhaps more importantly, this better aligns the attribute class method with upstream conventions in Rails (i.e. default, type-as-symbol, etc)

