### PR TITLE
Move code from the template to the class

### DIFF
--- a/app/components/blacklight/document/action_component.html.erb
+++ b/app/components/blacklight/document/action_component.html.erb
@@ -1,9 +1,2 @@
-<% if using_default_document_action? %>
-  <%= link_to label,
-              url,
-              id: @id,
-              class: @link_classes,
-              data: {}.merge(({ blacklight_modal: "trigger", turbo: false } if @action.modal != false) || {}) %>
-<% else %>
-  <%= helpers.render(partial: @action.partial || @action.name.to_s, locals: { document: @document, document_action_config: @action }.merge(@options)) %>
-<% end %>
+<%# We keep this template around so that downstream applications can override the template if desired %>
+<%= render_control %>

--- a/app/components/blacklight/document/action_component.rb
+++ b/app/components/blacklight/document/action_component.rb
@@ -16,11 +16,29 @@ module Blacklight
         @link_classes = link_classes
       end
 
+      def render_control
+        return link_to_modal_control if using_default_document_action?
+
+        render_partial
+      end
+
       def using_default_document_action?
         return true if @action.component
         return false unless @action.partial == 'document_action'
 
         helpers.partial_from_blacklight?(@action.partial)
+      end
+
+      def link_to_modal_control
+        link_to label,
+                url,
+                id: @id,
+                class: @link_classes,
+                data: {}.merge(({ blacklight_modal: "trigger", turbo: false } if @action.modal != false) || {})
+      end
+
+      def render_partial
+        helpers.render(partial: @action.partial || @action.name.to_s, locals: { document: @document, document_action_config: @action }.merge(@options))
       end
 
       def label


### PR DESCRIPTION
This makes it easier to override bits of it without having to copy the whole template

Backport #2870 