### PR TITLE
Expose useful stuff from javascript imports

### DIFF
--- a/app/javascript/blacklight/bookmark_toggle.js
+++ b/app/javascript/blacklight/bookmark_toggle.js
@@ -1,19 +1,14 @@
-import Blacklight from 'blacklight/core'
 import CheckboxSubmit from 'blacklight/checkbox_submit'
 
-const BookmarkToggle = (() => {
-    // change form submit toggle to checkbox
-    Blacklight.doBookmarkToggleBehavior = function() {
-      document.addEventListener('click', (e) => {
-        if (e.target.matches('[data-checkboxsubmit-target="checkbox"]')) {
-          const form = e.target.closest('form')
-          if (form) new CheckboxSubmit(form).clicked(e);
-        }
-      });
-    };
-    Blacklight.doBookmarkToggleBehavior.selector = 'form.bookmark-toggle';
+const BookmarkToggle = (e) => {
+  if (e.target.matches('[data-checkboxsubmit-target="checkbox"]')) {
+    const form = e.target.closest('form')
+    if (form) new CheckboxSubmit(form).clicked(e);
+  }
+};
 
-    Blacklight.doBookmarkToggleBehavior();
-})()
+BookmarkToggle.selector = 'form.bookmark-toggle';
+
+document.addEventListener('click', BookmarkToggle);
 
 export default BookmarkToggle

--- a/app/javascript/blacklight/button_focus.js
+++ b/app/javascript/blacklight/button_focus.js
@@ -1,12 +1,12 @@
-const ButtonFocus = (() => {
-  document.addEventListener('click', (e) => {
-    // Button clicks should change focus. As of 10/3/19, Firefox for Mac and
-    // Safari both do not set focus to a button on button click.
-    // See https://zellwk.com/blog/inconsistent-button-behavior/ for background information
-    if (e.target.matches('[data-toggle="collapse"]') || e.target.matches('[data-bs-toggle="collapse"]')) {
-      e.target.focus()
-    }
-  })
-})()
+const ButtonFocus = (e) => {
+  // Button clicks should change focus. As of 10/3/19, Firefox for Mac and
+  // Safari both do not set focus to a button on button click.
+  // See https://zellwk.com/blog/inconsistent-button-behavior/ for background information
+  if (e.target.matches('[data-toggle="collapse"]') || e.target.matches('[data-bs-toggle="collapse"]')) {
+    e.target.focus()
+  }
+}
+
+document.addEventListener('click', ButtonFocus)
 
 export default ButtonFocus

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -52,17 +52,10 @@
   can be a turbo-stream that defines some HTML fragementsand where on the page to put them:
   https://turbo.hotwired.dev/handbook/streams
 */
-import Blacklight from 'blacklight/core'
 import ModalForm from 'blacklight/modalForm'
 
 const Modal = (() => {
-  // We keep all our data in Blacklight.modal object.
-  // Create lazily if someone else created first.
-  if (Blacklight.modal === undefined) {
-    Blacklight.modal = {};
-  }
-
-  const modal = Blacklight.modal
+  const modal = {}
 
   // a Bootstrap modal div that should be already on the page hidden
   modal.modalSelector = '#blacklight-modal';
@@ -147,20 +140,22 @@ const Modal = (() => {
   };
 
   modal.hide = function (el) {
-    const dom = document.querySelector(Blacklight.modal.modalSelector)
+    const dom = document.querySelector(modal.modalSelector)
 
     if (!dom.open) return
     dom.close()
   }
 
   modal.show = function(el) {
-    const dom = document.querySelector(Blacklight.modal.modalSelector)
+    const dom = document.querySelector(modal.modalSelector)
 
     if (dom.open) return
     dom.showModal()
   }
 
   modal.setupModal()
+
+  return modal;
 })()
 
 export default Modal

--- a/app/javascript/blacklight/search_context.js
+++ b/app/javascript/blacklight/search_context.js
@@ -1,59 +1,53 @@
-import Blacklight from 'blacklight/core'
+const SearchContext = (e) => {
+  if (e.target.matches('[data-context-href]')) {
+    SearchContext.handleSearchContextMethod.call(e.target, e)
+  }
+}
 
-const SearchContext = (() => {
-  Blacklight.doSearchContextBehavior = function() {
-    document.addEventListener('click', (e) => {
-      if (e.target.matches('[data-context-href]')) {
-        Blacklight.handleSearchContextMethod.call(e.target, e)
-      }
-    })
-  };
+SearchContext.csrfToken = () => document.querySelector('meta[name=csrf-token]')?.content
+SearchContext.csrfParam = () => document.querySelector('meta[name=csrf-param]')?.content
 
-  Blacklight.csrfToken = () => document.querySelector('meta[name=csrf-token]')?.content
-  Blacklight.csrfParam = () => document.querySelector('meta[name=csrf-param]')?.content
+// this is the Rails.handleMethod with a couple adjustments, described inline:
+// first, we're attaching this directly to the event handler, so we can check for meta-keys
+SearchContext.handleSearchContextMethod = function(event) {
+  const link = this
 
-  // this is the Rails.handleMethod with a couple adjustments, described inline:
-  // first, we're attaching this directly to the event handler, so we can check for meta-keys
-  Blacklight.handleSearchContextMethod = function(event) {
-    const link = this
-
-    // instead of using the normal href, we need to use the context href instead
-    let href = link.getAttribute('data-context-href')
-    let target = link.getAttribute('target')
-    let csrfToken = Blacklight.csrfToken()
-    let csrfParam = Blacklight.csrfParam()
-    let form = document.createElement('form')
-    form.method = 'post'
-    form.action = href
+  // instead of using the normal href, we need to use the context href instead
+  let href = link.getAttribute('data-context-href')
+  let target = link.getAttribute('target')
+  let csrfToken = SearchContext.csrfToken()
+  let csrfParam = SearchContext.csrfParam()
+  let form = document.createElement('form')
+  form.method = 'post'
+  form.action = href
 
 
-    let formContent = `<input name="_method" value="post" type="hidden" />
-      <input name="redirect" value="${link.getAttribute('href')}" type="hidden" />`
+  let formContent = `<input name="_method" value="post" type="hidden" />
+    <input name="redirect" value="${link.getAttribute('href')}" type="hidden" />`
 
-    // check for meta keys.. if set, we should open in a new tab
-    if(event.metaKey || event.ctrlKey) {
-      target = '_blank';
-    }
+  // check for meta keys.. if set, we should open in a new tab
+  if(event.metaKey || event.ctrlKey) {
+    target = '_blank';
+  }
 
-    if (csrfParam !== undefined && csrfToken !== undefined) {
-      formContent += `<input name="${csrfParam}" value="${csrfToken}" type="hidden" />`
-    }
+  if (csrfParam !== undefined && csrfToken !== undefined) {
+    formContent += `<input name="${csrfParam}" value="${csrfToken}" type="hidden" />`
+  }
 
-    // Must trigger submit by click on a button, else "submit" event handler won't work!
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
-    formContent += '<input type="submit" />'
+  // Must trigger submit by click on a button, else "submit" event handler won't work!
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
+  formContent += '<input type="submit" />'
 
-    if (target) { form.setAttribute('target', target); }
+  if (target) { form.setAttribute('target', target); }
 
-    form.style.display = 'none'
-    form.innerHTML = formContent
-    document.body.appendChild(form)
-    form.querySelector('[type="submit"]').click()
+  form.style.display = 'none'
+  form.innerHTML = formContent
+  document.body.appendChild(form)
+  form.querySelector('[type="submit"]').click()
 
-    event.preventDefault()
-  };
+  event.preventDefault()
+};
 
-  Blacklight.doSearchContextBehavior();
-})()
+document.addEventListener('click', SearchContext)
 
 export default SearchContext


### PR DESCRIPTION
Most of the javascript exports current expose `null` because the wrapper function has no return value. With current build tools, the wrapping function (for isolation?) is probably unnecessary.

