### PR TITLE
Make the Blacklight 8.x DocumentComponent less different

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -3,7 +3,23 @@
 require 'view_component/version'
 
 module Blacklight
+  ##
+  # A component for rendering a single document
+  #
+  # @note when subclassing this component, you must explicitly specify the collection parameter
+  #    as `document` and handle the `document` parameter in your initializer.
+  #
+  # @example
+  #  class MyDocumentComponent < Blacklight::DocumentComponent
+  #    with_collection_parameter :document
+  #
+  #    def initialize(document:, **kwargs)
+  #      super(document: document, **kwargs)
+  #    end
+  #  end
   class DocumentComponent < Blacklight::Component
+    with_collection_parameter :document
+
     # ViewComponent 3 changes iteration counters to begin at 0 rather than 1
     COLLECTION_INDEX_OFFSET = ViewComponent::VERSION::MAJOR < 3 ? 0 : 1
 

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -63,6 +63,7 @@ module Blacklight
 
     # rubocop:disable Metrics/ParameterLists
     # @param document [Blacklight::DocumentPresenter]
+    # @param presenter [Blacklight::DocumentPresenter] alias for document
     # @param partials [Array, nil] view partial names that should be used to provide content for the `partials` slot
     # @param id [String] HTML id for the root element
     # @param classes [Array, String] additional HTML classes for the root element
@@ -72,11 +73,13 @@ module Blacklight
     # @param document_counter [Number, nil] provided by ViewComponent collection iteration
     # @param counter_offset [Number] the offset of the start of the collection counter parameter for the component to the overall result set
     # @param show [Boolean] are we showing only a single document (vs a list of search results); used for backwards-compatibility
-    def initialize(document: nil, partials: nil,
+    def initialize(document: nil, presenter: nil, partials: nil,
                    id: nil, classes: [], component: :article, title_component: nil,
                    counter: nil, document_counter: nil, counter_offset: 0,
                    show: false, **args)
-      @presenter = document || args[self.class.collection_parameter]
+      Blacklight.deprecation.warn('the `presenter` argument to DocumentComponent#initialize is deprecated; pass the `presenter` in as document instead') if presenter
+
+      @presenter = presenter || document || args[self.class.collection_parameter]
       @document = @presenter.document
       @view_partials = partials || []
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,4 @@
 <% # container for a single doc -%>
-<% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type) %>
-<% document_component = blacklight_config.view_config(:show).document_component -%>
+<% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type, action_name: action_name) %>
+<% document_component = view_config.document_component -%>
 <%= render document_component.new(document_component.collection_parameter => document_presenter(document), counter: document_counter_with_offset(document_counter), partials: view_config&.partials) %>

--- a/spec/views/catalog/_document.html.erb_spec.rb
+++ b/spec/views/catalog/_document.html.erb_spec.rb
@@ -24,4 +24,25 @@ RSpec.describe "catalog/_document" do
     expect(rendered).to match /b_partial/
     expect(rendered).to match /c_partial/
   end
+
+  context 'with a configured document component' do
+    let(:custom_component_class) do
+      Class.new(Blacklight::DocumentComponent) do
+        # Override component rendering with our own value
+        def call
+          'blah'
+        end
+      end
+    end
+
+    before do
+      stub_const('MyDocumentComponent', custom_component_class)
+      blacklight_config.index.document_component = MyDocumentComponent
+    end
+
+    it 'renders the document component' do
+      render partial: "catalog/document", locals: { document: document, document_counter: 1, view_config: blacklight_config.index }
+      expect(rendered).to match /blah/
+    end
+  end
 end


### PR DESCRIPTION
#2698 introduced some disruptive changes for downstream use. This smooths the migration path to 8.x a little better.