### PR TITLE
Continue to provide access to the view component's controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,10 +32,6 @@ else
     end
   end
 
-  unless ENV['VIEW_COMPONENT_VERSION'].to_s == ""
-    gem 'view_component', ENV.fetch('VIEW_COMPONENT_VERSION')
-  end
-
   case ENV['RAILS_VERSION'].to_s
   when /^(~> ?)?6\.0/
     gem 'sass-rails', '>= 6'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include PresenterTestHelpers, type: :presenter
   config.include ViewComponent::TestHelpers, type: :component
-  config.include ViewComponentCapybaraTestHelpers, type: :component
+  config.include ViewComponentTestHelpers, type: :component
 
   config.include(ControllerLevelHelpers, type: :helper)
   config.before(:each, type: :helper) { initialize_controller_helpers(helper) }

--- a/spec/support/view_component_capybara_test_helpers.rb
+++ b/spec/support/view_component_capybara_test_helpers.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module ViewComponentCapybaraTestHelpers
-  # Work around for https://github.com/teamcapybara/capybara/issues/2466
-  def render_inline_to_capybara_node(component)
-    Capybara::Node::Simple.new(render_inline(component).to_s)
-  end
-end

--- a/spec/support/view_component_test_helpers.rb
+++ b/spec/support/view_component_test_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ViewComponentTestHelpers
+  # Work around for https://github.com/teamcapybara/capybara/issues/2466
+  def render_inline_to_capybara_node(component)
+    Capybara::Node::Simple.new(render_inline(component).to_s)
+  end
+
+  # Work-around for https://github.com/ViewComponent/view_component/pull/1661
+  # which made the component test's controller method (more) private. This makes
+  # it available so we can set up controller-level state for our tests.
+  def controller
+    # ViewComponent 2.x
+    return super if defined?(super)
+
+    # ViewComponent 3.x
+    return __vc_test_helpers_controller if defined?(__vc_test_helpers_controller)
+
+    ApplicationController.new.extend(Rails.application.routes.url_helpers)
+  end
+end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,2 +1,6 @@
 gem 'rails-controller-testing'
 gem 'thor', '~> 0.20' if /^5.[12]/.match?(ENV['RAILS_VERSION'])
+
+unless ENV['VIEW_COMPONENT_VERSION'].to_s == ""
+  gem 'view_component', ENV.fetch('VIEW_COMPONENT_VERSION')
+end


### PR DESCRIPTION
This is a hacky fix for #3013, but upstream doesn't give us much choice. I don't see anywhere we could otherwise tap into their testing infrastructure short of reimplementing it here.