### PR TITLE
Allow the metadata_component to be configured

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -54,7 +54,7 @@ module Blacklight
     renders_one :metadata, (lambda do |static_content = nil, *args, component: nil, fields: nil, **kwargs|
       next static_content if static_content.present?
 
-      component ||= Blacklight::DocumentMetadataComponent
+      component ||= @presenter&.view_config&.metadata_component || Blacklight::DocumentMetadataComponent
 
       component.new(*args, fields: fields || @presenter&.field_presenters || [], **kwargs)
     end)


### PR DESCRIPTION
This makes it easier to swap out the default component without having to override the _show_main_content.html.erb.  Additionally this provides consistency with how you can set the thubmnail_component