### PR TITLE
Escape bootstrap-version

### DIFF
--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require 'shellwords'
+
 module Blacklight
   class AssetsGenerator < Rails::Generators::Base
     class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 5.1'), desc: "Set the generated app's bootstrap version"
 
     def run_asset_pipeline_specific_generator
-      generated_options = "--bootstrap-version='#{options[:'bootstrap-version']}'" if options[:'bootstrap-version']
+      generated_options = "--bootstrap-version='#{Shellwords.escape(options[:'bootstrap-version'])}'" if options[:'bootstrap-version']
 
       generator = if defined?(Propshaft)
                     'blacklight:assets:propshaft'

--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'shellwords'
+
 module Blacklight
   class Install < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
@@ -35,7 +37,7 @@ module Blacklight
     # Call external generator in AssetsGenerator, so we can
     # leave that callable seperately too.
     def copy_public_assets
-      generated_options = "--bootstrap-version='#{options[:'bootstrap-version']}'" if options[:'bootstrap-version']
+      generated_options = "--bootstrap-version='#{Shellwords.escape(options[:'bootstrap-version'])}'" if options[:'bootstrap-version']
 
       generate "blacklight:assets", generated_options unless options[:'skip-assets']
     end


### PR DESCRIPTION
So that a string like `~> 4.0` can be passed without bash transforming `~` to `$HOME`