### PR TITLE
Link only the blacklight logo

### DIFF
--- a/app/assets/config/blacklight/manifest.js
+++ b/app/assets/config/blacklight/manifest.js
@@ -1,3 +1,3 @@
-//= link_tree ../../images
+//= link ../../images/blacklight/logo.png
 //= link_directory ../../stylesheets .css
 //= link_tree ../../../javascript .js


### PR DESCRIPTION
This prevents a DoubleLinkError between a local favicon.ico and one in the gem

See https://github.com/sul-dlss/dlme/commit/9e649ad5108d95a429df9fb8e086b060f62b020a

This only happens if the local app has `app/assets/images/favicon.ico`, which is not the rails default behavior (by default it's public/favicon.ico)

Fixes #3025 