### PR TITLE
There is no need to have an initializer load the defaults

### DIFF
--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -6,10 +6,6 @@ module Blacklight
   class Engine < Rails::Engine
     engine_name "blacklight"
 
-    config.after_initialize do
-      Blacklight::Configuration.initialize_default_configuration
-    end
-
     # This makes our rake tasks visible.
     rake_tasks do
       Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..'))) do


### PR DESCRIPTION
The defaults are loaded when the configuration is initialized.  The existing initializer was overwriting values that Spotlight was trying to set in it's initializer