### PR TITLE
Allow the title_component to be configured

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -37,7 +37,7 @@ module Blacklight
 
     # The document title with some reasonable default behavior
     renders_one :title, (lambda do |*args, component: nil, **kwargs|
-      component ||= Blacklight::DocumentTitleComponent
+      component ||= @presenter&.view_config&.title_component || Blacklight::DocumentTitleComponent
 
       component.new(*args, counter: @counter, document: @document, presenter: @presenter, as: @title_component, actions: !@show, link_to_document: !@show, document_component: self, **kwargs)
     end)

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -181,6 +181,26 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
         expect(rendered).to have_text 'blah'
       end
     end
+
+    context 'with configured title component' do
+      let(:custom_component_class) do
+        Class.new(Blacklight::DocumentTitleComponent) do
+          # Override component rendering with our own value
+          def call
+            'Titleriffic'
+          end
+        end
+      end
+
+      before do
+        stub_const('MyTitleComponent', custom_component_class)
+        blacklight_config.show.title_component = MyTitleComponent
+      end
+
+      it 'renders custom component' do
+        expect(rendered).to have_text 'Titleriffic'
+      end
+    end
   end
 
   it 'renders partials' do


### PR DESCRIPTION
This provides a consistent way to configure the components (following on from #3020)