### PR TITLE
Link only the blacklight logo via png filter 

### DIFF
--- a/app/assets/config/blacklight/manifest.js
+++ b/app/assets/config/blacklight/manifest.js
@@ -1,3 +1,3 @@
-//= link_tree ../../images
+//= link_tree ../../images .png
 //= link_directory ../../stylesheets .css
 //= link_tree ../../../javascript .js


### PR DESCRIPTION
This prevents a DoubleLinkError between a local favicon.ico and one in the gem

This builds on @jcoyne's original PR #3027, but does not drop the link_tree.
It passed CI once.  I hope it will pass CI a second time.

I am unsure why the link_tree is needed, but CI was failing in the original PR so it seems neccisary