### PR TITLE
deprecate _show_tools partial

### DIFF
--- a/app/components/blacklight/document/sidebar_component.html.erb
+++ b/app/components/blacklight/document/sidebar_component.html.erb
@@ -1,2 +1,2 @@
-<%= render 'show_tools', document: document %>
+<%= render_show_tools %>
 <%= render(Blacklight::Document::MoreLikeThisComponent.new(document: document)) %>

--- a/app/components/blacklight/document/sidebar_component.rb
+++ b/app/components/blacklight/document/sidebar_component.rb
@@ -11,6 +11,18 @@ module Blacklight
       end
 
       attr_reader :document
+
+      delegate :blacklight_config, to: :helpers
+
+      private
+
+      def render_show_tools
+        blacklight_config.view_config(:show).show_tools_component&.tap do |show_tools_component_class|
+          return render show_tools_component_class.new(document: document)
+        end
+
+        render 'show_tools', document: document, silence_deprecation: helpers.partial_from_blacklight?('show_tools')
+      end
     end
   end
 end

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -37,4 +37,14 @@ module Blacklight::BlacklightHelperBehavior
     self.formats = old_formats
     nil
   end
+
+  def self.blacklight_gem_path
+    @blacklight_gem_path ||= Gem.loaded_specs["blacklight"].full_gem_path
+  end
+
+  def partial_from_blacklight?(partial)
+    path = lookup_context.find_all(partial, lookup_context.prefixes + [""], true).first&.identifier
+
+    path.nil? ? false : path.starts_with?(Blacklight::BlacklightHelperBehavior.blacklight_gem_path)
+  end
 end

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,1 +1,2 @@
+<% Blacklight.deprecation.warn('The partial _show_tools.html.erb will be removed in 9.0. Configure blacklight_config.show.show_tools_component instead (default Blacklight::Document::ShowToolsComponent).') unless local_assigns[:silence_deprecation] %>
 <%= render Blacklight::Document::ShowToolsComponent.new(document: document) %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -181,6 +181,9 @@ module Blacklight
         # document presenter class used by helpers and views
         document_presenter_class: nil,
         document_component: Blacklight::DocumentComponent,
+        # in Blacklight 9, the default show_tools_component configuration will
+        # be Blacklight::Document::ShowToolsComponent
+        show_tools_component: nil,
         sidebar_component: Blacklight::Document::SidebarComponent,
         display_type_field: nil,
         # the "field access" key to use to look up the document display fields

--- a/spec/components/blacklight/document/sidebar_component_spec.rb
+++ b/spec/components/blacklight/document/sidebar_component_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::Document::SidebarComponent, type: :component do
+  subject(:component) { described_class.new(presenter: document) }
+
+  let(:view_context) { controller.view_context }
+  let(:render) do
+    component.render_in(view_context)
+  end
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:document) { view_context.document_presenter(presented_document) }
+
+  let(:presented_document) { SolrDocument.new(id: 'x', title_tsim: 'Title') }
+
+  let(:blacklight_config) do
+    CatalogController.blacklight_config.deep_copy
+  end
+
+  let(:expected_html) { "<div class=\"expected-show_tools\">Expected Content</div>".html_safe }
+
+  before do
+    # Every call to view_context returns a different object. This ensures it stays stable.
+    allow(controller).to receive(:view_context).and_return(view_context)
+    allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
+  end
+
+  describe '#render_show_tools' do
+    # rubocop:disable RSpec/SubjectStub
+    before do
+      allow(component).to receive(:render).with(an_instance_of(Blacklight::Document::MoreLikeThisComponent)).and_return("")
+    end
+
+    context "without a configured ShowTools component" do
+      before do
+        allow(component).to receive(:render).with('show_tools', document: presented_document, silence_deprecation: false).and_return(expected_html)
+      end
+
+      it 'renders show_tools partial' do
+        expect(rendered).to have_selector 'div[@class="expected-show_tools"]'
+      end
+    end
+
+    context "with a configured ShowTools component" do
+      let(:show_tools_component) { Class.new(Blacklight::Document::ShowToolsComponent) }
+
+      before do
+        blacklight_config.show.show_tools_component = show_tools_component
+        allow(component).to receive(:render).with(an_instance_of(show_tools_component)).and_return(expected_html)
+      end
+
+      it 'renders configured show_tools component' do
+        expect(rendered).to have_selector 'div[@class="expected-show_tools"]'
+      end
+    end
+    # rubocop:enable RSpec/SubjectStub
+  end
+end


### PR DESCRIPTION
Deprecate the _show_tools partial in favor of a configurable component
fixes #3038

This PR also restores the helper method for inspecting whether a partial was overridden to minimize log noise when a Blacklight app is using default behaviors