### PR TITLE
Remove meta tag for IE 7 & 8

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -5,9 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <!-- Internet Explorer use the highest version available -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
     <title><%= render_page_title %></title>
     <script>
       document.querySelector('html').classList.remove('no-js');


### PR DESCRIPTION
These browsers are not supported.