### PR TITLE
Use updated capybara filter_block syntax

### DIFF
--- a/app/components/blacklight/response/pagination_component.html.erb
+++ b/app/components/blacklight/response/pagination_component.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :section, class: 'pagination',  **@html_attr do %>
+<%= content_tag :section, class: 'pagination',  **html_attr do %>
   <%= pagination %>
 <% end %>

--- a/app/components/blacklight/response/pagination_component.rb
+++ b/app/components/blacklight/response/pagination_component.rb
@@ -8,8 +8,12 @@ module Blacklight
       # @param [Hash] html html options for the pagination container
       def initialize(response:, html: {}, **pagination_args)
         @response = response
-        @html_attr = { aria: { label: t('views.pagination.aria.container_label') } }.merge(html)
+        @html = html
         @pagination_args = pagination_args
+      end
+
+      def html_attr
+        { aria: { label: t('views.pagination.aria.container_label') } }.merge(@html)
       end
 
       def pagination

--- a/lib/railties/blacklight.rake
+++ b/lib/railties/blacklight.rake
@@ -40,7 +40,7 @@ namespace :blacklight do
         exit 1
       end
     rescue => e
-      puts e.to_s
+      puts e
       exit 1
     end
 
@@ -70,7 +70,7 @@ namespace :blacklight do
         end
       rescue => e
         errors += 1
-        puts e.to_s
+        puts e
       end
 
       print " - search_results: "
@@ -92,7 +92,7 @@ namespace :blacklight do
         end
       rescue => e
         errors += 1
-        puts e.to_s
+        puts e
       end
 
       print " - fetch: "
@@ -112,7 +112,7 @@ namespace :blacklight do
         end
       rescue => e
         errors += 1
-        puts e.to_s
+        puts e
       end
 
       exit 1 if errors > 0

--- a/spec/presenters/blacklight/show_presenter_spec.rb
+++ b/spec/presenters/blacklight/show_presenter_spec.rb
@@ -50,10 +50,6 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
 
       MockDocument.use_extension(MockExtension)
 
-      def mock_document_app_helper_url *args
-        solr_document_url(*args)
-      end
-
       allow(request_context).to receive(:polymorphic_url) do |_, opts|
         "url.#{opts[:format]}"
       end
@@ -68,12 +64,10 @@ RSpec.describe Blacklight::ShowPresenter, api: true do
         tmp_value = Capybara.ignore_hidden_elements
         Capybara.ignore_hidden_elements = false
         document.export_formats.each_pair do |format, _spec|
-          expect(subject).to have_selector("link[href$='.#{format}']") do |matches|
-            expect(matches).to have(1).match
-            tag = matches[0]
-            expect(tag.attributes["rel"].value).to eq "alternate"
-            expect(tag.attributes["title"].value).to eq format.to_s
-            expect(tag.attributes["href"].value).to eq mock_document_app_helper_url(document, format: format)
+          expect(subject).to have_selector("link[href$='.#{format}']", count: 1) do |tag|
+            expect(tag["rel"]).to eq "alternate"
+            expect(tag["title"]).to eq format.to_s
+            expect(tag["href"]).to eq "url.#{format}"
           end
         end
         Capybara.ignore_hidden_elements = tmp_value


### PR DESCRIPTION
https://github.com/teamcapybara/capybara/issues/2616 changed how blocks are evaluated.  Thanks to @maxkadel for finding this change!

Also includes a fix for https://github.com/ViewComponent/view_component/pull/1666

closes #3043 