### PR TITLE
Allow in gemspec any 3.x view_component instead of stopping at 3.0.x

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results
   s.add_dependency "i18n", '>= 1.7.0' # added named parameters
   s.add_dependency "ostruct", '>= 0.3.2'
-  s.add_dependency "view_component", '>= 2.66', '< 3.1'
+  s.add_dependency "view_component", '>= 2.66', '< 4'
 
   s.add_development_dependency "rsolr", ">= 1.0.6", "< 3"  # Library for interacting with rSolr.
   s.add_development_dependency "rspec-rails", "~> 6.0"


### PR DESCRIPTION
The gemspec previously allowed anything from 2.66.x up to 3.0.x -- but did not allow past 3.0.x. view_component is now up to 3.3.0,

The spec on view_component was expanded up from just 2.x greater than 2.66  in commit 1b7d6c7aa from @barmintor.  This introduced locking to an upper bound of a `view_component` _minor_ version, 3.0.x, when before we had only been locking to major version, any 2.x greater than 2.66.  As `view_component` does semver, I suspect this was a mistake, and when opening up blacklight to 3.0.x, we meant to open it up to any future 3.x?

This does that.
