### PR TITLE
do not add nil query value clauses to json query (#3048)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-capybara
   - rubocop-rspec
   - rubocop-rails
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -176,12 +176,12 @@ RSpec/BeforeAfterAll:
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
   Exclude:
     - 'spec/features/alternate_controller_spec.rb'
 
 # Offense count: 13
-RSpec/Capybara/VisibilityMatcher:
+Capybara/VisibilityMatcher:
   Exclude:
     - 'spec/features/facets_spec.rb'
     - 'spec/features/search_filters_spec.rb'
@@ -211,10 +211,9 @@ RSpec/ExpectInHook:
 # Offense count: 5
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   Exclude:
     - 'spec/controllers/blacklight/catalog/component_configuration_spec.rb'
-    - 'spec/features/sitelinks_search_box.rb'
     - 'spec/models/blacklight/solr/search_builder_spec.rb'
     - 'spec/presenters/pipeline_spec.rb'
     - 'spec/presenters/thumbnail_presenter_spec.rb'

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -83,8 +83,9 @@ module Blacklight::Solr
     end
 
     def add_search_field_with_json_query_parameters(solr_parameters)
-      bool_query = search_field.clause_params.transform_values { |v| v.merge(query: search_state.query_param) }
+      return unless search_state.query_param
 
+      bool_query = search_field.clause_params.transform_values { |v| v.merge(query: search_state.query_param) }
       solr_parameters.append_boolean_query(:must, bool_query)
     end
 

--- a/spec/models/blacklight/solr/search_builder_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_spec.rb
@@ -406,6 +406,14 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, api: true do
       it 'includes addtional clause parameters for the field' do
         expect(subject.dig(:json, :query, :bool, :must, 0, :edismax)).to include another: :parameter
       end
+
+      context 'with an empty search' do
+        let(:subject_search_params) { { commit: "search", search_field: "subject", action: "index", controller: "catalog", rows: "10", q: nil } }
+
+        it 'does not add nil query value clauses to json query' do
+          expect(subject).not_to have_key :json
+        end
+      end
     end
 
     describe "sorting" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ Capybara.register_driver :headless_chrome do |app|
     opts.args << '--no-sandbox'
     opts.args << '--window-size=1280,1696'
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: capabilities)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: capabilities)
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
fixes #3048 
This refines the built-in advanced search features and better supports modern Solr