### PR TITLE
Accommodate variable libxml2 HTML parsing behavior in component spec

### DIFF
--- a/app/builders/blacklight/action_builder.rb
+++ b/app/builders/blacklight/action_builder.rb
@@ -20,7 +20,7 @@ module Blacklight
 
     # Define a simple action handler for the tool as long as the method
     # doesn't already exist or the `:define_method` option is not `false`
-    def build
+    def build # rubocop:disable Metrics/MethodLength
       return if skip?
 
       callback = opts.fetch(:callback, nil).inspect

--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -47,7 +47,7 @@ module Blacklight
 
           component_class.sidecar_files(extensions).each_with_object([]) do |path, memo|
             pieces = File.basename(path).split(".")
-            app_path = "#{Rails.root}/#{path.slice(path.index(component_class.view_component_path)..-1)}"
+            app_path = Rails.root.join(path.slice(path.index(component_class.view_component_path)..-1).to_s).to_s
 
             memo << {
               path: File.exist?(app_path) ? app_path : path,

--- a/spec/components/blacklight/facet_item_pivot_component_spec.rb
+++ b/spec/components/blacklight/facet_item_pivot_component_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
 
   it 'links to the facet and shows the number of hits' do
     expect(rendered).to have_selector 'li'
-    expect(rendered).to have_link 'x', href: '/catalog?f%5Bz%5D=x'
+    expect(rendered).to have_link 'x', href: nokogiri_mediated_href(facet_item.href)
     expect(rendered).to have_selector '.facet-count', text: '10'
   end
 
   it 'has the facet hierarchy' do
     expect(rendered).to have_selector 'li ul.pivot-facet'
-    expect(rendered).to have_link 'x:1', href: /f%5Bz%5D%5B%5D=x:1/
+    expect(rendered).to have_link 'x:1', href: nokogiri_mediated_href(facet_item.facet_item_presenters.first.href)
   end
 
   context 'with a selected facet' do

--- a/spec/support/view_component_test_helpers.rb
+++ b/spec/support/view_component_test_helpers.rb
@@ -18,4 +18,18 @@ module ViewComponentTestHelpers
 
     ApplicationController.new.extend(Rails.application.routes.url_helpers)
   end
+
+  # Nokogiri 1.15.0 upgrades the vendored libxml2 from v2.10.4 to v2.11.3
+  # libxml2 v2.11.0 introduces a change to parsing HTML href attributes
+  # in nokogiri < 1.15, brackets in href attributes are escaped:
+  # - <a class="facet-select" rel="nofollow" href="/catalog?f%5Bz%5D%5B%5D=x:1">x:1</a>
+  # in nokogiri >= 1.15, brackets in href attributes are not escaped:
+  # - <a class="facet-select" rel="nofollow" href="/catalog?f[z][]=x:1">x:1</a>
+  # until we can spec a minimum nokogiri version of 1.15.0, we need to see how
+  # the installed version parsed the html
+  def nokogiri_mediated_href(href)
+    start = "<a href=\"".length
+    stop = -"\"></a>".length
+    Nokogiri::HTML.fragment("<a href=\"#{href}\"></a>").to_s[start...stop]
+  end
 end


### PR DESCRIPTION
Accommodate variable libxml2 HTML parsing behavior in spec/components/blacklight/facet_item_pivot_component_spec.rb
fixes #3058