### PR TITLE
Address rubocop and rspec failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -197,6 +197,9 @@ Security/IoMethods: # new in 1.22
   Enabled: true
 Style/ArgumentsForwarding: # new in 1.1
   Enabled: true
+  Exclude:
+    # This cop includes some checks specific to Ruby 3.2
+    - 'lib/blacklight/solr/response/group_response.rb'
 Style/CollectionCompact: # new in 1.2
   Enabled: true
 Style/DocumentDynamicEvalDefinition: # new in 1.1

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency 'axe-core-rspec'
   s.add_development_dependency "capybara", '~> 3'
-  s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'engine_cart', '~> 2.1'
   s.add_development_dependency "equivalent-xml"

--- a/spec/models/blacklight/configurable_spec.rb
+++ b/spec/models/blacklight/configurable_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Blacklight::Configurable", api: true do
       instance.blacklight_config.bar << "123"
       expect(instance.blacklight_config).not_to eq klass.blacklight_config
       expect(klass.blacklight_config.foo).to eq "bar"
-      expect(instance.blacklight_config.foo).to eq  "bar"
+      expect(instance.blacklight_config.foo).to eq "bar"
       expect(klass.blacklight_config.bar).not_to include("123")
       expect(instance.blacklight_config.bar).to include("asd", "123")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ EngineCart.load_application!
 require 'rspec/rails'
 require 'rspec/collection_matchers'
 require 'capybara/rails'
-require 'webdrivers'
 require 'selenium-webdriver'
 require 'equivalent-xml'
 require 'axe-rspec'


### PR DESCRIPTION
closes #3062 

Also addresses [this issue with the webdrivers gem](https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1648154088), by simply removing the gem and relying on selenium-webdriver for this.