### PR TITLE
Use a separate requestHandler for JSON DSL queries

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,6 +43,14 @@ jobs:
         include:
         - ruby: '3.2.0'
           rails_version: '7.0.4'
+        - ruby: '3.2.0'
+          rails_version: '7.0.4'
+          solr_version: '9.3.0'
+          additional_name: 'Solr 9.3.0'
+        - ruby: '3.2.0'
+          rails_version: '7.0.4'
+          solr_version: '8.11.2'
+          additional_name: 'Solr 8.11.2'
         - ruby: '3.1'
           rails_version: '7.0.4'
         - ruby: '3.1'
@@ -64,6 +72,7 @@ jobs:
           additional_name: '/ API'
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
+      SOLR_VERSION: ${{ matrix.solr_version || 'latest' }}
       VIEW_COMPONENT_VERSION: ${{ matrix.view_component_version }}
       BOOTSTRAP_VERSION: ${{ matrix.bootstrap_version }}
       BLACKLIGHT_API_TEST: ${{ matrix.api }}

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -87,6 +87,10 @@ module Blacklight
       # @since v5.2.0
       # @return [String] The url path (relative to the solr base url) to use when requesting only a single document
       property :document_solr_path, default: 'get'
+      # @!attribute json_solr_path
+      # @since v7.34.0
+      # @return [String] The url path (relative to the solr base url) to use when using Solr's JSON Query DSL (as with the advanced search)
+      property :json_solr_path, default: 'advanced'
       # @!attribute document_unique_id_param
       # @since v5.2.0
       # @return [Symbol] The solr query parameter used for sending the unique identifiers for one or more documents

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -21,7 +21,7 @@ module Blacklight::Solr
     # Execute a search query against solr
     # @param [Hash] params solr query parameters
     def search params = {}
-      send_and_receive blacklight_config.solr_path, params.reverse_merge(qt: blacklight_config.qt)
+      send_and_receive search_path(params), params.reverse_merge(qt: blacklight_config.qt)
     end
 
     # @param [Hash] request_params
@@ -78,7 +78,7 @@ module Blacklight::Solr
     # @return [Hash]
     # @!visibility private
     def build_solr_request(solr_params)
-      if solr_params[:json].present?
+      if uses_json_query_dsl?(solr_params)
         {
           data: { params: solr_params.to_hash.except(:json) }.merge(solr_params[:json]).to_json,
           method: :post,
@@ -121,6 +121,18 @@ module Blacklight::Solr
       else
         []
       end
+    end
+
+    # @return [String]
+    def search_path(solr_params)
+      return blacklight_config.json_solr_path if blacklight_config.json_solr_path && uses_json_query_dsl?(solr_params)
+
+      blacklight_config.solr_path
+    end
+
+    # @return [Boolean]
+    def uses_json_query_dsl?(solr_params)
+      solr_params[:json].present?
     end
   end
 end

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -38,6 +38,7 @@ class <%= controller_name.classify %>Controller < ApplicationController
     # solr path which will be added to solr base url before the other solr params.
     #config.solr_path = 'select'
     #config.document_solr_path = 'get'
+    #config.json_solr_path = 'advanced'
 
     # items to show per page, each number in the array represent another option to choose from.
     #config.per_page = [10,20,50,100]

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -100,6 +100,75 @@
     </arr>
   </requestHandler>
 
+  <requestHandler name="/advanced" class="solr.SearchHandler">
+    <!-- a lucene request handler for using the JSON Query DSL,
+         specifically for advanced search.
+         Using a separate requestHandler is a workaround to
+         https://issues.apache.org/jira/browse/SOLR-16916, although
+         it could be desirable for other reasons as well.
+      -->
+     <lst name="defaults">
+       <str name="defType">lucene</str>
+       <str name="echoParams">explicit</str>
+        <str name="df">title_tsim</str>
+        <str name="qf">
+          id
+          full_title_tsim
+          short_title_tsim
+          alternative_title_tsim
+          active_fedora_model_ssi
+          title_tsim
+          author_tsim
+          subject_tsim
+          all_text_timv
+        </str>
+        <str name="pf">
+          all_text_timv^10
+        </str>
+
+       <str name="author_qf">
+          author_tsim
+       </str>
+       <str name="author_pf">
+       </str>
+       <str name="title_qf">
+          title_tsim
+          full_title_tsim
+          short_title_tsim
+          alternative_title_tsim
+       </str>
+       <str name="title_pf">
+       </str>
+       <str name="subject_qf">
+          subject_tsim
+       </str>
+       <str name="subject_pf">
+       </str>
+
+       <str name="fl">
+         *,
+         score
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.limit">10</str>
+       <str name="facet.field">active_fedora_model_ssi</str>
+       <str name="facet.field">subject_ssim</str>
+
+       <str name="spellcheck">true</str>
+       <str name="spellcheck.dictionary">default</str>
+       <str name="spellcheck.onlyMorePopular">true</str>
+       <str name="spellcheck.extendedResults">true</str>
+       <str name="spellcheck.collate">false</str>
+       <str name="spellcheck.count">5</str>
+
+     </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
   <requestHandler name="permissions" class="solr.SearchHandler" >
     <lst name="defaults">
       <str name="facet">off</str>

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -5,7 +5,14 @@ require 'spec_helper'
 RSpec.describe "Blacklight Advanced Search Form" do
   describe "advanced search form" do
     before do
+      CatalogController.blacklight_config.search_fields['title']['clause_params'] = {
+        edismax: {}
+      }
       visit '/catalog/advanced?hypothetical_existing_param=true&q=ignore+this+existing+query'
+    end
+
+    after do
+      CatalogController.blacklight_config.search_fields['title'].delete('clause_params')
     end
 
     it "has field and facet blocks" do
@@ -45,6 +52,7 @@ RSpec.describe "Blacklight Advanced Search Form" do
       click_on 'advanced-search-submit'
       expect(page).to have_content 'Remove constraint Title: Medicine'
       expect(page).to have_content 'Strong Medicine speaks'
+      expect(page).to have_selector('article.document', count: 1)
     end
   end
 

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -5,14 +5,25 @@ require 'spec_helper'
 RSpec.describe "Blacklight Advanced Search Form" do
   describe "advanced search form" do
     before do
-      CatalogController.blacklight_config.search_fields['title']['clause_params'] = {
+      CatalogController.blacklight_config.search_fields['all_fields']['clause_params'] = {
         edismax: {}
+      }
+      CatalogController.blacklight_config.search_fields['author']['clause_params'] = {
+        edismax: { qf: '${author_qf}' }
+      }
+      CatalogController.blacklight_config.search_fields['title']['clause_params'] = {
+        edismax: { qf: '${title_qf}' }
+      }
+      CatalogController.blacklight_config.search_fields['subject']['clause_params'] = {
+        edismax: { qf: '${subject_qf}' }
       }
       visit '/catalog/advanced?hypothetical_existing_param=true&q=ignore+this+existing+query'
     end
 
     after do
-      CatalogController.blacklight_config.search_fields['title'].delete(:clause_params)
+      %w[all_fields author title subject].each do |field|
+        CatalogController.blacklight_config.search_fields[field].delete(:clause_params)
+      end
     end
 
     it "has field and facet blocks" do
@@ -53,6 +64,42 @@ RSpec.describe "Blacklight Advanced Search Form" do
       expect(page).to have_content 'Remove constraint Title: Medicine'
       expect(page).to have_content 'Strong Medicine speaks'
       expect(page).to have_selector('article.document', count: 1)
+    end
+
+    it 'can limit to facets' do
+      fill_in 'Subject', with: 'Women'
+      click_on 'Language'
+      check 'Urdu 3'
+      click_on 'advanced-search-submit'
+      expect(page).to have_content 'Pākistānī ʻaurat dorāhe par'
+      expect(page).not_to have_content 'Ajikto kŭrŏk chŏrŏk sasimnikka : and 아직도　그럭　저럭　사십니까'
+      expect(page).to have_selector('article.document', count: 1)
+    end
+
+    it 'handles boolean queries' do
+      fill_in 'All Fields', with: 'history NOT strong'
+      click_on 'advanced-search-submit'
+      expect(page).to have_content('Ci an zhou bian')
+      expect(page).not_to have_content('Strong Medicine speaks')
+      expect(page).to have_selector('article.document', count: 10)
+    end
+
+    it 'handles queries in multiple fields with the ALL operator' do
+      fill_in 'All Fields', with: 'history'
+      fill_in 'Author', with: 'hearth'
+      click_on 'advanced-search-submit'
+      expect(page).to have_content('Strong Medicine speaks')
+      expect(page).to have_selector('article.document', count: 1)
+    end
+
+    it 'handles queries in multiple fields with the ANY operator' do
+      select 'any', from: 'op'
+      fill_in 'All Fields', with: 'history'
+      fill_in 'Subject', with: 'women'
+      click_on 'advanced-search-submit'
+      expect(page).to have_content('Ci an zhou bian')
+      expect(page).to have_content('Pākistānī ʻaurat dorāhe par')
+      expect(page).to have_selector('article.document', count: 10)
     end
   end
 

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Blacklight Advanced Search Form" do
     end
 
     after do
-      CatalogController.blacklight_config.search_fields['title'].delete('clause_params')
+      CatalogController.blacklight_config.search_fields['title'].delete(:clause_params)
     end
 
     it "has field and facet blocks" do

--- a/spec/models/blacklight/solr/repository_spec.rb
+++ b/spec/models/blacklight/solr/repository_spec.rb
@@ -153,6 +153,33 @@ RSpec.describe Blacklight::Solr::Repository, api: true do
         expect(JSON.parse(actual_params[:data]).with_indifferent_access).to include(query: { bool: {} })
         expect(actual_params[:headers]).to include({ 'Content-Type' => 'application/json' })
       end
+
+      context "without a json solr path configured" do
+        before do
+          blacklight_config.json_solr_path = nil
+        end
+
+        it "uses the default solr path" do
+          blacklight_config.solr_path = 'xyz'
+          allow(subject.connection).to receive(:send_and_receive) do |path|
+            expect(path).to eq 'xyz'
+          end
+          subject.search(input_params)
+        end
+      end
+
+      context "with a json solr path configured" do
+        before do
+          blacklight_config.json_solr_path = 'my-great-json'
+        end
+
+        it "uses the configured json_solr_path" do
+          allow(subject.connection).to receive(:send_and_receive) do |path|
+            expect(path).to eq 'my-great-json'
+          end
+          subject.search(input_params)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #3042 , particularly for Solr 9, by routing JSON DSL queries to a separate requestHandler.

A [separate requestHandler is the recommended approach](https://lists.apache.org/thread/2j9jjk8zmnrbr739r249vo4p1f95gqsl), at least for versions of solr without a fix to [SOLR-16916](https://issues.apache.org/jira/browse/SOLR-16916). 

With this PR and [the configuration steps from the wiki](https://github.com/projectblacklight/blacklight/wiki/Advanced-Search#configuration), it's possible to use the advanced search feature in development, even on Solr 9.