### PR TITLE
#form_with doesn't support ARIA properties

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: @url, local: true, method: @method, class: @classes.join(' '), scope: @prefix, role: 'search', aria: { label: scoped_t('submit') }, **@form_options do |f| %>
+<%= form_with url: @url, local: true, method: @method, class: @classes.join(' '), scope: @prefix, role: 'search', **@form_options do |f| %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
   <% if search_fields.length > 1 %>
     <%= f.label :search_field, scoped_t('search_field.label'), class: 'sr-only visually-hidden' %>


### PR DESCRIPTION
We were only using it for a (questionable?) aria label that duplicated the role anyway 🤷‍♂️