### PR TITLE
Avoid double-escape in blacklight:assets generator with revert of shell escaping f491661

### DIFF
--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'shellwords'
-
 module Blacklight
   class AssetsGenerator < Rails::Generators::Base
     class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 5.1'), desc: "Set the generated app's bootstrap version"
 
     def run_asset_pipeline_specific_generator
-      generated_options = "--bootstrap-version='#{Shellwords.escape(options[:'bootstrap-version'])}'" if options[:'bootstrap-version']
+      generated_options = "--bootstrap-version='#{options[:'bootstrap-version']}'" if options[:'bootstrap-version']
 
       generator = if defined?(Propshaft)
                     'blacklight:assets:propshaft'

--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'shellwords'
-
 module Blacklight
   class Install < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
@@ -37,7 +35,7 @@ module Blacklight
     # Call external generator in AssetsGenerator, so we can
     # leave that callable seperately too.
     def copy_public_assets
-      generated_options = "--bootstrap-version='#{Shellwords.escape(options[:'bootstrap-version'])}'" if options[:'bootstrap-version']
+      generated_options = "--bootstrap-version='#{options[:'bootstrap-version']}'" if options[:'bootstrap-version']
 
       generate "blacklight:assets", generated_options unless options[:'skip-assets']
     end


### PR DESCRIPTION
Commit f491661 adds some `Shellwords.escape` calls to arguments to `generate` method, to call a the blacklight assets install generator from inside the main assets generator. 

https://github.com/projectblacklight/blacklight/commit/f491661ad0a7e105c80e66a7625725c38072dff8#diff-c9171dc6ee82f6b53296c26439fe17f5f3fb38ac0db9aeedab740679dcbc1989R10

The commit message says this was necessary:

> So that a string like `~> 4.0` can be passed without bash transforming `~` to `$HOME`"

But this is actually causing "double escaping" or "extraneous slashes" issues in some cases. 

I ran into this problem in CI failures in blacklight_range_limit., such as you can see here:

https://github.com/projectblacklight/blacklight_range_limit/actions/runs/5834406502/job/15823853679#step:5:1088

After some effort, I am able to reproduce simply, especially in older Rails (that are still supported by Blacklight 8). 

* If I create a Rails 6.1 app with `rails _6.1.7.1_ new rails_6171_app`, and then manually add `gem "blacklight"` to the gemfile, and `bundle install` to get Blacklight 8.0.1.
   *  then run `rails g blacklight:install` from within the app
   * I get this error:
     *     [!] There was an error parsing `Gemfile`: Illformed requirement ["\\~\\>\\ 5.1"]. Bundler cannot continue.

            #  from /Users/jrochkind/code/rails_6171_bl_test/Gemfile:69
             #  -------------------------------------------
             #  gem 'rsolr', '>= 1.0', '< 3'
             >  gem 'bootstrap', '\~\>\ 5.1'
             #  ------------------------------------------- 

  * You can see it's adding extra slashes -- same problem in the `blacklight_range_limit` CI above. 

  * With this branch of Blacklight in this PR, the problem does not occur, the install goes well. 

* If I do the same thing with a later Rails 7.0.8.... I do not get an error, _however_, the Gemfile still looks wrong. 
  * if I look in the Gemfile in the Rails 7.0.8 app after running `rails g blacklight:install`, this is in there:
     * `gem "bootstrap", "\~\>\ 5.1"`
   * That is definitely extra slashes! I don't know why it doesn't seem to produce an error in Rails 7.0.8, but it is still not right, those slashes shouldn't be there. 


I am _not_ able to reproduce the problem that @jcoyne said he was fixing in f491661

In **this branch** (with escaping removed), In MacOS bash 5.1:  I  **am** able to run: eg `rails g blacklight:install --bootstrap-version="~> 5.2"`. Nothing gets interpreted as "home" alias.  `gem "bootstrap", "~> 5.2"` is added to Gemfile. 

So this is a revert of f491661 -- I am not able to reproduce the problem it was meant to solve, and reverting it resolves other problems I am able to reproduce. 

@jcoyne , thoughts?  Do you know what shell/version you were experiencing the problem in, which f491661 fixed? If it were necessary to fix a problem in some other shell, but causes a problem in Bash 5... that's a challenge! 