### PR TITLE
Fix stying of sort label on advanced search form

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -40,8 +40,8 @@
 
   <% if sort_fields_select %>
     <div class="form-group row mb-4">
-      <%= content_tag :h2, t('blacklight.advanced_search.form.sort_label'), id: 'advanced-search-sort-label', class: 'col-md-3 col-form-label text-md-right' %>
-      <div class="col">
+      <%= content_tag :h2, t('blacklight.advanced_search.form.sort_label'), id: 'advanced-search-sort-label', class: 'col-md-3 text-md-right' %>
+      <div class="col-md-9">
         <%= sort_fields_select %>
       </div>
     </div>


### PR DESCRIPTION
`.col-form-label` is only suitable for `<label>` tags as it imposes `font-size: inherit;` This is not what we'd want out of an `<h2>`