### PR TITLE
Fix advanced search "Start over" button

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -50,7 +50,7 @@
   <div class="form-group row">
     <div class="submit-buttons col-md-9 offset-md-3">
       <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
-      <%= button_tag t('blacklight.advanced_search.form.start_over_html'), type: 'reset', class: 'btn btn-link advanced-search-start-over' %>
+      <%= link_to t('blacklight.advanced_search.form.start_over_html'), @advanced_search_path, :class =>"btn btn-link advanced-search-start-over" %>
     </div>
   </div>
 <% end %>

--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -50,7 +50,7 @@
   <div class="form-group row">
     <div class="submit-buttons col-md-9 offset-md-3">
       <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
-      <%= link_to t('blacklight.advanced_search.form.start_over_html'), @advanced_search_path, :class =>"btn btn-link advanced-search-start-over" %>
+      <%= link_to t('blacklight.advanced_search.form.start_over_html'), request.path, :class =>"btn btn-link advanced-search-start-over" %>
     </div>
   </div>
 <% end %>

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -118,5 +118,11 @@ RSpec.describe "Blacklight Advanced Search Form" do
       expect(page.current_url).to match(/bread/)
       expect(page.current_url).not_to match(/medicine/)
     end
+
+    it "clears the prepopulated fields when the Start Over button is pressed" do
+      expect(page).to have_field 'Title', with: 'medicine'
+      click_on 'Start over'
+      expect(page).not_to have_field 'Title', with: 'medicine'
+    end
   end
 end


### PR DESCRIPTION
Addressed https://github.com/projectblacklight/blacklight/issues/3091

* Use a link instead of a button for the "Start over" action on the advanced search. This allowst the "Start over" button to clear prepopulated input fields rather than just values that have been input by the user since their current visit to the page.
* Add test to verify that the form gets reset