### PR TITLE
Allow configuration of the kaminari pagination options

### DIFF
--- a/app/components/blacklight/response/pagination_component.rb
+++ b/app/components/blacklight/response/pagination_component.rb
@@ -17,7 +17,12 @@ module Blacklight
       end
 
       def pagination
-        helpers.paginate @response, **Blacklight::Engine.config.blacklight.default_pagination_options, **@pagination_args
+        args = configured_options.merge(@pagination_args).compact
+        helpers.paginate @response, **args
+      end
+
+      def configured_options
+        controller.blacklight_config.index.pagination_options
       end
     end
   end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -175,7 +175,9 @@ module Blacklight
         # component class used to render the search bar
         search_bar_component: nil,
         # component class used to render the header above the documents
-        search_header_component: Blacklight::SearchHeaderComponent
+        search_header_component: Blacklight::SearchHeaderComponent,
+        # pagination parameters to pass to kaminari
+        pagination_options: Blacklight::Engine.config.blacklight.default_pagination_options.dup
       )
 
       # @!attribute show

--- a/spec/components/blacklight/response/pagination_component_spec.rb
+++ b/spec/components/blacklight/response/pagination_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::Response::PaginationComponent, type: :component do
+  let(:render) do
+    with_request_url '/catalog?q=foo' do
+      render_inline(instance)
+    end
+  end
+
+  let(:instance) { described_class.new(response: response) }
+
+  context 'when there are many results' do
+    let(:response) { instance_double(Blacklight::Solr::Response, total: 10, current_page: 5, limit_value: 10_000, total_pages: 100) }
+
+    context 'with default config' do
+      before { render }
+
+      it "has links to deep pages" do
+        expect(page).not_to have_link '98'
+        expect(page).to have_link '99'
+        expect(page).to have_link '100'
+        expect(page).not_to have_link '101'
+      end
+    end
+
+    context 'when a different configuration that removes deep links is passed as a parameter' do
+      let(:instance) { described_class.new(response: response, left: 5, right: 0, outer_window: nil) }
+
+      before { render }
+
+      it "does not link to deep pages" do
+        expect(page).to have_link '1'
+        expect(page).not_to have_link '100'
+      end
+    end
+
+    context 'when a different configuration that removes deep links is configured in the controller' do
+      before do
+        allow(controller.blacklight_config.index)
+          .to receive(:pagination_options)
+          .and_return(theme: 'blacklight', left: 5, right: 0)
+        render
+      end
+
+      it "does not link to deep pages" do
+        expect(page).to have_link '1'
+        expect(page).not_to have_link '100'
+      end
+    end
+  end
+end

--- a/spec/views/catalog/_paginate_compact.html.erb_spec.rb
+++ b/spec/views/catalog/_paginate_compact.html.erb_spec.rb
@@ -2,9 +2,11 @@
 
 RSpec.describe "catalog/_paginate_compact.html.erb" do
   let(:user) { User.new { |u| u.save(validate: false) } }
+  let(:blacklight_config) { Blacklight::Configuration.new }
 
   before do
     controller.request.path_parameters[:action] = 'index'
+    allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
   end
 
   it "renders paginatable arrays" do


### PR DESCRIPTION
This enables us to turn off deep pagination via the configuration or by passing arguments to the component