### PR TITLE
Remove duplicate paginate class

### DIFF
--- a/app/components/blacklight/response/pagination_component.html.erb
+++ b/app/components/blacklight/response/pagination_component.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :section, class: 'pagination',  **html_attr do %>
+<%= content_tag :section, class: 'paginate-section',  **html_attr do %>
   <%= pagination %>
 <% end %>


### PR DESCRIPTION
So that one can customize the style easily.   There was a `paginate` class on the section and on the contained `ul`.

Fixes #3095