### PR TITLE
[backport] Use bs5 form-select class in advanced search

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -33,7 +33,7 @@ module Blacklight
       options = sort_fields.values.map { |field_config| [helpers.sort_field_label(field_config.key), field_config.key] }
       return unless options.any?
 
-      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-control sort-select w-auto", aria: { labelledby: 'advanced-search-sort-label' })
+      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-select custom-select sort-select w-auto", aria: { labelledby: 'advanced-search-sort-label' })
     end
 
     private


### PR DESCRIPTION
This supports bootstrap 4 & 5