### PR TITLE
Build and support on Rails 7.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,6 +41,8 @@ jobs:
         additional_engine_cart_rails_options: ['']
         additional_name: ['']
         include:
+        - ruby: '3.2.2'
+          rails_version: '7.1.1'
         - ruby: '3.2.0'
           rails_version: '7.0.4'
         - ruby: '3.2.0'

--- a/app/models/concerns/blacklight/document/active_model_shim.rb
+++ b/app/models/concerns/blacklight/document/active_model_shim.rb
@@ -29,6 +29,16 @@ module Blacklight::Document
       def find id
         repository.find(id).documents.first
       end
+
+      # In Rails 7.1+, needs this method
+      def composite_primary_key?
+        false
+      end
+
+      # In Rails 7.1+, needs this method
+      def has_query_constraints?
+        false
+      end
     end
 
     ##

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -3,7 +3,12 @@
 class Search < ApplicationRecord
   belongs_to :user, optional: true
 
-  serialize :query_params, Blacklight::SearchParamsYamlCoder
+  if ::Rails.version.to_f >= 7.1
+    # non-deprecated coder: keyword arg for Rails 7.1+
+    serialize :query_params, coder: Blacklight::SearchParamsYamlCoder
+  else
+    serialize :query_params, Blacklight::SearchParamsYamlCoder
+  end
 
   # A Search instance is considered a saved search if it has a user_id.
   def saved?

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -6,6 +6,18 @@ module Blacklight
   class Engine < Rails::Engine
     engine_name "blacklight"
 
+    config.before_configuration do
+      # see https://github.com/fxn/zeitwerk#for_gem
+      # Blacklight puts a generator into LOCAL APP lib/generators, so tell
+      # zeitwerk to ignore the whole directory? If we're using a recent
+      # enough version of Rails to have zeitwerk config
+      #
+      # See: https://github.com/cbeer/engine_cart/issues/117
+      if Rails.try(:autoloaders).try(:main).respond_to?(:ignore)
+        Rails.autoloaders.main.ignore(Rails.root.join('lib/generators'))
+      end
+    end
+
     config.after_initialize do
       Blacklight::Configuration.initialize_default_configuration
     end

--- a/spec/components/blacklight/facet_component_spec.rb
+++ b/spec/components/blacklight/facet_component_spec.rb
@@ -45,8 +45,18 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
       Blacklight::Configuration::FacetField.new(key: 'field', partial: 'catalog/facet_partial').normalize!
     end
 
+    # Not sure why we need to re-implement rspec's stub_template, but
+    # we already were, and need a Rails 7.1+ safe alternate too
+    # https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8
+    # https://github.com/rspec/rspec-rails/issues/2696
     before do
-      controller.view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for('catalog/_facet_partial.html.erb' => 'facet partial'))
+      replace_hash = { 'catalog/_facet_partial.html.erb' => 'facet partial' }
+
+      if ::Rails.version.to_f >= 7.1
+        controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+      else
+        controller.view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+      end
     end
 
     it 'renders the partial' do

--- a/spec/components/blacklight/search_context/server_applied_params_component_spec.rb
+++ b/spec/components/blacklight/search_context/server_applied_params_component_spec.rb
@@ -10,7 +10,17 @@ RSpec.describe Blacklight::SearchContext::ServerAppliedParamsComponent, type: :c
   let(:view_context) { controller.view_context }
 
   before do
-    view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for('application/_start_over.html.erb' => 'start over'))
+    # Not sure why we need to re-implement rspec's stub_template, but
+    # we already were, and need a Rails 7.1+ safe alternate too
+    # https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8
+    # https://github.com/rspec/rspec-rails/issues/2696
+    replace_hash = { 'application/_start_over.html.erb' => 'start over' }
+    if ::Rails.version.to_f >= 7.1
+      controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+    else
+      view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+    end
+
     allow(view_context).to receive(:current_search_session).and_return current_search_session
     allow(view_context).to receive(:link_back_to_catalog).with(any_args)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -118,3 +118,31 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+# RSpec's stub_template method needs a differnet implementation for Rails 7.1, that
+# isn't yet in an rspec-rails release.
+#
+# First rspec-rails tried this:
+#   https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8
+#
+# But it was subject to this problem:
+#   https://github.com/rspec/rspec-rails/issues/2696
+#
+# Below implementation appears to work for our purposes here, so we will patch it in
+# if we are on Rails 7.1+, and  not yet rspec-rails 6.1 which we expect to have it.
+
+if ::Rails.version.to_f >= 7.1 && Gem.loaded_specs["rspec-rails"].version.release < Gem::Version.new('6.1')
+
+  module RSpec
+    module Rails
+      module ViewExampleGroup
+        module ExampleMethods
+          def stub_template(hash)
+            controller.prepend_view_path(StubResolverCache.resolver_for(hash))
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
gemspec already (mistakenly?) allows Rails 7.1, even though build does not pass on Rails 7.1, including for at least one non-test-harness reason. 

This is passing for me locally on Rails 7.1.1, let's see how it does in CI. 

There were actually only a couple fairly simple issues (although not always simple to fix!). 

1. The "ActiveModelShim" needed a couple more boilerplate methods in order to pass tests. I don't really understand what's going on here, especially the `has_query_constraints?` method. (and things like primary keys suggest to me that what we're testing isn't really an **ActiveModel** shim but an **ActiveRecord** one?).  Not sure what this is all used for, but some simple changes make tests green. 

2. RSpec-rails does not currently have a `stub_template` method that works in Rails 7.1.  There is an [unreleased one in rspec-rails main](https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8) that tries, but suffers from problems with stubs persisting to subsequent tests. I found an implementation that appears to work though, and does let our tests pass. 
   * I patched that implementation in to rspec-rails, in our local `spec_helper.rb`.  The patch expires with a subsequent rspec-rails release.  Conditional implementation on Rails version, like rspec-rails was trying. 
      *  I think it could be a while until rspec-rails has a release, and is acceptable to use a local patch here, that _only effects test harness_ and not production code, in order to get a blacklight release that supports rails 7.1. 
   * The codebase has three other places where we copy-paste-modify rspec-rails `stub_template` implementation to work in non-view-specs.  I modified these too, each still inline one-off, to use new implementation that works. 


3. Was getting a deprecation warning on `serialize :query_params, Blacklight::SearchParamsYamlCoder` telling me it should be `serialize :query_params, coder: Blacklight::SearchParamsYamlCoder`, so went ahead and fixed that with a conditional for Rails version too. 