### PR TITLE
Backport of Rails 7.1 support to release-7.x

### DIFF
--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -42,7 +42,11 @@ module Blacklight::Bookmarks
     @bookmarks = token_or_current_or_guest_user.bookmarks
     bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
     @response, deprecated_document_list = search_service.fetch(bookmark_ids)
-    @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_document_list, "The @document_list instance variable is now deprecated and will be removed in Blacklight 8.0")
+    @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+      deprecated_document_list,
+      "The @document_list instance variable is now deprecated",
+      ActiveSupport::Deprecation.new("8.0", "blacklight")
+    )
 
     respond_to do |format|
       format.html {}

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -34,7 +34,11 @@ module Blacklight::Catalog
   def index
     (@response, deprecated_document_list) = search_service.search_results
 
-    @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_document_list, 'The @document_list instance variable is deprecated; use @response.documents instead.')
+    @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+      deprecated_document_list,
+      'The @document_list instance variable is deprecated; use @response.documents instead.',
+      ActiveSupport::Deprecation.new("8.0", "blacklight")
+    )
 
     respond_to do |format|
       format.html { store_preferred_view }
@@ -53,7 +57,11 @@ module Blacklight::Catalog
   # to add responses for formats other than html or json see _Blacklight::Document::Export_
   def show
     deprecated_response, @document = search_service.fetch(params[:id])
-    @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, 'The @response instance variable is deprecated; use @document.response instead.')
+    @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+      deprecated_response,
+      'The @response instance variable is deprecated; use @document.response instead.',
+      ActiveSupport::Deprecation.new("8.0", "blacklight")
+    )
 
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }

--- a/app/models/concerns/blacklight/document/active_model_shim.rb
+++ b/app/models/concerns/blacklight/document/active_model_shim.rb
@@ -28,6 +28,16 @@ module Blacklight::Document
       def find id
         repository.find(id).documents.first
       end
+
+      # In Rails 7.1+, needs this method
+      def composite_primary_key?
+        false
+      end
+
+      # In Rails 7.1+, needs this method
+      def has_query_constraints?
+        false
+      end
     end
 
     ##

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -4,7 +4,12 @@ class Search < ApplicationRecord
   belongs_to :user, optional: true
 
   # use a backwards-compatible serializer until the Rails API stabilizes and we can evaluate for major-revision compatibility
-  serialize :query_params, Blacklight::SearchParamsYamlCoder
+  if ::Rails.version.to_f >= 7.1
+    # non-deprecated coder: keyword arg for Rails 7.1+
+    serialize :query_params, coder: Blacklight::SearchParamsYamlCoder
+  else
+    serialize :query_params, Blacklight::SearchParamsYamlCoder
+  end
 
   # A Search instance is considered a saved search if it has a user_id.
   def saved?

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency "rails", '>= 5.1', '< 7.1'
+  s.add_dependency "rails", '>= 5.1', '< 7.2'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashdiff'
 
   s.add_development_dependency "rsolr", ">= 1.0.6", "< 3"  # Library for interacting with rSolr.
-  s.add_development_dependency "rspec-rails", "~> 5.0"
+  s.add_development_dependency "rspec-rails", ">= 5.0" # some versions tested need >= 6.0
   s.add_development_dependency "rspec-collection_matchers", ">= 1.0"
   s.add_development_dependency 'axe-core-rspec'
   s.add_development_dependency "capybara", '~> 3'

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -6,6 +6,17 @@ module Blacklight
   class Engine < Rails::Engine
     engine_name "blacklight"
 
+    config.before_configuration do
+      # see https://github.com/fxn/zeitwerk#for_gem
+      # Blacklight puts a generator into LOCAL APP lib/generators, so tell
+      # zeitwerk to ignore the whole directory? If we're using zeitwerk
+      #
+      # https://github.com/cbeer/engine_cart/issues/117
+      if Rails.try(:autoloaders).try(:main).respond_to?(:ignore)
+        Rails.autoloaders.main.ignore(Rails.root.join('lib/generators'))
+      end
+    end
+
     # BlacklightHelper is needed by all helpers, so we inject it
     # into action view base here.
     initializer 'blacklight.helpers' do

--- a/spec/components/blacklight/facet_component_spec.rb
+++ b/spec/components/blacklight/facet_component_spec.rb
@@ -51,7 +51,17 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
     end
 
     before do
-      controller.view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for('catalog/_facet_partial.html.erb' => 'facet partial'))
+      # Not sure why we need to re-implement rspec's stub_template, but
+      # we already were, and need a Rails 7.1+ safe alternate too
+      # https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8
+      # https://github.com/rspec/rspec-rails/issues/2696
+
+      replace_hash = { 'catalog/_facet_partial.html.erb' => 'facet partial' }
+      if ::Rails.version.to_f >= 7.1
+        controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+      else
+        controller.view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+      end
     end
 
     it 'renders the partial' do

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -331,12 +331,17 @@ RSpec.describe BlacklightHelper do
         blacklight_config.view.gallery(template: '/my/partial')
       end
 
-      def stub_template(hash)
-        view.view_paths.unshift(ActionView::FixtureResolver.new(hash))
-      end
-
       it 'renders that template' do
-        stub_template 'my/_partial.html.erb' => 'some content'
+        # Not sure why we need to re-implement rspec's stub_template, but
+        # we already were, and need a Rails 7.1+ safe alternate too
+        # https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8
+        # https://github.com/rspec/rspec-rails/issues/2696
+        replace_hash = { 'my/_partial.html.erb' => 'some content' }
+        if ::Rails.version.to_f >= 7.1
+          controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+        else
+          view.view_paths.unshift(ActionView::FixtureResolver.new(replace_hash))
+        end
 
         response = helper.render_document_index_with_view :gallery, [obj1, obj1]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,3 +117,31 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+# RSpec's stub_template method needs a differnet implementation for Rails 7.1, that
+# isn't yet in an rspec-rails release.
+#
+# First rspec-rails tried this:
+#   https://github.com/rspec/rspec-rails/commit/4d65bea0619955acb15023b9c3f57a3a53183da8
+#
+# But it was subject to this problem:
+#   https://github.com/rspec/rspec-rails/issues/2696
+#
+# Below implementation appears to work for our purposes here, so we will patch it in
+# if we are on Rails 7.1+, and  not yet rspec-rails 6.1 which we expect to have it.
+
+if ::Rails.version.to_f >= 7.1 && Gem.loaded_specs["rspec-rails"].version.release < Gem::Version.new('6.1')
+
+  module RSpec
+    module Rails
+      module ViewExampleGroup
+        module ExampleMethods
+          def stub_template(hash)
+            controller.prepend_view_path(StubResolverCache.resolver_for(hash))
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Backport of #3099 

Remain in "draft" until #3099 is merged to main, to make sure what we're backporting is what actually got committed. 