### PR TITLE
Wrap template generator code in an after_bundle block

### DIFF
--- a/template.demo.rb
+++ b/template.demo.rb
@@ -2,12 +2,12 @@
 
 gem 'blacklight', '>= 7.0'
 
-run "bundle install"
+after_bundle do
+  # run the blacklight install generator
+  options = ENV.fetch("BLACKLIGHT_INSTALL_OPTIONS", '--devise --marc')
 
-# run the blacklight install generator
-options = ENV.fetch("BLACKLIGHT_INSTALL_OPTIONS", '--devise --marc')
+  generate 'blacklight:install', options
 
-generate 'blacklight:install', options
-
-# run the database migrations
-rake "db:migrate"
+  # run the database migrations
+  rake "db:migrate"
+end


### PR DESCRIPTION
Thanks to @jcoyne for finding this solution! I am just writing it up.

We were encountering the issues recorded here: https://github.com/projectblacklight/blacklight/issues/3031, where `config/importmap.rb` was not being created when installing Blacklight from the template as described in the Quickstart guide "easy way" (`generate blacklight:install` itself worked correctly, but when invoked from the template, the rails install process was not executing in full).

Wrapping the code in this `after_bundle` block fixes the issue. See the commit message from Rails here: https://github.com/rails/rails/commit/83e69c22e9ebfb3585c0fb6d536353f4f43fd483#diff-4521b0667f0d930737cfa0a1ced7dd5c00a15909503123cf3752a6c6ebfcca04

