### PR TITLE
Fix allowing imports of individual source files/modules from blacklight-frontend npm package

### DIFF
--- a/app/javascript/blacklight/bookmark_toggle.js
+++ b/app/javascript/blacklight/bookmark_toggle.js
@@ -1,4 +1,4 @@
-import CheckboxSubmit from 'blacklight/checkbox_submit'
+import CheckboxSubmit from './checkbox_submit.js'
 
 const BookmarkToggle = (e) => {
   if (e.target.matches('[data-checkboxsubmit-target="checkbox"]')) {

--- a/app/javascript/blacklight/index.js
+++ b/app/javascript/blacklight/index.js
@@ -1,8 +1,13 @@
-import BookmarkToggle from 'blacklight/bookmark_toggle'
-import ButtonFocus from 'blacklight/button_focus'
-import Modal from 'blacklight/modal'
-import SearchContext from 'blacklight/search_context'
-import Core from 'blacklight/core'
+// ALL imports in this dir, including in files imported, should be RELATIVE
+// paths to keep things working in the various ways these files get used, at
+// both compile time and npm package run time.
+
+import BookmarkToggle from './bookmark_toggle.js'
+import ButtonFocus from './button_focus.js'
+import Modal from './modal.js'
+import SearchContext from './search_context.js'
+import Core from './core.js'
+
 
 export default {
   BookmarkToggle,

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -52,7 +52,7 @@
   can be a turbo-stream that defines some HTML fragementsand where on the page to put them:
   https://turbo.hotwired.dev/handbook/streams
 */
-import ModalForm from 'blacklight/modalForm'
+import ModalForm from './modalForm.js'
 
 const Modal = (() => {
   const modal = {}


### PR DESCRIPTION
Closes #3050 

All imports should be relative, so individual files can still be imported from blacklight-frontend npm packagerted from blacklight-frontend npm package

It turns out the solution to #3050 was as simple as this!  Thank you for letting me rubber-duck it at the blacklight committers meeting, @jcoyne, @tpendragon @hackartisan @tampakis 

I have built the NPM package locally, and verified this appears to work in WIP BL8 upgrade, to let me selective import like I did before (with the somewhat odd source path that remians the same from BL7):

    import 'blacklight-frontend/app/javascript/blacklight/core';

Or instead you can now also do like (that i don't think you could in BL7 but now can):

    import Blacklight from 'blacklight-frontend/app/javascript/blacklight/core'
    import Modal from 'blacklight-frontend/app/javascript/blacklight/modal';

I am not an expert in JS or in what BL is trying to do with JS; I don't _think_ this will cause any problems for existing uses, but perhaps @jcoyne or @cbeer want to review?

Not sure how to encourage/instruct people to keep using only relative paths in these source files, since tests don't currently test for anything relevant here, but better than nothing. 
