### PR TITLE
[backport] Use the new method for getting secret_key_base

### DIFF
--- a/app/controllers/concerns/blacklight/token_based_user.rb
+++ b/app/controllers/concerns/blacklight/token_based_user.rb
@@ -48,18 +48,7 @@ module Blacklight::TokenBasedUser
   end
 
   def secret_key_generator
-    @secret_key_generator ||= begin
-      app = Rails.application
-
-      secret_key_base = if app.respond_to?(:credentials)
-                          # Rails 5.2+
-                          app.credentials.secret_key_base
-                        else
-                          # Rails <= 5.1
-                          app.secrets.secret_key_base
-                        end
-      ActiveSupport::KeyGenerator.new(secret_key_base)
-    end
+    @secret_key_generator ||= ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base)
   end
 
   def message_encryptor


### PR DESCRIPTION
See https://blog.saeloun.com/2023/08/11/rails-7-1-store-secret-key-base-in-rails-config/

In Rails 7.1 the existing way causes a problem because `Rails.application.credentials.secret_key_base` returns `nil`