### PR TITLE
[backport] Add role=region and aria-controls to the FacetFieldComponent

### DIFF
--- a/app/components/blacklight/facet_field_component.html.erb
+++ b/app/components/blacklight/facet_field_component.html.erb
@@ -8,11 +8,12 @@
       data-target="#<%= @facet_field.html_id %>"
       data-bs-target="#<%= @facet_field.html_id %>"
       aria-expanded="<%= @facet_field.collapsed? ? 'false' : 'true' %>"
+      arial-controls="<%= @facet_field.html_id %>"
     >
       <%= label %>
     </button>
   </h3>
-  <div id="<%= @facet_field.html_id %>" aria-labelledby="<%= @facet_field.html_id %>-header" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
+  <div id="<%= @facet_field.html_id %>" role="region" aria-labelledby="<%= @facet_field.html_id %>-header" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
     <div class="card-body">
       <%= body %>
 


### PR DESCRIPTION
This follows the example of https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/ for setting the aria properties for an accordion type widget