### PR TITLE
[backport] Stop skipping action-cable temporarily

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake ci
       env:
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test'
   test_bootstrap5:
     runs-on: ubuntu-latest
     strategy:
@@ -68,7 +68,7 @@ jobs:
       run: bundle exec rake ci
       env:
         BOOTSTRAP_VERSION: '~> 5.0'
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test'
   test_rails6_0:
     runs-on: ubuntu-latest
     strategy:
@@ -151,7 +151,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake ci
       env:
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test'
   api_test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This works around a bug in turbo-rails 2.0.2 https://github.com/hotwired/turbo-rails/issues/573 We should be able to revert this if that issue is resolved in a future release

Backport of #3146