### PR TITLE
Generate <button> for flash alert dismissal

### DIFF
--- a/app/components/blacklight/system/flash_message_component.html.erb
+++ b/app/components/blacklight/system/flash_message_component.html.erb
@@ -1,6 +1,6 @@
 <div class="alert <%= @classes %>">
   <%= message %>
-  <%= tag.button_tag button_contents, type: "button", class: "btn-close",
+  <%= tag.button button_contents, type: "button", class: "btn-close",
                      data: { dismiss: "alert", bs_dismiss: "alert" },
                      aria: { label: "Close" } %>
 </div>


### PR DESCRIPTION
Currently we are generating `<button-tag>` which is not valid.
This is causing styling difficulties downstream.
