### PR TITLE
Fix the facet group toggle button accessible name

### DIFF
--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -15,7 +15,6 @@
       aria: {
         controls: @panel_id,
         expanded: 'false',
-        label: t('blacklight.search.facets.group.toggle'),
       } do %>
       <span data-show-label><%= t('blacklight.search.facets.group.open') %></span>
       <span data-hide-label><%= t('blacklight.search.facets.group.close') %></span>

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -101,7 +101,6 @@ ar:
         group:
           close: إخفاء الأوجه
           open: عرض الأوجه
-          toggle: المزيد »
         missing: "[غير موجود]"
         more_html: المزيد <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:

--- a/config/locales/blacklight.ca.yml
+++ b/config/locales/blacklight.ca.yml
@@ -190,8 +190,6 @@ ca:
         pivot:
           show: Mostrar
           hide: Amagar
-        group:
-          toggle: 'altres »'
       group:
         more: 'més »'
       filters:

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -91,7 +91,6 @@ de:
         group:
           close: Facetten ausblenden
           open: Facetten zeigen
-          toggle: mehr »
         missing:
         - fehlt
         more_html: mehr <span class="sr-only visually-hidden">%{field_name}</span> »

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -191,7 +191,6 @@ en:
           show: Show
           hide: Hide
         group:
-          toggle: Toggle facets
           open: Show facets
           close: Hide facets
       group:

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -91,7 +91,6 @@ es:
         group:
           close: Ocultar facetas
           open: Mostrar facetas
-          toggle: más »
         missing: "[Falta]"
         more_html: más <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -91,7 +91,6 @@ fr:
         group:
           close: Masquer les facettes
           open: Afficher les facettes
-          toggle: plus »
         missing: "[manquante]"
         more_html: plus <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -89,7 +89,6 @@ hu:
         group:
           close: Fazetek elrejtése
           open: Szempontok megjelenítése
-          toggle: több »
         missing: "[Hiányzó]"
         more_html: több <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -91,7 +91,6 @@ it:
         group:
           close: Nascondi sfaccettature
           open: Mostra sfaccettature
-          toggle: altri »
         missing:
         - Mancante
         more_html: altri <span class="sr-only visually-hidden">%{field_name}</span> »

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -89,7 +89,6 @@ nl:
         group:
           close: Verberg facetten
           open: Toon facetten
-          toggle: meer »
         missing: "[Ontbrekend]"
         more_html: Meer <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -89,7 +89,6 @@ pt-BR:
         group:
           close: Ocultar facetas
           open: Mostrar facetas
-          toggle: mais »
         missing:
         - Ausência
         more_html: mais <span class="sr-only visually-hidden">%{field_name}</span> »

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -89,7 +89,6 @@ sq:
         group:
           close: Fshih aspektet
           open: Trego aspektet
-          toggle: më shumë »
         missing: "[Mungon]"
         more_html: Më shumë <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -89,7 +89,6 @@ zh:
         group:
           close: 隐藏方面
           open: 显示方面
-          toggle: 更多 »
         missing: "[未找到]"
         more_html: 更多 <span class="sr-only visually-hidden">%{field_name}</span> »
         pivot:


### PR DESCRIPTION
At smaller sizes when the facet group toggle button is displayed, we're getting a [Label in Name (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name) violation because the button has been given a fixed aria-label, but the visible text varies based on state (e.g., "Toggle Facets" versus "Show Facets"/"Hide Facets").

If we stop explicitly setting the toggle aria-label I believe it will use the visible text for accessibility purposes (it makes Siteimprove happy).
