### PR TITLE
Hide search bar component #autocomplete-popup element in html

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -23,7 +23,7 @@
     <% if autocomplete_path.present? %>
       <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
         <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
-        <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>"></ul>
+        <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
       </auto-complete>
     <% else %>
       <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>


### PR DESCRIPTION
Hello,

While using Arclight, my team noticed that the Blacklight search bar component's `#autocomplete-popup` element is visible for a fraction of a second before the `@github/auto-complete-element` js kicks in to hide it (via `hidden` attribute).  Once you do a search with auto-complete enabled, the `hidden` attribute is removed, and then it's added again when it's time for the `#autocomplete-popup` box to close.

I'm submitting this PR to propose adding the `hidden` attribute to the `#autocomplete-popup` html by default, to avoid the flash of unstyled content.

You can see the issue I'm describing if you go to the Arclight demo page (https://arclight-demo.projectblacklight.org) and click your browser refresh button a bunch of times in a row.  An empty white box appears below the "Search..." placeholder text in the input.  I'll also attach a video below:

https://github.com/projectblacklight/blacklight/assets/1017323/7ce7f4a3-f575-44a1-94cb-b4250c9d57b4

Best,
Eric