### PR TITLE
Revert "all imports should be relative, so individual files can still…

### DIFF
--- a/app/javascript/blacklight/bookmark_toggle.js
+++ b/app/javascript/blacklight/bookmark_toggle.js
@@ -1,4 +1,4 @@
-import CheckboxSubmit from './checkbox_submit.js'
+import CheckboxSubmit from 'blacklight/checkbox_submit'
 
 const BookmarkToggle = (e) => {
   if (e.target.matches('[data-checkboxsubmit-target="checkbox"]')) {

--- a/app/javascript/blacklight/index.js
+++ b/app/javascript/blacklight/index.js
@@ -1,13 +1,8 @@
-// ALL imports in this dir, including in files imported, should be RELATIVE
-// paths to keep things working in the various ways these files get used, at
-// both compile time and npm package run time.
-
-import BookmarkToggle from './bookmark_toggle.js'
-import ButtonFocus from './button_focus.js'
-import Modal from './modal.js'
-import SearchContext from './search_context.js'
-import Core from './core.js'
-
+import BookmarkToggle from 'blacklight/bookmark_toggle'
+import ButtonFocus from 'blacklight/button_focus'
+import Modal from 'blacklight/modal'
+import SearchContext from 'blacklight/search_context'
+import Core from 'blacklight/core'
 
 export default {
   BookmarkToggle,

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -52,7 +52,7 @@
   can be a turbo-stream that defines some HTML fragementsand where on the page to put them:
   https://turbo.hotwired.dev/handbook/streams
 */
-import ModalForm from './modalForm.js'
+import ModalForm from 'blacklight/modalForm'
 
 const Modal = (() => {
   const modal = {}


### PR DESCRIPTION
… be imported from blacklight-frontend npm package"

This reverts commit d8c0ec4435db34b85f83a2e4799bc15b0469ef27.

This change broke the javascript imports in all our Blacklight apps.
<img width="808" alt="Screenshot 2024-06-03 at 3 21 02 PM" src="https://github.com/projectblacklight/blacklight/assets/458247/f9230ba1-f463-416b-998f-0f0c9eb5193c">
