### PR TITLE
Test components return html-safe content

### DIFF
--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
         def initialize(**); end
 
         def call
-          'embed'
+          'embed'.html_safe
         end
       end)
 
@@ -167,7 +167,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
         Class.new(Blacklight::DocumentMetadataComponent) do
           # Override component rendering with our own value
           def call
-            'blah'
+            'blah'.html_safe
           end
         end
       end
@@ -187,7 +187,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
         Class.new(Blacklight::DocumentTitleComponent) do
           # Override component rendering with our own value
           def call
-            'Titleriffic'
+            'Titleriffic'.html_safe
           end
         end
       end

--- a/spec/components/blacklight/facet_component_spec.rb
+++ b/spec/components/blacklight/facet_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
         end
 
         def call
-          'Custom facet rendering'
+          'Custom facet rendering'.html_safe
         end
       end
     end

--- a/spec/components/blacklight/response/view_type_component_spec.rb
+++ b/spec/components/blacklight/response/view_type_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Blacklight::Response::ViewTypeComponent, type: :component do
     Class.new(Blacklight::Icons::IconComponent) do
       # Override component rendering with our own value
       def call
-        'blah'
+        'blah'.html_safe
       end
     end
   end

--- a/spec/views/catalog/_document.html.erb_spec.rb
+++ b/spec/views/catalog/_document.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "catalog/_document" do
       Class.new(Blacklight::DocumentComponent) do
         # Override component rendering with our own value
         def call
-          'blah'
+          'blah'.html_safe
         end
       end
     end

--- a/spec/views/catalog/index.atom.builder_spec.rb
+++ b/spec/views/catalog/index.atom.builder_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "catalog/index" do
       before do
         my_template = Class.new(ViewComponent::Base) do
           def call
-            'whatever content'
+            'whatever content'.html_safe
           end
 
           def self.name


### PR DESCRIPTION
This avoids warnings from view_component about the content not being html-safe
Fixes #3168 