### PR TITLE
Set navbar-search search element to display:contents so layout is not impacted

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -24,6 +24,10 @@
 .navbar-search {
   z-index: 1;
 
+  search {
+    display: contents;
+  }
+
   .search-field {
     // This prevents the widget from being squished so the text overflows
     min-width: 7em;


### PR DESCRIPTION
The addition of the search element around the search form in the navbar in this commit https://github.com/projectblacklight/blacklight/commit/c9031f2385b2aa12b88b4bd80d4bbbab6ffda8d8 impacted the layout. Setting the search element's display to `contents` preserves the original layout.

Before:
<img width="774" alt="Screenshot 2024-06-06 at 9 46 33 AM" src="https://github.com/projectblacklight/blacklight/assets/458247/4904772e-8cc4-4d53-b40c-6ef5f22c9365">

After:
<img width="815" alt="Screenshot 2024-06-06 at 9 58 37 AM" src="https://github.com/projectblacklight/blacklight/assets/458247/9974c9fe-ff90-45f0-b82d-2d1f7c0c4b7f">
