### PR TITLE
Require rubocop that we use

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-capybara
   - rubocop-rspec
+  - rubocop-rspec_rails
   - rubocop-rails
 
 inherit_from:
@@ -11,24 +12,22 @@ AllCops:
   TargetRubyVersion: 2.7
   TargetRailsVersion: 6.1
   Exclude:
-  - "lib/generators/blacklight/templates/**/*"
-  - "blacklight.gemspec"
-
+    - "lib/generators/blacklight/templates/**/*"
+    - "blacklight.gemspec"
 
 Lint/UselessAssignment:
   Exclude:
     - app/presenters/blacklight/facet_item_pivot_presenter.rb # https://github.com/rubocop/rubocop/issues/11124
 
-
 # engine_cart block includes conditional, not duplication
 Bundler/DuplicatedGem:
   Exclude:
-  - 'Gemfile'
+    - "Gemfile"
 
 # engine_cart block is following default Rails order
 Bundler/OrderedGems:
   Exclude:
-  - 'Gemfile'
+    - "Gemfile"
 
 Layout/IndentationConsistency:
   EnforcedStyle: normal
@@ -51,13 +50,13 @@ Metrics/ClassLength:
 Layout/LineLength:
   Max: 200
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Metrics/ModuleLength:
   Exclude:
-    - 'app/controllers/concerns/blacklight/catalog.rb'
-    - 'lib/blacklight/solr/search_builder_behavior.rb'
-    - 'lib/blacklight/solr/response/facets.rb'
+    - "app/controllers/concerns/blacklight/catalog.rb"
+    - "lib/blacklight/solr/search_builder_behavior.rb"
+    - "lib/blacklight/solr/response/facets.rb"
 
 Metrics/AbcSize:
   Exclude:
@@ -90,7 +89,7 @@ Style/AccessModifierDeclarations:
 
 Style/MissingRespondToMissing:
   Exclude:
-  - 'lib/blacklight/nested_open_struct_with_hash_access.rb'
+    - "lib/blacklight/nested_open_struct_with_hash_access.rb"
 
 Style/StringLiterals:
   Enabled: false
@@ -122,7 +121,7 @@ Style/ExponentialNotation:
 Style/HashEachMethods:
   Enabled: true
   Exclude:
-    - 'spec/services/blacklight/search_service_spec.rb'
+    - "spec/services/blacklight/search_service_spec.rb"
 
 Style/HashTransformKeys:
   Enabled: true
@@ -200,7 +199,7 @@ Style/ArgumentsForwarding: # new in 1.1
   Enabled: true
   Exclude:
     # This cop includes some checks specific to Ruby 3.2
-    - 'lib/blacklight/solr/response/group_response.rb'
+    - "lib/blacklight/solr/response/group_response.rb"
 Style/CollectionCompact: # new in 1.2
   Enabled: true
 Style/DocumentDynamicEvalDefinition: # new in 1.1
@@ -241,18 +240,18 @@ Style/SwapValues: # new in 1.1
   Enabled: true
 RSpec/DescribeClass:
   Exclude:
-    - 'spec/lib/tasks/blacklight_task_spec.rb'
-    - 'spec/features/**/*'
-    - 'spec/requests/**/*'
-    - 'spec/routing/**/*'
-    - 'spec/views/**/*'
+    - "spec/lib/tasks/blacklight_task_spec.rb"
+    - "spec/features/**/*"
+    - "spec/requests/**/*"
+    - "spec/routing/**/*"
+    - "spec/views/**/*"
 RSpec/ExcessiveDocstringSpacing: # new in 2.5
   Enabled: true
 RSpec/IdenticalEqualityAssertion: # new in 2.4
   Enabled: true
 RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
+RSpecRails/AvoidSetupHook: # new in 2.4
   Enabled: true
 Rails/ActiveRecordCallbacksOrder: # new in 2.7
   Enabled: true
@@ -320,7 +319,7 @@ RSpec/BeEq: # new in 2.9.0
   Enabled: true
 RSpec/BeNil: # new in 2.9.0
   Enabled: true
-RSpec/FactoryBot/SyntaxMethods: # new in 2.7
+FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
 Rails/ActionControllerTestCase: # new in 2.14
   Enabled: true


### PR DESCRIPTION
This avoids a warning telling us to make these changes