### PR TITLE
Use bootstrap classes on elements rather than depending on Sass

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_form.scss
+++ b/app/assets/stylesheets/blacklight/_search_form.scss
@@ -1,6 +1,6 @@
 // bootstrap does flex-grow: 1 by default which makes the
 // text input roughly the same size as the select in many cases
-.input-group>.search-q {
+.input-group > .search-q {
   flex-grow: 4;
 }
 
@@ -10,20 +10,15 @@
   flex-grow: 4;
   padding: 0;
   position: relative;
-  
+
   .search-q {
     border: 0;
     height: 100%;
     width: 100%;
   }
-  
-  ul {
-    @extend .dropdown-menu;
-    display: block;
 
-    li {
-      @extend .dropdown-item;
-    }
+  ul {
+    display: block;
   }
 }
 

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -24,7 +24,7 @@
       <% if autocomplete_path.present? %>
         <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
           <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
-          <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
+          <ul id="autocomplete-popup" class="dropdown-menu" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
         </auto-complete>
       <% else %>
         <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>

--- a/app/views/catalog/suggest.html.erb
+++ b/app/views/catalog/suggest.html.erb
@@ -1,3 +1,3 @@
 <% @suggestions.each do |suggestion| %>
-  <li role="option"><span><%= suggestion['term'] %></span></li>
+  <li role="option" class="dropdown-item"><span><%= suggestion['term'] %></span></li>
 <% end %>

--- a/spec/requests/load_suggestions_spec.rb
+++ b/spec/requests/load_suggestions_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'GET /catalog/suggest' do
   it 'returns suggestions' do
     get '/catalog/suggest?q=new'
     expect(response.body).to eq <<-RESULT
-  <li role="option"><span>new jersey</span></li>
-  <li role="option"><span>new jersey bridgeton biography</span></li>
-  <li role="option"><span>new jersey bridgeton history</span></li>
-  <li role="option"><span>new york</span></li>
-  <li role="option"><span>nuwākshūṭ</span></li>
+  <li role="option" class="dropdown-item"><span>new jersey</span></li>
+  <li role="option" class="dropdown-item"><span>new jersey bridgeton biography</span></li>
+  <li role="option" class="dropdown-item"><span>new jersey bridgeton history</span></li>
+  <li role="option" class="dropdown-item"><span>new york</span></li>
+  <li role="option" class="dropdown-item"><span>nuwākshūṭ</span></li>
     RESULT
   end
 end


### PR DESCRIPTION
This will allow us to have a blacklight build that does not require the user to install Sass