### PR TITLE
Fix skip link styling

### DIFF
--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -9,7 +9,8 @@
   }
 }
 
-.navbar-logo {  /* The main logo image for the Blacklight instance */
+.navbar-logo {
+  /* The main logo image for the Blacklight instance */
   @if $logo-image {
     background: transparent $logo-image no-repeat top left;
     background-size: $logo-width $logo-height;
@@ -37,31 +38,5 @@
     @extend .col-md-12;
     @extend .col-lg-8;
     padding-left: 0;
-  }
-}
-
-#skip-link {
-  position: absolute;
-  top: 5px;
-  left: 10px;
-  z-index: 1;
-
-  .element-invisible {
-    position: absolute !important;
-    clip: rect(1px, 1px, 1px, 1px);
-    overflow: hidden;
-    height: 1px;
-  }
-
-  .element-invisible.element-focusable:active,
-  .element-invisible.element-focusable:focus {
-    position: static !important;
-    clip: auto;
-    overflow: visible;
-    height: auto;
-  }
-
-  a:focus {
-    background-color: $white;
   }
 }

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for(:skip_links) do -%>
-    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'd-inline-flex p-2 m-1', data: { turbolinks: 'false' } %>
 <% end %>
 
 <% content_for(:container_header) do -%>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -28,10 +28,12 @@
     <%= content_for(:head) %>
   </head>
   <body class="<%= render_body_class %>">
-    <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
-      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
-      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
-      <%= content_for(:skip_links) %>
+    <nav id="skip-link" role="navigation" class="visually-hidden-focusable sr-only sr-only-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
+      <div class="container-xl">
+        <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'd-inline-flex p-2 m-1', data: { turbolinks: 'false' } %>
+        <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'd-inline-flex p-2 m-1', data: { turbolinks: 'false' } %>
+        <%= content_for(:skip_links) %>
+      </div>
     </nav>
     <%= render partial: 'shared/header_navbar' %>
 


### PR DESCRIPTION
This makes it a big more generic and relies on bootstrap provided styles
After:
<img width="1390" alt="Screenshot 2024-06-10 at 12 04 11 PM" src="https://github.com/projectblacklight/blacklight/assets/92044/17ee9fee-5a1e-42d8-a8d9-d68f9e31c699">

Before:
<img width="1397" alt="Screenshot 2024-06-10 at 12 07 31 PM" src="https://github.com/projectblacklight/blacklight/assets/92044/d574c668-5dbd-4f9e-9838-b542255e7f2a">
