### PR TITLE
Avoid deprecated class .text-muted

### DIFF
--- a/app/assets/stylesheets/blacklight/_balanced_list.scss
+++ b/app/assets/stylesheets/blacklight/_balanced_list.scss
@@ -1,7 +1,7 @@
 .dl-invert {
   dt {
     font-weight: normal;
-    color: $field_name_color;
+    color: var(--bl-field-name-color);
     @media (max-width: breakpoint-min(md)) {
       text-align: left;
     }

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -148,9 +148,9 @@
   }
 
   .remove {
-    color: $text-muted;
+    color: var(--bl-facet-remove-color);
     font-weight: bold;
-    padding-left: $spacer * .5;
+    padding-left: $spacer * 0.5;
     text-decoration: none;
 
     &:hover {

--- a/app/assets/stylesheets/blacklight/_search_history.scss
+++ b/app/assets/stylesheets/blacklight/_search_history.scss
@@ -1,8 +1,9 @@
 /* Search History */
 .search-history {
+  --bl-history-filter-name-color: var(--bs-secondary-color);
 
   td {
-    padding: $spacer
+    padding: $spacer;
   }
 
   .constraints-container {
@@ -15,7 +16,7 @@
     text-indent: -1 * map-get($spacers, 3);
   }
 
-  .filter-name, .filter-separator {
-    @extend .text-muted;
+  .filter-name {
+    color: var(--bl-history-filter-name-color);
   }
 }

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -4,9 +4,6 @@ $logo-image: image_url('blacklight/logo.png') !default;
 $logo-width: 150px !default;
 $logo-height: 50px !default;
 
-/* label (field names) */
-$field_name_color: $text-muted !default;
-
 // the default bootstrap font-family list includes "Segoe UI Emoji", which, on windows
 // renders our remove icon as an emoji-sized x instead of what we see on all other platforms...
 // so, for now (until we replace it with an SVG icon or something), we get to override bootstrap:
@@ -15,3 +12,13 @@ $remove-icon-font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helveti
 $facet-active-border: $success !default;
 $facet-active-bg: $success !default;
 $facet-active-item-color: $success !default;
+
+/* for compatability with BS < 5.3  */
+$body-secondary-color: rgba($body-color, 0.75) !default;
+
+:root {
+  --bs-secondary-color: #{$body-secondary-color}; /* for compatability with BS < 5.3  */
+
+  --bl-field-name-color: var(--bs-secondary-color);
+  --bl-facet-remove-color: var(--bs-secondary-color);
+}


### PR DESCRIPTION
It is deprecated in Bootstrap 5.3. https://getbootstrap.com/docs/5.3/migration/\#utilities-2