### PR TITLE
Explicitly set margin classes

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -1,5 +1,4 @@
 .constraints-container {
-  @extend .mb-2;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem 0.25rem;

--- a/app/assets/stylesheets/blacklight/_search_history.scss
+++ b/app/assets/stylesheets/blacklight/_search_history.scss
@@ -6,10 +6,6 @@
     padding: $spacer;
   }
 
-  .constraints-container {
-    @extend .mb-0;
-  }
-
   .constraint {
     @extend .px-4;
     display: block;

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -20,7 +20,7 @@ module Blacklight
     def initialize(search_state:,
                    tag: :div,
                    render_headers: true,
-                   id: 'appliedParams', classes: 'clearfix constraints-container',
+                   id: 'appliedParams', classes: 'clearfix constraints-container mb-2',
                    query_constraint_component: Blacklight::ConstraintLayoutComponent,
                    query_constraint_component_options: {},
                    facet_constraint_component: Blacklight::ConstraintComponent,

--- a/app/components/blacklight/search_context/server_applied_params_component.html.erb
+++ b/app/components/blacklight/search_context/server_applied_params_component.html.erb
@@ -1,4 +1,4 @@
-<div id="appliedParams" class="clearfix constraints-container">
+<div id="appliedParams" class="clearfix constraints-container mb-2">
   <%= render 'start_over' %>
   <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>
 </div>

--- a/app/components/blacklight/search_context/server_applied_params_component.rb
+++ b/app/components/blacklight/search_context/server_applied_params_component.rb
@@ -2,6 +2,7 @@
 
 module Blacklight
   module SearchContext
+    # This is displayed on the show page when the user has a search session.
     class ServerAppliedParamsComponent < Blacklight::Component
       delegate :current_search_session, :link_back_to_catalog, to: :helpers
 

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -114,6 +114,6 @@ module Blacklight::UrlHelperBehavior
   # Use in e.g. the search history display, where we want something more like text instead of the normal constraints
   def link_to_previous_search(params)
     search_state = controller.search_state_class.new(params, blacklight_config, self)
-    link_to(render(Blacklight::ConstraintsComponent.for_search_history(search_state: search_state)), search_action_path(params))
+    link_to(render(Blacklight::ConstraintsComponent.for_search_history(search_state: search_state, classes: 'clearfix constraints-container mb-0')), search_action_path(params))
   end
 end


### PR DESCRIPTION
This makes it easier to customize the style and doesn't require sass

Ref #3206