### PR TITLE
Apply bootstrap style to title with classes instead of sass extend

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_results.scss
+++ b/app/assets/stylesheets/blacklight/_search_results.scss
@@ -6,10 +6,6 @@
     margin-top: $spacer;
     padding-top: $spacer;
 
-    .document-title-heading {
-      @extend h5;
-    }
-
     .document-main-section {
       flex-grow: 1;
     }

--- a/app/components/blacklight/document_title_component.rb
+++ b/app/components/blacklight/document_title_component.rb
@@ -7,7 +7,8 @@ module Blacklight
     renders_many :actions
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(title = nil, document: nil, presenter: nil, as: :h3, counter: nil, classes: 'index_title document-title-heading col', link_to_document: true, document_component: nil, actions: true)
+    def initialize(title = nil, document: nil, presenter: nil, as: :h3, counter: nil, classes: 'index_title document-title-heading col h5', link_to_document: true, document_component: nil,
+                   actions: true)
       raise ArgumentError, 'missing keyword: :document or :presenter' if presenter.nil? && document.nil?
 
       @title = title


### PR DESCRIPTION
This will allow us to run blacklight without sass

Ref #3206