### PR TITLE
Remove obsolete mixin for hyphens-auto

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -159,18 +159,12 @@
     }
   }
 
-  @mixin hyphens-auto {
-    overflow-wrap: break-word;
-    -webkit-hyphens: auto;
-    -o-hyphens: auto;
-    hyphens: auto;
-  }
-
   .facet-label {
+    hyphens: auto;
+    overflow-wrap: break-word;
+    padding-left: 15px;
     padding-right: 1em;
     text-indent: -15px;
-    padding-left: 15px;
-    @include hyphens-auto;
   }
 
   .facet-count {


### PR DESCRIPTION
hyphens: auto is now supported on all browsers without prefixes. https://caniuse.com/mdn-css_properties_hyphens_auto