### PR TITLE
Explicitly pass classes on the search widgets

### DIFF
--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -1,9 +1,5 @@
 .search-widgets {
   display: flex;
-
-  > * {
-    @extend .mx-1;
-  }
 }
 
 .sort-pagination,

--- a/app/components/blacklight/response/sort_component.html.erb
+++ b/app/components/blacklight/response/sort_component.html.erb
@@ -2,5 +2,6 @@
       param: @param,
       choices: @choices,
       id: @id,
+      classes: @classes,
       search_state: @search_state,
       selected: @selected)) %>

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -4,6 +4,7 @@
     param: :per_page,
     choices: per_page_options_for_select,
     id: 'per_page-dropdown',
+    classes: ['mx-1'],
     search_state: search_state,
     selected: current_per_page,
     interpolation: :count)) %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,6 +1,7 @@
 <% if show_sort_and_per_page? %>
   <%= render(Blacklight::Response::SortComponent.new(
     choices: active_sort_fields.map { |key, config| [sort_field_label(config.key), key] },
+    classes: ['mx-1'],
     search_state: search_state,
     selected: current_sort_field&.key)) %>
 <% end %>


### PR DESCRIPTION
This makes it possible to easily override the spacing in downstream applications