### PR TITLE
Explicitly set the margin class on the constraint component

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -6,8 +6,6 @@
 }
 
 .applied-filter {
-  @extend .mx-1;
-
   .constraint-value {
     cursor: default;
     text-overflow: ellipsis;

--- a/app/components/blacklight/constraint_component.rb
+++ b/app/components/blacklight/constraint_component.rb
@@ -4,7 +4,7 @@ module Blacklight
   class ConstraintComponent < Blacklight::Component
     with_collection_parameter :facet_item_presenter
 
-    def initialize(facet_item_presenter:, classes: 'filter', layout: Blacklight::ConstraintLayoutComponent)
+    def initialize(facet_item_presenter:, classes: %w[filter mx-1], layout: Blacklight::ConstraintLayoutComponent)
       @facet_item_presenter = facet_item_presenter
       @classes = classes
       @layout = layout


### PR DESCRIPTION
This makes it easier to override the margin if necessary

Ref #3206