### PR TITLE
Explictly add the form-control class to the auto-complete

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_form.scss
+++ b/app/assets/stylesheets/blacklight/_search_form.scss
@@ -5,7 +5,6 @@
 }
 
 .input-group > .search-autocomplete-wrapper {
-  @extend .form-control;
   display: inline-block;
   flex-grow: 4;
   padding: 0;

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -22,7 +22,7 @@
 
       <%= f.label @query_param, scoped_t('search.label'), class: 'sr-only visually-hidden' %>
       <% if autocomplete_path.present? %>
-        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
+        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper form-control">
           <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
           <ul id="autocomplete-popup" class="dropdown-menu" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
         </auto-complete>


### PR DESCRIPTION
This will make it possible to run blacklight without a sass dependency

Ref #3206