### PR TITLE
Simplify constraint spacing on history.

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_history.scss
+++ b/app/assets/stylesheets/blacklight/_search_history.scss
@@ -11,9 +11,8 @@
   }
 
   .constraint {
-    @extend .px-4;
+    padding-inline-end: $spacer;
     display: block;
-    text-indent: -1 * map-get($spacers, 3);
   }
 
   .filter-name {


### PR DESCRIPTION
If we don't provide start padding, we don't need to have a negative text indent.  This also decouples from Sass

Ref #3206