### PR TITLE
Remove obsolete engine_cart config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,16 +31,6 @@ else
       gem 'rails', ENV['RAILS_VERSION']
     end
   end
-
-  case ENV['RAILS_VERSION'].to_s
-  when /^(~> ?)?6\.0/
-    gem 'sass-rails', '>= 6'
-    gem 'webpacker', '~> 4.0'
-  when /^5.[12]/
-    gem 'sass-rails', '~> 5.0'
-    gem 'sprockets', '~> 3.7'
-    gem 'thor', '~> 0.20'
-  end
 end
 # END ENGINE_CART BLOCK
 


### PR DESCRIPTION
This is for branches of Rails we don't support