### PR TITLE
Test using the supported way of compiling sass

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,7 +40,7 @@ jobs:
         bootstrap_version: [null]
         view_component_version: ["~> 3.12"]
         api: [null]
-        additional_engine_cart_rails_options: [""]
+        additional_engine_cart_rails_options: ["--css=bootstrap"]
         additional_name: [""]
         include:
           - ruby: "3.3"
@@ -48,12 +48,15 @@ jobs:
             additional_engine_cart_rails_options: --css=bootstrap
           - ruby: "3.2"
             rails_version: "7.0.8.4"
+            additional_engine_cart_rails_options: --css=bootstrap
           - ruby: "3.2"
             rails_version: "7.1.3.4"
             solr_version: "8.11.2"
             additional_name: "Solr 8.11.2"
+            additional_engine_cart_rails_options: --css=bootstrap
           - ruby: "3.1"
             rails_version: "7.1.3.4"
+            additional_engine_cart_rails_options: --css=bootstrap
           - ruby: "3.1"
             rails_version: "7.0.8.4"
             additional_name: "/ Propshaft"
@@ -63,6 +66,7 @@ jobs:
             api: "true"
             additional_engine_cart_rails_options: --api --skip-yarn
             additional_name: "/ API"
+      fail-fast: false
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       SOLR_VERSION: ${{ matrix.solr_version || 'latest' }}

--- a/lib/generators/blacklight/assets/importmap_generator.rb
+++ b/lib/generators/blacklight/assets/importmap_generator.rb
@@ -5,6 +5,15 @@ module Blacklight
     class ImportmapGenerator < Rails::Generators::Base
       class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 5.3'), desc: "Set the generated app's bootstrap version"
 
+      # Add css files from blacklight-frontend
+      def add_package
+        if ENV['CI']
+          run "yarn add blacklight-frontend:#{Blacklight::Engine.root}"
+        else
+          run 'yarn add blacklight-frontend'
+        end
+      end
+
       # This could be skipped if you want to use webpacker
       def add_javascript_dependencies
         gem 'bootstrap', options[:'bootstrap-version'].presence # in rails 7, only for stylesheets

--- a/lib/generators/blacklight/assets/importmap_generator.rb
+++ b/lib/generators/blacklight/assets/importmap_generator.rb
@@ -8,7 +8,7 @@ module Blacklight
       # Add css files from blacklight-frontend
       def add_package
         if ENV['CI']
-          run "yarn add blacklight-frontend:#{Blacklight::Engine.root}"
+          run "yarn add file:#{Blacklight::Engine.root}"
         else
           run 'yarn add blacklight-frontend'
         end

--- a/lib/generators/blacklight/assets/sprockets_generator.rb
+++ b/lib/generators/blacklight/assets/sprockets_generator.rb
@@ -8,7 +8,7 @@ module Blacklight
       # Add css files from blacklight-frontend
       def add_package
         if ENV['CI']
-          run "yarn add blacklight-frontend:#{Blacklight::Engine.root}"
+          run "yarn add file:#{Blacklight::Engine.root}"
         else
           run 'yarn add blacklight-frontend'
         end

--- a/lib/generators/blacklight/assets/sprockets_generator.rb
+++ b/lib/generators/blacklight/assets/sprockets_generator.rb
@@ -5,6 +5,15 @@ module Blacklight
     class SprocketsGenerator < Rails::Generators::Base
       class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 5.3'), desc: "Set the generated app's bootstrap version"
 
+      # Add css files from blacklight-frontend
+      def add_package
+        if ENV['CI']
+          run "yarn add blacklight-frontend:#{Blacklight::Engine.root}"
+        else
+          run 'yarn add blacklight-frontend'
+        end
+      end
+
       # This could be skipped if you want to use webpacker
       def add_javascript_dependencies
         gem 'bootstrap', options[:'bootstrap-version'].presence
@@ -20,14 +29,11 @@ module Blacklight
       end
 
       def assets
-        create_file 'app/assets/stylesheets/blacklight.scss' do
+        append_to_file 'app/assets/stylesheets/application.bootstrap.scss' do
           <<~CONTENT
-            @import 'bootstrap';
-            @import 'blacklight/blacklight';
+            @import "blacklight-frontend/app/assets/stylesheets/blacklight/blacklight";
           CONTENT
         end
-
-        gem "sassc-rails", "~> 2.1"
 
         # Ensure this method is idempotent
         return if has_blacklight_assets?


### PR DESCRIPTION
There are warnings about sassc-rails being not supported since 2019 in https://guides.rubyonrails.org/asset_pipeline.html#cssbundling-rails

In rails 6:
```
The file /home/runner/work/blacklight/blacklight/.internal_test_app/app/assets/stylesheets/application.bootstrap.scss does not appear to exist
```


In rails 7.0:
```
$ esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets
Error: R] No matching export in "node_modules/bootstrap/dist/js/bootstrap.esm.js" for import "default"

    app/javascript/application.js:5:7:
      5 │ import bootstrap from "bootstrap"
        ╵        ~~~~~~~~~
```