### PR TITLE
Handle beginless/endless ranges in facet value

### DIFF
--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -334,7 +334,7 @@ module Blacklight::Solr
 
     ##
     # Convert a facet/value pair into a solr fq parameter
-    # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def facet_value_to_fq_string(facet_field, value, use_local_params: true)
       facet_config = blacklight_config.facet_fields[facet_field]
 
@@ -353,14 +353,16 @@ module Blacklight::Solr
         end
       elsif value.is_a?(Range)
         prefix = "{!#{local_params.join(' ')}}" unless local_params.empty?
-        "#{prefix}#{solr_field}:[#{value.first} TO #{value.last}]"
+        start = value.begin || '*'
+        finish = value.end || '*'
+        "#{prefix}#{solr_field}:[#{start} TO #{finish}]"
       elsif value == Blacklight::SearchState::FilterField::MISSING
         "-#{solr_field}:[* TO *]"
       else
         "{!term f=#{solr_field}#{" #{local_params.join(' ')}" unless local_params.empty?}}#{convert_to_term_value(value)}"
       end
     end
-    # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def facet_inclusive_value_to_fq_string(facet_field, values)
       return if values.blank?

--- a/spec/models/blacklight/solr/search_builder_behavior_spec.rb
+++ b/spec/models/blacklight/solr/search_builder_behavior_spec.rb
@@ -575,6 +575,9 @@ RSpec.describe Blacklight::Solr::SearchBuilderBehavior, :api do
 
     it "handles range requests" do
       expect(subject.send(:facet_value_to_fq_string, "facet_name", 1..5)).to eq "facet_name:[1 TO 5]"
+      expect(subject.send(:facet_value_to_fq_string, "facet_name", 1..nil)).to eq "facet_name:[1 TO *]"
+      expect(subject.send(:facet_value_to_fq_string, "facet_name", nil..5)).to eq "facet_name:[* TO 5]"
+      expect(subject.send(:facet_value_to_fq_string, "facet_name", nil..nil)).to eq "facet_name:[* TO *]"
     end
 
     it "adds tag local parameters" do


### PR DESCRIPTION
I have been looking at https://github.com/projectblacklight/blacklight_range_limit/issues/235. It seems like it might be easier to fix that issue if Blacklight handled beginless/endless ranges for facets in the search builder.
