### PR TITLE
Pin to bundler 2.5.14

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
-          bundler: "latest"
+          bundler: "2.5.14"
       - name: Install dependencies
         run: bundle install
       - name: Run linter
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler: "latest"
+          bundler: "2.5.14"
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,9 @@ jobs:
           ruby-version: 3.2
           bundler: "2.5.14"
       - name: Install dependencies
-        run: bundle install
+        run: |
+          bundle config path /home/runner/work/blacklight/blacklight
+          bundle install
       - name: Run linter
         run: bundle exec rake rubocop
   test:
@@ -83,7 +85,9 @@ jobs:
           bundler: "2.5.14"
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
-        run: bundle install
+        run: |
+          bundle config path /home/runner/work/blacklight/blacklight
+          bundle install
       - name: Run tests
         run: bundle exec rake ci
   docker_build:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
   Exclude:
     - "lib/generators/blacklight/templates/**/*"
     - "blacklight.gemspec"
+    - "vendor/**/*"
 
 Lint/UselessAssignment:
   Exclude:


### PR DESCRIPTION
This fixes errors in CI when running on 2.5.15 (latest)

```
 The installation path is insecure. Bundler cannot continue.
/opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems is world-writable
(without sticky bit).
Bundler cannot safely replace gems in world-writeable directories due to
potential vulnerabilities.
Please change the permissions of this directory or choose a different install
path.
Error: Process completed with exit code 38.
```