### PR TITLE
add optional bookmark icon for bookmarks

### DIFF
--- a/app/assets/stylesheets/blacklight/_bookmark.scss
+++ b/app/assets/stylesheets/blacklight/_bookmark.scss
@@ -18,3 +18,23 @@ label.toggle-bookmark {
 		display: none;
 	}
 }
+.toggle-bookmark .blacklight-icons svg {
+  height: 1.25rem;
+  width: 1.25rem;
+  overflow: visible;
+  fill: var(--bs-primary);
+
+  &.bookmark-checked {
+    display: none;
+  }
+}
+
+.toggle-bookmark[type="checkbox"]:checked+span svg {
+  &.bookmark-checked {
+    display: inherit;
+  }
+
+  &.bookmark-unchecked {
+    display: none;
+  }
+}

--- a/app/components/blacklight/document/bookmark_component.html.erb
+++ b/app/components/blacklight/document/bookmark_component.html.erb
@@ -10,7 +10,8 @@
             }) do %>
   <div class="checkbox toggle-bookmark">
     <label class="toggle-bookmark" data-checkboxsubmit-target="label">
-      <input type="checkbox" class="toggle-bookmark" data-checkboxsubmit-target="checkbox" <%= 'checked="checked"' if bookmarked? %>>
+      <input type="checkbox" class="toggle-bookmark <%= bookmark_icon ? 'd-none' : '' %>" data-checkboxsubmit-target="checkbox" <%= 'checked="checked"' if bookmarked? %>>
+      <%= bookmark_icon %>
       <span data-checkboxsubmit-target="span"><%= bookmarked? ? t('blacklight.search.bookmarks.present') : t('blacklight.search.bookmarks.absent') %></span>
     </label>
   </div>

--- a/app/components/blacklight/document/bookmark_component.rb
+++ b/app/components/blacklight/document/bookmark_component.rb
@@ -21,6 +21,12 @@ module Blacklight
         helpers.bookmarked? @document
       end
 
+      def bookmark_icon
+        return unless helpers.blacklight_config.bookmark_icon_component
+
+        render helpers.blacklight_config.bookmark_icon_component.new(name: 'bookmark')
+      end
+
       def bookmark_path
         @bookmark_path || helpers.bookmark_path(@document)
       end

--- a/app/components/blacklight/icons/bookmark_icon_component.rb
+++ b/app/components/blacklight/icons/bookmark_icon_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    class BookmarkIconComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-bookmark-check-fill bookmark-checked" viewBox="0 0 16 16">
+          <path fill-rule="evenodd" d="M2 15.5V2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.74.439L8 13.069l-5.26 2.87A.5.5 0 0 1 2 15.5m8.854-9.646a.5.5 0 0 0-.708-.708L7.5 7.793 6.354 6.646a.5.5 0 1 0-.708.708l1.5 1.5a.5.5 0 0 0 .708 0z"/>
+        </svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-bookmark-plus bookmark-unchecked" viewBox="0 0 16 16">
+          <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.777.416L8 13.101l-5.223 2.815A.5.5 0 0 1 2 15.5zm2-1a1 1 0 0 0-1 1v12.566l4.723-2.482a.5.5 0 0 1 .554 0L13 14.566V2a1 1 0 0 0-1-1z"/>
+          <path d="M8 4a.5.5 0 0 1 .5.5V6H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V7H6a.5.5 0 0 1 0-1h1.5V4.5A.5.5 0 0 1 8 4"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -150,6 +150,12 @@ module Blacklight
       # @return [#partials]
       property :navbar, default: OpenStructWithHashAccess.new(partials: {})
 
+      # @!attribute bookmark_icon_component
+      # @since v8.3.1
+      # component class used to render a document
+      # set to Blacklight::Icons::BookmarkIconComponent to replace checkbox with icon
+      property :bookmark_icon_component, default: nil
+
       # @!attribute index
       # General configuration for all views
       # @return [Blacklight::Configuration::ViewConfig::Index]

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -81,4 +81,19 @@ RSpec.describe "Bookmarks" do
     expect(page).to have_content 'Strong Medicine speaks'
     expect(page).to have_content 'Ci an zhou bian'
   end
+
+  context "has bookmark icon" do
+    before do
+      CatalogController.blacklight_config.bookmark_icon_component = Blacklight::Icons::BookmarkIconComponent
+    end
+
+    it 'shows bookmark icon instead of checkbox', :js do
+      visit solr_document_path('2007020969')
+      expect(page).to have_css('.blacklight-icons-bookmark')
+      find('.blacklight-icons-bookmark').click
+
+      expect(find('.toggle-bookmark[type="checkbox"]', visible: false)).to be_checked
+      find('.blacklight-icons-bookmark').click
+    end
+  end
 end


### PR DESCRIPTION
When the user updates the config to point to a icon component it will render the icon as a bookmark instead of the checkbox.

![Screenshot 2024-07-17 at 1 28 24 PM](https://github.com/user-attachments/assets/5c9e7df8-f495-4a47-b843-718c83b0da41)
![Screenshot 2024-07-17 at 1 28 20 PM](https://github.com/user-attachments/assets/21383df7-6dc9-4b20-b8a8-1403a6ccf48d)
![Screenshot 2024-07-17 at 1 28 12 PM](https://github.com/user-attachments/assets/e22429c6-1a58-4224-9356-bc8968a88093)

