### PR TITLE
Add Configuration#fetch_many_documents_path 

### DIFF
--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -148,7 +148,15 @@ module Blacklight
               .merge(blacklight_config.fetch_many_document_params)
               .merge(extra_controller_params)
 
-      solr_response = repository.search(query)
+      # find_many was introduced in Blacklight 8.4. Before that, we used the
+      # regular search method (possibly with a find-many specific `qt` parameter).
+      # In order to support Repository implementations that may not have a find_many,
+      # we'll fall back to search if find_many isn't available.
+      solr_response = if repository.respond_to?(:find_many)
+                        repository.find_many(query)
+                      else
+                        repository.search(query)
+                      end
 
       solr_response.documents
     end

--- a/lib/blacklight/abstract_repository.rb
+++ b/lib/blacklight/abstract_repository.rb
@@ -35,6 +35,12 @@ module Blacklight
       raise NotImplementedError
     end
 
+    # Find multiple documents by their ids
+    # @param [Hash] _params query parameters
+    def find_many(params, **kwargs)
+      search(params, **kwargs)
+    end
+
     ##
     # Execute a search query against a search index
     # @param [Hash] _params query parameters

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -99,6 +99,10 @@ module Blacklight
       # @!attribute default_document_solr_params
       # @return [Hash] Default values of parameters to send with every single-document request
       property :default_document_solr_params, default: {}
+      # @!attribute fetch_many_documents_path
+      # @since v8.4.0
+      # @return [String] The url path (relative to the solr base url) to use when requesting multiple documents by id
+      property :fetch_many_documents_path, default: nil
       # @!attribute fetch_many_document_params
       # @since v7.0.0
       # @return [Hash] Default values of parameters to send with every multi-document request

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -17,13 +17,20 @@ module Blacklight::Solr
       solr_response
     end
 
+    # Find multiple documents by their ids
+    # @param [Hash] _params query parameters
+    def find_many(params)
+      search(params: params, path: blacklight_config.fetch_many_documents_path)
+    end
+
     ##
     # Execute a search query against solr
     # @param [Hash] params solr query parameters
-    def search params = {}
-      request_params = params.reverse_merge({ qt: blacklight_config.qt })
+    # @param [String] path solr request handler path
+    def search pos_params = {}, path: nil, params: nil, **kwargs
+      request_params = (params || pos_params).reverse_merge(kwargs).reverse_merge({ qt: blacklight_config.qt })
 
-      send_and_receive search_path(request_params), request_params
+      send_and_receive(path || default_search_path(request_params), request_params)
     end
 
     # @param [Hash] request_params
@@ -126,7 +133,7 @@ module Blacklight::Solr
     end
 
     # @return [String]
-    def search_path(solr_params)
+    def default_search_path(solr_params)
       return blacklight_config.json_solr_path if blacklight_config.json_solr_path && uses_json_query_dsl?(solr_params)
 
       blacklight_config.solr_path

--- a/spec/models/blacklight/solr/repository_spec.rb
+++ b/spec/models/blacklight/solr/repository_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe Blacklight::Solr::Repository, :api do
     end
   end
 
+  describe '#find_many' do
+    context 'with a configured fetch_many_documents_path' do
+      it 'uses the path' do
+        blacklight_config.fetch_many_documents_path = 'documents'
+        allow(subject.connection).to receive(:send_and_receive).with('documents', anything).and_return(mock_response)
+        expect(subject.find_many({})).to be_a Blacklight::Solr::Response
+      end
+    end
+
+    context 'without a configured fetch_many_documents_path' do
+      it 'falls back to the search path' do
+        blacklight_config.solr_path = 'xyz'
+        allow(subject.connection).to receive(:send_and_receive).with('xyz', anything).and_return(mock_response)
+        expect(subject.find_many({})).to be_a Blacklight::Solr::Response
+      end
+    end
+  end
+
   describe "#search" do
     it "uses the search-specific solr path" do
       blacklight_config.solr_path = 'xyz'


### PR DESCRIPTION
... and use it when we're retrieving multiple documents by id.

By default, this uses the existing search behavior (maintaining backwards compatible), but allows applications to use other paths (e.g. the real-time `/get` or other path) that's more appropriate. Without this change, applications have been limited to using `qt` with old-style request handlers in Solr.

 