### PR TITLE
Use the bootstrap icon for removing a facet

### DIFF
--- a/app/assets/stylesheets/blacklight/_icons.scss
+++ b/app/assets/stylesheets/blacklight/_icons.scss
@@ -6,6 +6,7 @@
   }
 }
 
-.remove-icon {
-  font-family: $remove-icon-font-family;
+.remove .bi {
+  height: 1em;
+  width: 1em;
 }

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -1,13 +1,8 @@
 /* Warning! If you want to change these, just copy them into your own theme css. But you want to remove the !default, which only will set them if not already set. */
 
-$logo-image: image_url('blacklight/logo.png') !default;
+$logo-image: image_url("blacklight/logo.png") !default;
 $logo-width: 150px !default;
 $logo-height: 50px !default;
-
-// the default bootstrap font-family list includes "Segoe UI Emoji", which, on windows
-// renders our remove icon as an emoji-sized x instead of what we see on all other platforms...
-// so, for now (until we replace it with an SVG icon or something), we get to override bootstrap:
-$remove-icon-font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif !default;
 
 $facet-active-border: $success !default;
 $facet-active-bg: $success !default;

--- a/app/components/blacklight/constraint_layout_component.html.erb
+++ b/app/components/blacklight/constraint_layout_component.html.erb
@@ -9,7 +9,7 @@
   </span>
   <% if @remove_path.present? %>
     <%= link_to(@remove_path, class: 'btn btn-outline-secondary remove') do %>
-      <span class="remove-icon" aria-hidden="true">✖</span>
+      <%= render Blacklight::Icons::RemoveComponent.new %>
       <span class="sr-only visually-hidden">
         <%= if @label.blank?
             t('blacklight.search.filters.remove.value', value: @value)

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -54,7 +54,7 @@ module Blacklight
         tag.span(label, class: "selected") +
           # remove link
           link_to(href, class: "remove", rel: "nofollow") do
-            tag.span('✖', class: "remove-icon", aria: { hidden: true }) +
+            render(Blacklight::Icons::RemoveComponent.new) +
               tag.span(helpers.t(:'blacklight.search.facets.selected.remove'), class: 'sr-only visually-hidden')
           end
       end + render_facet_count(classes: ["selected"])

--- a/app/components/blacklight/icons/remove_component.rb
+++ b/app/components/blacklight/icons/remove_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # This is the remove (x) icon for the facets and constraints.
+    # You can override the default svg by setting:
+    #   Blacklight::Icons::RemoveComponent.svg = '<svg>your SVG here</svg>'
+    class RemoveComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x fs-4" viewBox="0 0 16 16">
+          <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
+        </svg>
+      SVG
+    end
+  end
+end


### PR DESCRIPTION
Putting the svg in a component allows the user to customize the SVG without having to override templates.

This also eliminates an unfortunate hack we had to do for Windows.