### PR TITLE
Use Bootstrap 5 Accordion for the facet list

### DIFF
--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -1,27 +1,3 @@
-// Facet field headings and buttons
-.facet-field-heading {
-  border-bottom: 0;
-
-  button {
-    font-weight: $headings-font-weight;
-
-    &::after {
-      content: "❯";
-      float: right;
-      transform: rotate(90deg);
-    }
-
-    &.collapsed {
-      border-bottom: 0;
-
-      &::after {
-        transform: rotate(0deg);
-        transition: transform 0.1s ease;
-      }
-    }
-  }
-}
-
 .page-link {
   white-space: nowrap;
 }

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -1,10 +1,7 @@
 .sidenav {
   --bl-facet-active-bg: #{$facet-active-bg};
   --bl-facet-active-item-color: #{$facet-active-item-color};
-  --bl-facet-margin-bottom: #{$spacer};
   --bl-facet-remove-color: var(--bs-secondary-color);
-
-  --bl-facet-limit-body-padding: #{$spacer};
 
   --bl-facets-smallish-padding: 0.25rem;
   --bl-facets-smallish-border: var(--bs-border-width) solid
@@ -85,33 +82,17 @@
 }
 
 .facet-limit {
-  margin-bottom: var(--bl-facet-margin-bottom);
-
-  .card-body {
-    padding: var(--bl-facet-limit-body-padding);
-  }
-
-  /* Provide a focus ring on the expand/collapse button */
-  .btn {
-    --bs-btn-focus-shadow-rgb: 50, 50, 50;
-    &:focus-visible {
-      border-color: var(--bs-btn-hover-border-color);
-      outline: 0;
-      box-shadow: var(--bs-btn-focus-box-shadow);
-    }
-  }
+  --bs-accordion-btn-bg: var(--bs-gray-100);
+  --bs-btn-hover-bg: var(--bs-gray-200);
+  --bs-accordion-active-bg: var(--bs-accordion-btn-bg);
 }
 
 .facet-limit-active {
-  border-color: $facet-active-border;
-
-  .card-header {
-    background-color: var(--bl-facet-active-bg);
-
-    .btn {
-      color: color-contrast($facet-active-bg);
-    }
-  }
+  --bs-accordion-btn-bg: var(--bl-facet-active-bg);
+  --bs-btn-hover-bg: var(--bs-accordion-btn-bg);
+  --bs-accordion-btn-color: #{color-contrast($facet-active-bg)};
+  --bs-btn-hover-color: var(--bs-accordion-btn-color);
+  --bs-accordion-active-color: var(--bs-accordion-btn-color);
 }
 
 .facet-values {

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -4,7 +4,6 @@ $logo-image: image_url("blacklight/logo.png") !default;
 $logo-width: 150px !default;
 $logo-height: 50px !default;
 
-$facet-active-border: $success !default;
 $facet-active-bg: $success !default;
 $facet-active-item-color: $success !default;
 

--- a/app/components/blacklight/facet_field_component.html.erb
+++ b/app/components/blacklight/facet_field_component.html.erb
@@ -1,8 +1,8 @@
-<div class="card facet-limit blacklight-<%= @facet_field.key %> <%= 'facet-limit-active' if @facet_field.active? %>">
-  <h3 class="card-header p-0 facet-field-heading h6" id="<%= header_html_id %>">
+<div class="accordion-item facet-limit blacklight-<%= @facet_field.key %> <%= 'facet-limit-active' if @facet_field.active? %>">
+  <h3 class="accordion-header p-0 facet-field-heading h6" id="<%= header_html_id %>">
     <button
       type="button"
-      class="btn w-100 d-block btn-block p-2 text-start text-left collapse-toggle <%= "collapsed" if @facet_field.collapsed? %>"
+      class="btn accordion-button <%= "collapsed" if @facet_field.collapsed? %>"
       data-toggle="collapse"
       data-bs-toggle="collapse"
       data-target="#<%= html_id %>"
@@ -14,7 +14,7 @@
     </button>
   </h3>
   <div id="<%= html_id %>" role="region" aria-labelledby="<%= header_html_id %>" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
-    <div class="card-body">
+    <div class="accordion-body">
       <%= body %>
 
       <% if @facet_field.modal_path %>

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -21,7 +21,7 @@
     <% end %>
   </div>
 
-  <div id="<%= @panel_id %>" class="facets-collapse d-lg-block collapse">
+  <div id="<%= @panel_id %>" class="facets-collapse d-lg-block collapse accordion">
     <%= body %>
   </div>
 <% end %>

--- a/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
   let(:search_state) { Blacklight::SearchState.new(params.with_indifferent_access, Blacklight::Configuration.new) }
   let(:params) { { f: { field: ['a'] } } }
 
-  it 'renders a collapsible card' do
-    expect(rendered).to have_css '.card'
+  it 'renders an accordion item' do
+    expect(rendered).to have_css '.accordion-item'
     expect(rendered).to have_button 'Field'
     expect(rendered).to have_css 'button[data-bs-target="#facet-field"]'
     expect(rendered).to have_css '#facet-field.collapse.show'

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
                     ])
   end
 
-  it 'renders a collapsible card' do
-    expect(rendered).to have_css '.card'
+  it 'renders an accordion item' do
+    expect(rendered).to have_css '.accordion-item'
     expect(rendered).to have_button 'Field'
     expect(rendered).to have_css 'button[data-bs-target="#facet-field"]'
     expect(rendered).to have_css '#facet-field.collapse.show'

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Accessibility testing', :js, api: false do
 
     expect(page).to be_accessible
 
-    within '.card.blacklight-language_ssim' do
+    within '.accordion-item.blacklight-language_ssim' do
       click_on 'Language'
       click_on "Tibetan"
     end

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "Facets" do
     visit root_path
 
     within(".blacklight-subject_ssim") do
-      expect(page).to have_no_css(".card-body", visible: true)
+      expect(page).to have_no_css(".accordion-body", visible: true)
     end
   end
 
@@ -179,9 +179,9 @@ RSpec.describe "Facets" do
     visit root_path
 
     within(".blacklight-subject_ssim") do
-      expect(page).to have_no_css(".card-body", visible: true)
+      expect(page).to have_no_css(".accordion-body", visible: true)
       click_on 'Topic'
-      expect(page).to have_css(".card-body", visible: true)
+      expect(page).to have_css(".accordion-body", visible: true)
     end
   end
 
@@ -189,9 +189,9 @@ RSpec.describe "Facets" do
     visit root_path
 
     within(".blacklight-subject_ssim") do
-      expect(page).to have_no_css(".card-body", visible: true)
-      find(".card-header").click
-      expect(page).to have_css(".card-body", visible: true)
+      expect(page).to have_no_css(".accordion-body", visible: true)
+      find(".accordion-header").click
+      expect(page).to have_css(".accordion-body", visible: true)
     end
   end
 

--- a/spec/views/catalog/_facet_layout.html.erb_spec.rb
+++ b/spec/views/catalog/_facet_layout.html.erb_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe "catalog/facet_layout" do
   it "is collapsable" do
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
     expect(rendered).to have_css 'button.collapsed[data-toggle="collapse"][data-bs-toggle="collapse"][aria-expanded="false"]'
-    expect(rendered).to have_css '.collapse .card-body'
+    expect(rendered).to have_css '.collapse .accordion-body'
   end
 
   it "is configured to be open by default" do
     allow(facet_field).to receive_messages(collapse: false)
     render partial: 'catalog/facet_layout', locals: { facet_field: facet_field }
     expect(rendered).to have_css 'button[data-toggle="collapse"][data-bs-toggle="collapse"][aria-expanded="true"]'
-    expect(rendered).to have_no_css '.card-header.collapsed'
-    expect(rendered).to have_css '.collapse.show .card-body'
+    expect(rendered).to have_no_css '.accordion-header.collapsed'
+    expect(rendered).to have_css '.collapse.show .accordion-body'
   end
 end


### PR DESCRIPTION
<img width="337" alt="Screenshot 2024-08-07 at 10 04 19 AM" src="https://github.com/user-attachments/assets/3af0f715-71ab-48a5-b75a-1d0cb68a99a2">

This was not available in Bootstrap 4.  It allows a lot more customization (via Bootstrap variables) and requires Blacklight itself to have less code.
