### PR TITLE
Bump max Rails version to 7.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -131,6 +131,26 @@ jobs:
       run: bundle exec rake ci
       env:
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-keeps --skip-action-cable --skip-test'
+  test_rails7_2:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.1, 3.2]
+    env:
+      RAILS_VERSION: 7.2.0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler: 'default'
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake ci
+      env:
+        ENGINE_CART_RAILS_OPTIONS: '--skip-keeps --skip-test'
   test_vc3:
     runs-on: ubuntu-latest
     strategy:

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency "rails", '>= 5.1', '< 7.2'
+  s.add_dependency "rails", '>= 5.1', '< 7.3'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results


### PR DESCRIPTION
Bump max Rails version to 7.2 in Blacklight 7.x. Allow implementers time to upgrade from older versions of Rails that will be EOL soon.