### PR TITLE
Backport: Fix docker compose usage

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -176,6 +176,6 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build docker image
-      run: docker-compose build app
+      - uses: actions/checkout@v3
+      - name: Build docker image
+        run: docker compose build app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         - ALPINE_RUBY_VERSION
     # mounting . is causing seg-fault on macosx
     #volumes:
-      #- .:/app
+    #- .:/app
     depends_on:
       - solr
     ports:

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -21,18 +21,18 @@ def system_with_error_handling(*args)
 end
 
 def with_solr
-  # We're being invoked by the app entrypoint script and solr is already up via docker-compose
+  # We're being invoked by the app entrypoint script and solr is already up via docker compose
   if ENV['SOLR_ENV'] == 'docker-compose'
     yield
-  elsif system('docker-compose -v')
-    # We're not running docker-compose up but still want to use a docker instance of solr.
+  elsif system('docker compose -v')
+    # We're not running `docker compose up' but still want to use a docker instance of solr.
     begin
       puts "Starting Solr"
-      system_with_error_handling "docker-compose up -d solr"
+      system_with_error_handling "docker compose up -d solr"
       yield
     ensure
       puts "Stopping Solr"
-      system_with_error_handling "docker-compose stop solr"
+      system_with_error_handling "docker compose stop solr"
     end
   else
     SolrWrapper.wrap do |solr|


### PR DESCRIPTION
docker-compose has been replaced by docker compose (no dash).

Backport of #3254