### PR TITLE
moves next after numbers

### DIFF
--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -11,7 +11,6 @@
 <%= paginator.render do -%>
   <ul class="pagination">
     <%= prev_page_tag %>
-    <%= next_page_tag  %>
     <% each_relevant_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
         <%= page_tag page %>
@@ -19,5 +18,6 @@
         <%= gap_tag %>
       <% end -%>
     <% end -%>  
+    <%= next_page_tag  %>
   </ul>
 <% end -%>


### PR DESCRIPTION
You can see the changes by changing https://github.com/projectblacklight/blacklight/blob/a8b5a3d3a2e8243c8a875d40528eae5c106d83bd/lib/blacklight/engine.rb#L71 to `blacklight9`

![Screenshot 2024-08-14 at 11 34 18 AM](https://github.com/user-attachments/assets/63345d4e-ffdf-48a1-b127-36da9b2c6cc9)
