### PR TITLE
Use nav tag rather than section tag for pagination links

### DIFF
--- a/app/components/blacklight/response/pagination_component.html.erb
+++ b/app/components/blacklight/response/pagination_component.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :section, class: 'paginate-section',  **html_attr do %>
+<%= tag.nav class: 'paginate-section', **html_attr do %>
   <%= pagination %>
 <% end %>


### PR DESCRIPTION
This offers better accessibility and follows the example markup in https://getbootstrap.com/docs/5.3/components/pagination/\#disabled-and-active-states