### PR TITLE
allow show tools to be moved to the header, closes #2316

### DIFF
--- a/app/assets/stylesheets/blacklight/_bookmark.scss
+++ b/app/assets/stylesheets/blacklight/_bookmark.scss
@@ -3,6 +3,12 @@ label.toggle-bookmark {
 	min-width: 8.5em;
 }
 
+/* override for line 3.
+Creates weird spacing in toolbar when min-width is set to 8rem */
+.header-tools label.toggle-bookmark {
+  min-width: 2rem;
+}
+
 .bookmark-toggle {
 	.no-js & {
 		input[type="submit"] {

--- a/app/components/blacklight/document/page_header_component.html.erb
+++ b/app/components/blacklight/document/page_header_component.html.erb
@@ -1,0 +1,7 @@
+<%= render applied_params_component %>
+<div class="<%= header_container_classes %>">
+  <div class="<%= pagination_container_classes %>">
+    <%= render pagination_component %>
+  </div>
+  <%= render_header_tools %>
+</div>

--- a/app/components/blacklight/document/page_header_component.rb
+++ b/app/components/blacklight/document/page_header_component.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Document
+    # Render the start over and prev/next displays
+    class PageHeaderComponent < Blacklight::Component
+      attr_reader :document, :blacklight_config, :search_context, :search_session
+
+      delegate :blacklight_config, to: :helpers
+
+      def initialize(document:, search_context:, search_session:)
+        super
+        @search_context = search_context
+        @search_session = search_session
+        @document = document
+      end
+
+      def render?
+        search_context.present? || search_session.present? || has_header_tools?
+      end
+
+      def applied_params_component
+        return unless blacklight_config.track_search_session.applied_params_component
+
+        blacklight_config.track_search_session.applied_params_component.new
+      end
+
+      def pagination_component
+        return unless blacklight_config.track_search_session.item_pagination_component
+
+        blacklight_config.track_search_session.item_pagination_component.new(search_context: search_context, search_session: search_session, current_document: document)
+      end
+
+      def has_header_tools?
+        header_actions.any? || show_header_tools_component
+      end
+
+      def pagination_container_classes
+        has_header_tools? ? 'col-12 col-md-6 ms-auto' : ''
+      end
+
+      def header_container_classes
+        has_header_tools? ? 'row pagination-search-widgets pb-2' : 'pagination-search-widgets'
+      end
+
+      def header_actions
+        actions = helpers.filter_partials(blacklight_config.view_config(:show).header_actions, { document: document })
+        actions.map { |_k, v| v }
+      end
+
+      def show_header_tools_component
+        blacklight_config.view_config(:show).show_header_tools_component
+      end
+
+      def default_action_component_render
+        render Blacklight::Document::ActionsComponent.new(document: document,
+                                                          tag: action_component_tag,
+                                                          classes: classes,
+                                                          link_classes: link_classes,
+                                                          actions: header_actions,
+                                                          url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h))
+      end
+
+      def action_component_tag
+        'div'
+      end
+
+      def classes
+        'd-inline-flex header-tools align-items-center col-12 col-md-6 ms-auto justify-content-md-end'
+      end
+
+      def link_classes
+        'btn btn-outline-primary ms-2'
+      end
+
+      def render_header_tools
+        return unless has_header_tools?
+
+        return render show_header_tools_component.new(document: document) if show_header_tools_component
+
+        default_action_component_render
+      end
+    end
+  end
+end

--- a/app/components/blacklight/search_context/server_item_pagination_component.html.erb
+++ b/app/components/blacklight/search_context/server_item_pagination_component.html.erb
@@ -1,10 +1,7 @@
-<div class='pagination-search-widgets'>
+<div class="search-context page-links">
+  <%= link_to_previous_document %> |
 
-  <div class="page-links">
-    <%= link_to_previous_document %> |
+  <%= item_page_entry_info %> |
 
-    <%= item_page_entry_info %> |
-
-    <%= link_to_next_document %>
-  </div>
+  <%= link_to_next_document %>
 </div>

--- a/app/helpers/blacklight/component_helper_behavior.rb
+++ b/app/helpers/blacklight/component_helper_behavior.rb
@@ -37,6 +37,10 @@ module Blacklight
       filter_partials(blacklight_config.view_config(:show).document_actions, { document: document }.merge(options)).map { |_k, v| v }
     end
 
+    def filter_partials(partials, options)
+      partials.select { |_, config| blacklight_configuration_context.evaluate_if_unless_configuration config, options }
+    end
+
     private
 
     def render_filtered_partials(partials, options = {})
@@ -51,10 +55,6 @@ module Blacklight
         end
       end
       safe_join(content, "\n") unless block_given?
-    end
-
-    def filter_partials(partials, options)
-      partials.select { |_, config| blacklight_configuration_context.evaluate_if_unless_configuration config, options }
     end
   end
 end

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,4 +1,4 @@
-<%= render blacklight_config.track_search_session.item_pagination_component.new(search_context: @search_context, search_session: search_session, current_document: @document) if blacklight_config.track_search_session.item_pagination_component %>
+<%= render blacklight_config.view_config(:show).document_header_component.new(document: @document, search_context: @search_context, search_session: search_session) %>
 <% @page_title = t('blacklight.search.show.title', document_title: document_presenter(@document).html_title, application_name: application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,3 @@
-<%= render blacklight_config.track_search_session.applied_params_component.new if blacklight_config.track_search_session.applied_params_component %>
-
 <%= render 'show_main_content' %>
 
 <% content_for(:sidebar) do %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -201,6 +201,8 @@ module Blacklight
         # in Blacklight 9, the default show_tools_component configuration will
         # be Blacklight::Document::ShowToolsComponent
         show_tools_component: nil,
+        show_header_tools_component: nil,
+        document_header_component: Blacklight::Document::PageHeaderComponent,
         sidebar_component: Blacklight::Document::SidebarComponent,
         display_type_field: nil,
         # the "field access" key to use to look up the document display fields
@@ -211,7 +213,8 @@ module Blacklight
         route: nil,
         # partials to render for each document(see #render_document_partials)
         partials: [],
-        document_actions: NestedOpenStructWithHashAccess.new(ToolConfig)
+        document_actions: NestedOpenStructWithHashAccess.new(ToolConfig),
+        header_actions: NestedOpenStructWithHashAccess.new(ToolConfig)
       )
 
       # @!attribute action_mapping
@@ -558,6 +561,22 @@ module Blacklight
       add_action(show.document_actions, name, opts)
       klass && ActionBuilder.new(klass, name, opts).build
     end
+
+    # Add a partial to the show page header when rendering a document.
+    # @!macro partial_if_unless
+    #   @param name [String] the name of the document partial
+    #   @param opts [Hash]
+    #   @option opts [Class] :component draw a component
+    #   @option opts [String] :partial partial to draw if component is false
+    #   @option opts [Symbol,Proc] :if render this action if the method identified by the symbol or the proc evaluates to true. The proc will receive the action configuration and the document or documents for the action.
+    #   @option opts [Symbol,Proc] :unless render this action unless the method identified by the symbol or the proc evaluates to true. The proc will receive the action configuration and the document or documents for the action.
+    def add_show_header_tools_partial(name, opts = {})
+      opts[:partial] ||= 'document_action'
+
+      add_action(show.header_actions, name, opts)
+      klass && ActionBuilder.new(klass, name, opts).build
+    end
+
     # rubocop:enable Layout/LineLength
 
     # Add a tool for the search result list itself

--- a/spec/components/blacklight/document/page_header_component_spec.rb
+++ b/spec/components/blacklight/document/page_header_component_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::Document::PageHeaderComponent, type: :component do
+  subject(:component) { described_class.new(document: document, search_context: search_context, search_session: current_search_session) }
+
+  let(:show_header_tools_component) { Class.new(Blacklight::Document::ShowToolsComponent) }
+
+  let(:view_context) { controller.view_context }
+  let(:render) do
+    component.render_in(view_context)
+  end
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:document) { SolrDocument.new(id: 'x', title_tsim: 'Title') }
+
+  let(:blacklight_config) do
+    CatalogController.blacklight_config.deep_copy
+  end
+
+  # rubocop:disable RSpec/SubjectStub
+  before do
+    # Every call to view_context returns a different object. This ensures it stays stable.
+    allow(controller).to receive_messages(blacklight_config: blacklight_config)
+    allow(controller).to receive(:current_search_session).and_return(double(id: document.id))
+    controller.class.helper_method :current_search_session
+    allow(controller).to receive_messages(controller_name: 'catalog', link_to_previous_document: '', link_to_next_document: '')
+    allow(view_context).to receive_messages(search_context: search_context, search_session: current_search_session, current_search_session: current_search_session)
+    allow(component).to receive(:render).and_call_original
+    allow(component).to receive(:render).with(an_instance_of(show_header_tools_component)).and_return('tool component content')
+    replace_hash = { 'application/_start_over.html.erb' => 'Start Over' }
+    if Rails.version.to_f >= 7.1
+      controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+    else
+      view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+
+  context "all variables are empty" do
+    let(:search_context) { nil }
+    let(:current_search_session) { {} }
+
+    it 'does not render' do
+      expect(rendered.native.inner_html).to be_blank
+    end
+
+    context 'has header tools' do
+      before do
+        blacklight_config.show.show_header_tools_component = show_header_tools_component
+      end
+
+      it 'renders the tools' do
+        expect(rendered).to have_text 'tool component content'
+        expect(rendered).to have_css '.row'
+      end
+    end
+  end
+
+  context "has pagination" do
+    let(:search_context) { { next: next_doc, prev: prev_doc } }
+    let(:prev_doc) { SolrDocument.new(id: '777') }
+    let(:next_doc) { SolrDocument.new(id: '888') }
+    let(:current_search_session) { { query_params: { q: 'abc' }, 'id' => '123', 'document_id' => document.id } }
+
+    it 'renders pagination' do
+      expect(rendered).to have_text 'Previous'
+      expect(rendered).to have_text 'Next'
+      expect(rendered).to have_text 'Start Over'
+      expect(rendered).to have_text 'Back to Search'
+    end
+
+    context 'has header tools' do
+      before do
+        blacklight_config.show.show_header_tools_component = show_header_tools_component
+      end
+
+      it 'renders the tools and pagination' do
+        expect(rendered).to have_text 'Previous'
+        expect(rendered).to have_text 'Next'
+        expect(rendered).to have_text 'Start Over'
+        expect(rendered).to have_text 'Back to Search'
+        expect(rendered).to have_text 'tool component content'
+        expect(rendered).to have_css '.row'
+      end
+    end
+  end
+end

--- a/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
+++ b/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Blacklight::SearchContext::ServerItemPaginationComponent, type: :
     end
 
     it "renders content" do
-      expect(render.css('.pagination-search-widgets').to_html).not_to be_blank
+      expect(render.css('.search-context.page-links').to_html).not_to be_blank
     end
 
     context "session and document are out of sync" do


### PR DESCRIPTION
Add a new function called add_show_header_tools_partial. This will allow the user to add tools to the page header. 

When the app is spun up nothing changes. Changes only go into effect if the user enables these settings.


<img width="1115" alt="Screenshot 2024-08-15 at 11 10 15 AM" src="https://github.com/user-attachments/assets/c2c9e223-d2c4-4579-92ff-16151459fab4">


add_show_header_tools_partial small screen
<img width="647" alt="Screenshot 2024-08-15 at 11 06 45 AM" src="https://github.com/user-attachments/assets/4d9bf3c8-22c0-4fd3-a0c3-d3b4098b8124">


