### PR TITLE
Improve how adv search handles incoming params

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
-  <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
+  <%= render Blacklight::HiddenSearchStateComponent.new(params: hidden_search_state_params) %>
 
   <div class="input-criteria">
     <div class="query-criteria mb-4">

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -34,6 +34,12 @@ module Blacklight
       select_tag(:sort, options_for_select(options, params[:sort]), class: "form-select custom-select sort-select w-auto", aria: { labelledby: 'advanced-search-sort-label' })
     end
 
+    # Filtered params to pass to hidden search fields
+    # @return [ActiveSupport::HashWithIndifferentAccess]
+    def hidden_search_state_params
+      @params.except(:clause, :f_inclusive, :op, :sort)
+    end
+
     private
 
     def initialize_search_field_controls

--- a/app/components/blacklight/facet_field_checkboxes_component.rb
+++ b/app/components/blacklight/facet_field_checkboxes_component.rb
@@ -17,7 +17,7 @@ module Blacklight
       return to_enum(:presenters) unless block_given?
 
       @facet_field.paginator.items.each do |item|
-        yield @facet_field.facet_field.item_presenter.new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
+        yield Blacklight::FacetCheckboxItemPresenter.new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
       end
     end
   end

--- a/app/presenters/blacklight/facet_checkbox_item_presenter.rb
+++ b/app/presenters/blacklight/facet_checkbox_item_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class FacetCheckboxItemPresenter < Blacklight::FacetItemPresenter
+    # Check if the query parameters have any inclusive facets with the given value
+    # @return [Boolean]
+    def selected?
+      search_state.filter(facet_config).values(except: [:filters, :missing]).flatten.include?(value)
+    end
+  end
+end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -105,11 +105,23 @@ RSpec.describe "Blacklight Advanced Search Form" do
 
   describe "prepopulated advanced search form" do
     before do
-      visit '/catalog/advanced?op=must&clause[0][field]=title&clause[0]query=medicine'
+      visit '/catalog/advanced?op=must&clause[1][field]=title&clause[1]query=medicine&f_inclusive[language_ssim][]=Tibetan&sort=author'
     end
 
-    it "does not create hidden inputs for search fields" do
+    it 'prepopulates the expected fields' do
       expect(page).to have_field 'Title', with: 'medicine'
+      expect(page).to have_field 'Tibetan', checked: true
+      expect(page).to have_select 'op', selected: 'all'
+      expect(page).to have_select 'sort', selected: 'author'
+    end
+
+    it "does not create hidden inputs for fields included in adv search form" do
+      within('form.advanced') do
+        expect(page).to have_no_field('clause[1][query]', type: :hidden, with: 'medicine')
+        expect(page).to have_no_field('f_inclusive[language_ssim][]', type: :hidden, with: 'Tibetan')
+        expect(page).to have_no_field('op', type: :hidden, with: 'must')
+        expect(page).to have_no_field('sort', type: :hidden, with: 'author')
+      end
     end
 
     it "does not have multiple parameters for a search field" do
@@ -121,8 +133,10 @@ RSpec.describe "Blacklight Advanced Search Form" do
 
     it "clears the prepopulated fields when the Start Over button is pressed" do
       expect(page).to have_field 'Title', with: 'medicine'
+      expect(page).to have_field 'Tibetan', checked: true
       click_on 'Start over'
       expect(page).to have_no_field 'Title', with: 'medicine'
+      expect(page).to have_no_field 'Tibetan', checked: true
     end
   end
 end

--- a/spec/presenters/blacklight/facet_checkbox_item_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_checkbox_item_presenter_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::FacetCheckboxItemPresenter, type: :presenter do
+  subject(:presenter) do
+    described_class.new(facet_item, facet_config, view_context, facet_field, search_state)
+  end
+
+  let(:facet_item) { Blacklight::Solr::Response::Facets::FacetItem.new(value: 'Book', hits: 30) }
+  let(:facet_config) { Blacklight::Configuration::FacetField.new(key: 'format') }
+  let(:view_context) { controller.view_context }
+  let(:filter_field) { Blacklight::SearchState::FilterField.new(facet_config, search_state) }
+  let(:facet_field) { Blacklight::Solr::Response::Facets::FacetField.new('format', [facet_item]) }
+  let(:params) { ActionController::Parameters.new(f_inclusive: { format: ["Book"] }) }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:search_state) { Blacklight::SearchState.new(params, blacklight_config) }
+
+  before do
+    blacklight_config.add_facet_field 'format'
+  end
+
+  describe '#selected?' do
+    subject { presenter.selected? }
+
+    context 'with a matching inclusive filter' do
+      it 'returns true' do
+        expect(subject).to be true
+      end
+    end
+
+    context 'with an inclusive filter that does not match' do
+      let(:params) { ActionController::Parameters.new(f_inclusive: { format: ["Manuscript"] }) }
+
+      it 'returns true' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'with a matching exclusive filter' do
+      let(:params) { ActionController::Parameters.new(f: { format: ["Book"] }) }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/spec/presenters/blacklight/facet_checkbox_item_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_checkbox_item_presenter_spec.rb
@@ -24,25 +24,19 @@ RSpec.describe Blacklight::FacetCheckboxItemPresenter, type: :presenter do
     subject { presenter.selected? }
 
     context 'with a matching inclusive filter' do
-      it 'returns true' do
-        expect(subject).to be true
-      end
+      it { is_expected.to be true }
     end
 
     context 'with an inclusive filter that does not match' do
       let(:params) { ActionController::Parameters.new(f_inclusive: { format: ["Manuscript"] }) }
 
-      it 'returns true' do
-        expect(subject).to be false
-      end
+      it { is_expected.to be false }
     end
 
     context 'with a matching exclusive filter' do
       let(:params) { ActionController::Parameters.new(f: { format: ["Book"] }) }
 
-      it 'returns false' do
-        expect(subject).to be false
-      end
+      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
closes #3237, #3238 

### Changes
- excludes adv search form parameters from hidden search fields to prevent duplicate query params 
- pre selects facet appropriate facet checkbox _only_ when receiving inclusive filter parameters
  - implements check using new `FacetCheckboxItemPresenter` that overrides `#selected?`
- increases spec coverage when prepopulating adv search form
- adds specs for new presenter 

### Questions
I have a couple lingering questions that would help clarify my understanding of the expected behavior of the adv search and provide additional context for a review: 

Currently, incoming exclusive filter parameters will pre-check the corresponding facet checkbox. This PR prevents this behavior, and now any incoming exclusive filters will continue to be added as a hidden field. What is the desired behavior around incoming exclusive filters? In my opinion, the facet checkboxes represent inclusive filters, so it's a bit misleading to have them pre selected with an incoming exclusive filter. Any thoughts on this?

Currently, we exclude incoming inclusive parameters from the displayed constraints on the adv search page. This PR does not change this, but is this desired behavior? 