### PR TITLE
Move the component override to the test

### DIFF
--- a/spec/features/component_template_override_spec.rb
+++ b/spec/features/component_template_override_spec.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Generated test application template at default path' do
+  let(:target_template) { File.join('.internal_test_app', 'app', 'components', 'blacklight', 'top_navbar_component.html.erb') }
+
+  before do
+    FileUtils.mkdir_p('.internal_test_app/app/components/blacklight')
+    src_template = File.join(Blacklight::Engine.root, 'app', 'components', 'blacklight', 'top_navbar_component.html.erb')
+    contents = File.read(src_template).gsub('role="navigation"', 'role="navigation" data-template-override="top_navbar_component"')
+    File.write(target_template, contents)
+  end
+
+  after do
+    FileUtils.rm(target_template)
+  end
+
   it 'unobtrusively overrides default top navbar component template' do
     visit root_path
     expect(page).to have_css 'nav[data-template-override="top_navbar_component"]'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -34,12 +34,4 @@ class TestAppGenerator < Rails::Generators::Base
 
     run "yarn add #{Blacklight::Engine.root}"
   end
-
-  def add_component_template_override
-    src_template = File.join(Blacklight::Engine.root, 'app', 'components', 'blacklight', 'top_navbar_component.html.erb')
-    target_template = File.join('app', 'components', 'blacklight', 'top_navbar_component.html.erb')
-    create_file(target_template) do
-      File.read(src_template).gsub('role="navigation"', 'role="navigation" data-template-override="top_navbar_component"')
-    end
-  end
 end


### PR DESCRIPTION
And out of the test app generator.  This helps keep the pieces that depend on each other proxmially located