### PR TITLE
Remove unused parameter.

### DIFF
--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,4 +1,4 @@
 <div id="sortAndPerPage" class="sort-pagination d-md-flex justify-content-between" role="navigation" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
-  <%= render partial: "paginate_compact", object: @response if show_pagination? %>
+  <%= render "paginate_compact" if show_pagination? %>
   <%= render_results_collection_tools wrapping_class: "search-widgets" %>
 </div>


### PR DESCRIPTION
`render` doesn't do anything with an `object` argument