### PR TITLE
Ensure the matching version of the assets package is installed

### DIFF
--- a/lib/generators/blacklight/assets/propshaft_generator.rb
+++ b/lib/generators/blacklight/assets/propshaft_generator.rb
@@ -7,7 +7,7 @@ module Blacklight
         if ENV['CI']
           run "yarn add file:#{Blacklight::Engine.root}"
         else
-          run 'yarn add blacklight-frontend'
+          run "yarn add blacklight-frontend@#{Blacklight::VERSION}"
         end
       end
 


### PR DESCRIPTION
Because the "latest" npm package version is not related to the newest semver version, doing a `yarn add blacklight-frontend`  with no version specifier currently results in retrieving v7.38.0, even though versions for v8.x are published. 

This means a new Blacklight 8 app with propshaft will not retrieve the correct asset package.

This ensures that we get the npm asset version that matches Blacklight's version by asking for it explicitly, even if it has not been marked `latest`. If there is a mismatch between npm package versions and Blacklight gem versions, we'll get an error.