### PR TITLE
Enable overriding the method that renders the field

### DIFF
--- a/app/components/blacklight/metadata_field_component.html.erb
+++ b/app/components/blacklight/metadata_field_component.html.erb
@@ -3,6 +3,6 @@
     <%= label %>
   <% end %>
   <% component.with_value do %>
-    <%= @field.render %>
+    <%= render_field %>
   <% end %>
 <% end %>

--- a/app/components/blacklight/metadata_field_component.rb
+++ b/app/components/blacklight/metadata_field_component.rb
@@ -26,6 +26,11 @@ module Blacklight
       @field.render_field?
     end
 
+    # Override this method in a subclass to change the way this value is rendered
+    def render_field
+      @field.render
+    end
+
     ##
     # Render the index field label for a document
     #


### PR DESCRIPTION
This enables us to provide a custom component to add_show_field, that inherits most of MetadataFieldComponet, but overrides the rendering of the value