### PR TITLE
Address Style/EmptyLiteral rubocop failure

### DIFF
--- a/app/models/concerns/blacklight/document/semantic_fields.rb
+++ b/app/models/concerns/blacklight/document/semantic_fields.rb
@@ -31,16 +31,19 @@ module Blacklight::Document
     # but extensions should call super and modify hash returned, to avoid
     # unintentionally erasing values provided by other extensions.
     def to_semantic_values
-      @semantic_value_hash ||= self.class.field_semantics.each_with_object(Hash.new([])) do |(key, field_names), hash|
-        ##
-        # Handles single string field_name or an array of field_names
-        value = Array.wrap(field_names).map { |field_name| self[field_name] }.flatten.compact
+      @semantic_value_hash ||= begin
+        new_hash = {}
+        new_hash.default = []
+        self.class.field_semantics.each_with_object(new_hash) do |(key, field_names), hash|
+          ##
+          # Handles single string field_name or an array of field_names
+          value = Array.wrap(field_names).map { |field_name| self[field_name] }.flatten.compact
 
-        # Make single and multi-values all arrays, so clients
-        # don't have to know.
-        hash[key] = value unless value.empty?
+          # Make single and multi-values all arrays, so clients
+          # don't have to know.
+          hash[key] = value unless value.empty?
+        end
       end
-
       @semantic_value_hash ||= {}
     end
   end


### PR DESCRIPTION
Version 1.66.0 of rubocop is stricter in its Style/EmptyLiteral rule. See https://github.com/rubocop/rubocop/blob/master/relnotes/v1.66.0.md?plain=1

Steps to recreate:
1. Clone the blacklight git repo
2. Delete the Gemfile.lock file if it exists
3. bundle install
4. bundle exec rubocop
5. Note that without this patch, you get a rubocop complaint.