### PR TITLE
adding option for single page count

### DIFF
--- a/app/components/blacklight/search_context/server_item_pagination_component.rb
+++ b/app/components/blacklight/search_context/server_item_pagination_component.rb
@@ -12,7 +12,11 @@ module Blacklight
       end
 
       def render?
-        @search_context.present? && (@search_context[:prev] || @search_context[:next]) && (@search_session['document_id'] == @current_document_id)
+        return false unless (@search_session['document_id'] == @current_document_id)
+
+        return true if total == 1
+        
+        @search_context.present? && (@search_context[:prev] || @search_context[:next]) 
       end
 
       ##
@@ -20,25 +24,34 @@ module Blacklight
       #
       # @return [String]
       def item_page_entry_info
-        t('blacklight.search.entry_pagination_info.other', current: number_with_delimiter(count),
+        t('blacklight.search.entry_pagination_info.other', current: current_count,
                                                            total: number_with_delimiter(total),
                                                            count: total).html_safe
       end
 
       def link_to_previous_document(previous_document = nil, classes: 'previous', **link_opts)
+        return if total == 1
+
         previous_document ||= @search_context[:prev]
         link_opts = session_tracking_params(previous_document, count - 1, per_page: per_page, search_id: search_id).merge(class: classes, rel: 'prev').merge(link_opts)
+       
         link_to_unless previous_document.nil?, raw(t('views.pagination.previous')), url_for_document(previous_document), link_opts do
           tag.span raw(t('views.pagination.previous')), class: 'previous'
         end
       end
 
       def link_to_next_document(next_document = nil, classes: 'next', **link_opts)
+        return if total == 1
+        
         next_document ||= @search_context[:next]
         link_opts = session_tracking_params(next_document, count + 1, per_page: per_page, search_id: search_id).merge(class: classes, rel: 'next').merge(link_opts)
         link_to_unless next_document.nil?, raw(t('views.pagination.next')), url_for_document(next_document), link_opts do
           tag.span raw(t('views.pagination.next')), class: 'next'
         end
+      end
+
+      def current_count
+        (total == 1)? total : number_with_delimiter(count)
       end
 
       private

--- a/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
+++ b/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe Blacklight::SearchContext::ServerItemPaginationComponent, type: :
     end
   end
 
+  context 'when there is exactly one search result with no next or previous document' do
+    let(:search_context) { {} }
+    let(:search_session) { { 'document_id' => current_document_id, 'total' => '1' } }
+
+    it "renders single page count" do
+      expect(render.to_html).to include '<strong>1</strong> of <strong>1</strong>'
+      expect(render.css('span.previous').to_html).to be_blank
+      expect(render.css('span.next').to_html).to be_blank
+    end
+  end
+
   context 'when there is next and previous' do
     let(:search_context) { { next: next_doc, prev: prev_doc } }
     let(:prev_doc) { SolrDocument.new(id: '777') }


### PR DESCRIPTION
What this pull request does:

Adds a check to see if there is only one search result, and shows "1 of 1" in the view without showing previous or next links.
Adds a test for this particular case. 

Closes #3314 .
Addresses a ticket in EarthWorks: https://github.com/sul-dlss/earthworks/issues/1367 