### PR TITLE
Change bookmarkCounter to find multiple selectors

### DIFF
--- a/app/javascript/blacklight/checkbox_submit.js
+++ b/app/javascript/blacklight/checkbox_submit.js
@@ -37,7 +37,9 @@ export default class CheckboxSubmit {
       this.labelTarget.removeAttribute('disabled')
       this.checkboxTarget.removeAttribute('disabled')
       this.updateStateFor(!this.checked)
-      if (this.bookmarkCounter()) this.bookmarkCounter().innerHTML = json.bookmarks.count
+      this.bookmarksCounter().forEach(counter => {
+        counter.innerHTML = json.bookmarks.count;
+      });
     }).catch((error) => {
       this.handleError(error)
     })
@@ -63,8 +65,8 @@ export default class CheckboxSubmit {
     return this.form.querySelector('[data-checkboxsubmit-target="span"]')
   }
 
-  bookmarkCounter() {
-    return document.querySelector('[data-role="bookmark-counter"]')
+  bookmarksCounter() {
+    return document.querySelectorAll('[data-role="bookmark-counter"]')
   }
 
   handleError() {


### PR DESCRIPTION
This commit will change the bookmarkCounter function to look for multiple selectors instead of one.  This way if we want to put the bookmark counter elsewhere it will also be dynamic.

Ref:
- https://github.com/projectblacklight/blacklight/issues/3350

![bl-bookmark-pr](https://github.com/user-attachments/assets/c91143e3-e9b6-4a1d-8ca9-12189394b6f7)
