### PR TITLE
Swap order of skip links so main content comes first

### DIFF
--- a/app/components/blacklight/skip_link_component.html.erb
+++ b/app/components/blacklight/skip_link_component.html.erb
@@ -1,7 +1,7 @@
 <nav id="skip-link" role="navigation" class="visually-hidden-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
   <div class="container-xl">
-    <%= link_to_search %>
     <%= link_to_main %>
+    <%= link_to_search %>
     <%= content %>
   </div>
 </nav>


### PR DESCRIPTION
Some accessibility checkers, like SiteImprove, regard it as a
failure that the 'skip to main' link is not the first focusable
element on the page.

This swaps the order of the 'skip to main' and 'skip to search'
links so that 'skip to main' comes first, which is in line with
the WCAG 2.2 guidelines
(https://www.w3.org/WAI/WCAG22/Techniques/general/G1.html).

Related: https://github.com/sul-dlss/earthworks/issues/1431
