### PR TITLE
Rename 'Blacklight' inside of core.js as 'Core'

### DIFF
--- a/app/javascript/blacklight/core.js
+++ b/app/javascript/blacklight/core.js
@@ -1,4 +1,4 @@
-const Blacklight = function() {
+const Core = function() {
   const buffer = new Array;
   return {
     onLoad: function(func) {
@@ -34,13 +34,13 @@ const Blacklight = function() {
 
 // turbolinks triggers page:load events on page transition
 // If app isn't using turbolinks, this event will never be triggered, no prob.
-Blacklight.listeners().forEach(function(listener) {
+Core.listeners().forEach(function(listener) {
   document.addEventListener(listener, function() {
-    Blacklight.activate()
+    Core.activate()
   })
 })
 
-Blacklight.onLoad(function () {
+Core.onLoad(function () {
   const elem = document.querySelector('.no-js');
 
   // The "no-js" class may already have been removed because this function is
@@ -52,4 +52,4 @@ Blacklight.onLoad(function () {
 })
 
 
-export default Blacklight
+export default Core


### PR DESCRIPTION
When bundled into one file such as the 'blacklight.esm.js' being produced, it was resulting in a conflict with top-level Blacklight module, and resulting in error `'Uncaught TypeError: Blacklight.activate is not a function'`

While Javascript modules are normally isolated namespaces and you wouldn't expect a conflict, something about how bundlers end up bundling them together means that when the onload callback is actually called (at runtime, after the bundle has been bundled), and tries to call `Blacklight`, it ends up refering to a different top-level 'Blacklight' module -- one that doens't have an 'activate' property, instead has 'Core', 'Modal', etc -- the default exports.  Instead of capturing the local one under closure as desired. 


https://github.com/projectblacklight/blacklight/blob/04e3cf0250bf2538d2a36060fe5f5de28052cbdc/app/javascript/blacklight/core.js#L37-L41

The current produced 'blacklight.esm.js' file is not actually useable (also in BL8).  This makes it useable again. 


The problem is present in the produced ./app/assets/javascripts/blacklight/blacklight.esm.js file which this gem already produces (using rollup), and I think I also reproduced it with esbuild. 

Renaming to const name to `Core` to avoid a conflict seems to resolve the problem -- and follows the pattern in all of the other module files. 

It should not cause a problem or be backwards incompatible for anyone else using ESM modules (including `importmap-rails`!), precisely because the names inside the module are _supposed_ to be isolated inside the module, the exports are still the same and still used the same. In my manual tests it seemed to be good, and should also be demonstrated not causing a problem by tests being green here hopefully!

I plan to backport this to BL8 if/once merged!
