### PR TITLE
Backport: 'Blacklight' inside of core.js as 'Core'

### DIFF
--- a/app/javascript/blacklight/core.js
+++ b/app/javascript/blacklight/core.js
@@ -1,4 +1,4 @@
-const Blacklight = function() {
+const Core = function() {
   const buffer = new Array;
   return {
     onLoad: function(func) {
@@ -34,13 +34,13 @@ const Blacklight = function() {
 
 // turbolinks triggers page:load events on page transition
 // If app isn't using turbolinks, this event will never be triggered, no prob.
-Blacklight.listeners().forEach(function(listener) {
+Core.listeners().forEach(function(listener) {
   document.addEventListener(listener, function() {
-    Blacklight.activate()
+    Core.activate()
   })
 })
 
-Blacklight.onLoad(function () {
+Core.onLoad(function () {
   const elem = document.querySelector('.no-js');
 
   // The "no-js" class may already have been removed because this function is
@@ -52,4 +52,4 @@ Blacklight.onLoad(function () {
 })
 
 
-export default Blacklight
+export default Core


### PR DESCRIPTION
Backport of #3355 to 8.x, much discussion there. 

When bundled into one file such as the 'blacklight.esm.js' this file produces, it was resulting in a conflict with top-level Blacklight module, and resulting in error 'Uncaught TypeError: Blacklight.activate is not a function'
