### PR TITLE
Remove role=treeitem

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -144,7 +144,7 @@
     align-items: flex-start;
     padding: 3px 0;
 
-    &[role="treeitem"] {
+    &.treeitem {
       display: block;
     }
 

--- a/app/components/blacklight/facet_item_pivot_component.rb
+++ b/app/components/blacklight/facet_item_pivot_component.rb
@@ -32,7 +32,7 @@ module Blacklight
 
       id = "h-#{self.class.mint_id}" if @collapsing && has_items?
 
-      content_tag @wrapping_element, role: 'treeitem', class: 'treeitem' do
+      content_tag @wrapping_element, class: 'treeitem' do
         concat(content_tag('span', class: "d-flex flex-row align-items-center") do
           concat facet_toggle_button(id) if has_items? && @collapsing
           concat content_tag('span', render(facet), class: "facet-values d-flex flex-row flex-grow-1 #{'facet-leaf-node' if has_items? && @collapsing}", id: id && "#{id}_label")


### PR DESCRIPTION
This was causing an accessability violation, because treeitems must be a child of a tree. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role