### PR TITLE
Test with esbuild/propshaft including both Rails 7.2 and 8.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test (ruby ${{ matrix.ruby }} / rails ${{ matrix.rails_version }} ${{ matrix.additional_name }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["3.3"]
         rails_version: ["7.0.8.4", "7.1.3.4", "7.2.0"]
@@ -46,6 +47,10 @@ jobs:
           - ruby: "3.3"
             rails_version: "8.0.0.beta1"
             additional_engine_cart_rails_options: --css=bootstrap
+          - ruby: "3.3"
+            rails_version: "8.0.0.beta1"
+            additional_engine_cart_rails_options: --css=bootstrap --js=esbuild
+            additional_name: "/ esbuild"
           - ruby: "3.2"
             rails_version: "7.0.8.4"
           - ruby: "3.2"
@@ -63,6 +68,10 @@ jobs:
             api: "true"
             additional_engine_cart_rails_options: --api --skip-yarn
             additional_name: "/ API"
+          - ruby: "3.3"
+            rails_version: "7.2.1"
+            additional_engine_cart_rails_options: -a propshaft --css=bootstrap --js=esbuild
+            additional_name: "/ Propshaft, esbuild"
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       SOLR_VERSION: ${{ matrix.solr_version || 'latest' }}


### PR DESCRIPTION
Adding esbuild to test matrix -- as long as it's with propshaft, **it just passes with no code-changes** on main in **both Rails 7 and Rails 8**, because in fact the existing [propshaft_generator](https://github.com/projectblacklight/blacklight/blob/main/lib/generators/blacklight/assets/propshaft_generator.rb) is _really_ a YarnPackageGenerator -- it works with anything that wants NPM dependencies added with `yarn add` to a package.json. 

Apparently that includes some propshaft setups, but it also includes ESBuild setups. 

I think that means it would work in Rails 7 with **sprockets** and  esbuild as well (or any `jsbundling-rails` option using `yarn` -- that is, any but `bun`: esbuild, rollup, or webpack.  

Before merging we can discuss at community meeting to make sure there is agreement on the project taking this on. 

If we do want to merge this, I would after that try an additional suggested PR that renames PropshaftGenerator to say YarnPackageGenerator;  adds explicit options to choose which kind of asset generator you want if the default guesses aren't right (say you have importmaps AND sprockets AND esbuild, it is possible!); and adds another clause to default choice too to make it easier for us to test Rails 7+sprockets+esbuild too. 
