### PR TITLE
Use a valid command to test for the existence of docker compose

### DIFF
--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -24,7 +24,7 @@ def with_solr(&block)
   # We're being invoked by the app entrypoint script and solr is already up via docker compose
   if ENV['SOLR_ENV'] == 'docker-compose'
     yield
-  elsif system('docker compose -v')
+  elsif system('docker compose version')
     # We're not running `docker compose up' but still want to use a docker instance of solr.
     begin
       puts "Starting Solr"


### PR DESCRIPTION
docker compose -v was not a valid command, it produces the docker compose help text