### PR TITLE
Precompile assets for propshaft

### DIFF
--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -47,8 +47,8 @@ task ci: ['build:npm'] do
   with_solr do
     Rake::Task['blacklight:internal:seed'].invoke
     within_test_app do
-      # Precompiles the javascript
-      system "bin/rake spec:prepare"
+      # Precompiles the assets
+      system "bin/rake assets:precompile" # Required due to https://github.com/rails/propshaft/issues/211
     end
     Rake::Task['blacklight:coverage'].invoke
   end


### PR DESCRIPTION
Propshaft's server does not run when `config.eager_load = true`, which is the default behavior when running in CI.  See https://github.com/rails/propshaft/issues/211