### PR TITLE
Workaround bug in devise

### DIFF
--- a/lib/generators/blacklight/user_generator.rb
+++ b/lib/generators/blacklight/user_generator.rb
@@ -35,6 +35,8 @@ module Blacklight
       generate "devise_guests", model_name.classify
 
       gsub_file("config/initializers/devise.rb", "config.sign_out_via = :delete", "config.sign_out_via = :get")
+      # Work around for https://github.com/heartcombo/devise/issues/5720
+      gsub_file("config/initializers/devise.rb", "# config.reload_routes = true", "config.reload_routes = false")
     end
 
     # Add Blacklight to the user model

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -48,7 +48,7 @@ task ci: ['build:npm'] do
     Rake::Task['blacklight:internal:seed'].invoke
     within_test_app do
       # Precompiles the assets
-      system "bin/rake assets:precompile" # Required due to https://github.com/rails/propshaft/issues/211
+      system "bin/rake spec:prepare"
     end
     Rake::Task['blacklight:coverage'].invoke
   end


### PR DESCRIPTION
We previously thought there was a bug in Rails or Propshaft which we were working around by precompiling assets in test.  However, further analysis led us to conclude the problem is really in the default configuration for Devise.  It prevents other engines (like propshaft) from loading their routes when config.eager_load=true

See https://github.com/heartcombo/devise/issues/5720