### PR TITLE
[release-8.x branch] Don't include blacklight js twice when using Sprockets

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -18,7 +18,6 @@
       <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <% else %>
       <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-      <%= javascript_include_tag "blacklight/blacklight", type: 'module' %>
       <script type="module">
         import githubAutoCompleteElement from 'https://cdn.skypack.dev/@github/auto-complete-element';
       </script>


### PR DESCRIPTION
As @mamrey noted on #3263, this can lead to a user being unable to add bookmarks, since the relevant eventlistener is added twice, so every time the user clicks to add a bookmark, the toggle function is run twice, essentially doing nothing.

This bug (and fix) only affect Sprockets -- when using Importmap or Propshaft, this branch of the view isn't even reached.