### PR TITLE
Directly use the visually-hidden class

### DIFF
--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -28,10 +28,6 @@
 
 .view-type {
   display: inline-block;
-
-  .caption {
-    @extend .visually-hidden !optional;
-  }
 }
 
 .search-input-group {

--- a/app/components/blacklight/response/view_type_button_component.html.erb
+++ b/app/components/blacklight/response/view_type_button_component.html.erb
@@ -1,4 +1,4 @@
 <%= link_to url, title: label, class: "#{Array(@classes).join(' ')} view-type-#{ @key.to_s.parameterize } #{"active" if selected?}" do %>
   <%= icon %>
-  <span class="caption"><%= label %></span>
+  <span class="caption visually-hidden"><%= label %></span>
 <% end %>


### PR DESCRIPTION
This allows us to remove a SASS @extend, which will allow us to decouple from SASS