### PR TITLE
Remove breakpoint specific visually hidden styles

### DIFF
--- a/app/assets/stylesheets/blacklight/_blacklight_base.scss
+++ b/app/assets/stylesheets/blacklight/_blacklight_base.scss
@@ -6,8 +6,7 @@
    which over-rides things in this file. Or of course you can choose
    not to use the Blacklight CSS file at all in your local app. */
 
-@import "mixins";
-@import 'blacklight_defaults';
+@import "blacklight_defaults";
 @import "bootstrap_overrides";
 @import "layout";
 @import "header";

--- a/app/assets/stylesheets/blacklight/_mixins.scss
+++ b/app/assets/stylesheets/blacklight/_mixins.scss
@@ -1,9 +1,0 @@
-// define a visually-hidden class that applies to a given breakpoint and below
-// https://getbootstrap.com/docs/5.3/helpers/visually-hidden/
-@each $breakpoint in map-keys($grid-breakpoints) {
-  .visually-hidden-#{$breakpoint} {
-    @include media-breakpoint-down($breakpoint) {
-      @include visually-hidden;
-    }
-  }
-}

--- a/app/components/blacklight/search_button_component.rb
+++ b/app/components/blacklight/search_button_component.rb
@@ -8,8 +8,8 @@ module Blacklight
     end
 
     def call
-      tag.button(class: 'btn btn-primary search-btn', type: 'submit', id: @id) do
-        tag.span(@text, class: "visually-hidden-sm me-sm-1 submit-search-text") +
+      tag.button(class: 'btn btn-primary search-btn', type: 'submit', id: @id, aria: { label: @text }) do
+        tag.span(@text, class: "d-none d-md-inline me-sm-1 submit-search-text", aria: { hidden: true }) +
           render(Blacklight::Icons::SearchComponent.new)
       end
     end


### PR DESCRIPTION
We added the whole collection of these, but we only ever used it once.  It's much simpler to just style this element independently