### PR TITLE
Extract styles applied at all breakpoints

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -43,17 +43,16 @@
 }
 
 .facets-toggleable {
+  border: var(--bl-facets-smallish-border);
+  padding: var(--bl-facets-smallish-padding);
+  margin-bottom: var(--bl-facets-smallish-margin-bottom);
+  border-radius: var(--bl-facets-smallish-border-radius);
+
   @each $breakpoint in map-keys($grid-breakpoints) {
     $next: breakpoint-next($breakpoint, $grid-breakpoints);
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     &#{$infix} {
-      @include media-breakpoint-down($next) {
-        border: var(--bl-facets-smallish-border);
-        padding: var(--bl-facets-smallish-padding);
-        margin-bottom: var(--bl-facets-smallish-margin-bottom);
-        border-radius: var(--bl-facets-smallish-border-radius);
-      }
       @include media-breakpoint-up($next) {
         // scss-lint:disable ImportantRule
         .facets-collapse {

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -47,26 +47,6 @@
   padding: var(--bl-facets-smallish-padding);
   margin-bottom: var(--bl-facets-smallish-margin-bottom);
   border-radius: var(--bl-facets-smallish-border-radius);
-
-  @each $breakpoint in map-keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-    &#{$infix} {
-      @include media-breakpoint-up($next) {
-        // scss-lint:disable ImportantRule
-        .facets-collapse {
-          display: block !important;
-          width: 100%;
-        }
-        // scss-lint:enable ImportantRule
-
-        .navbar-toggler {
-          display: none;
-        }
-      }
-    }
-  }
 }
 
 .no-js {

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -4,7 +4,7 @@
     <%= content_tag :h2, @title, class: 'facets-heading h4' if @title %>
 
     <%= content_tag :button,
-      class:'navbar-toggler navbar-toggler-right',
+      class:'navbar-toggler navbar-toggler-right d-block d-lg-none',
       type: 'button',
       data: {
         toggle: 'collapse',
@@ -21,7 +21,7 @@
     <% end %>
   </div>
 
-  <div id="<%= @panel_id %>" class="facets-collapse collapse">
+  <div id="<%= @panel_id %>" class="facets-collapse d-lg-block collapse">
     <%= body %>
   </div>
 <% end %>


### PR DESCRIPTION
So we don't repeat it 6 times in the compiled css. Perfer to use bootstrap classes over custom scss code.