### PR TITLE
Show the item page information even if there's only one result

### DIFF
--- a/app/components/blacklight/search_context/server_item_pagination_component.html.erb
+++ b/app/components/blacklight/search_context/server_item_pagination_component.html.erb
@@ -1,7 +1,11 @@
 <div class="search-context page-links">
-  <%= link_to_previous_document %> |
+  <% if total == 1 %>
+    <%= item_page_entry_info %>
+  <% else %>
+    <%= link_to_previous_document %> |
 
-  <%= item_page_entry_info %> |
+    <%= item_page_entry_info %> |
 
-  <%= link_to_next_document %>
+    <%= link_to_next_document %>
+  <% end %>
 </div>

--- a/app/components/blacklight/search_context/server_item_pagination_component.rb
+++ b/app/components/blacklight/search_context/server_item_pagination_component.rb
@@ -12,7 +12,7 @@ module Blacklight
       end
 
       def render?
-        @search_context.present? && (@search_context[:prev] || @search_context[:next]) && (@search_session['document_id'] == @current_document_id)
+        @search_context.present? && (@search_context[:prev] || @search_context[:next] || total.positive?) && (@search_session['document_id'] == @current_document_id)
       end
 
       ##

--- a/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
+++ b/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Blacklight::SearchContext::ServerItemPaginationComponent, type: :
 
   let(:current_document_id) { 9 }
   let(:current_document) { SolrDocument.new(id: current_document_id) }
-  let(:search_session) { { 'document_id' => current_document_id } }
+  let(:search_session) { { 'document_id' => current_document_id, 'counter' => 1, 'total' => '3' } }
   let(:instance) { described_class.new(search_context: search_context, search_session: search_session, current_document: current_document) }
 
   before do
@@ -20,6 +20,17 @@ RSpec.describe Blacklight::SearchContext::ServerItemPaginationComponent, type: :
 
     it "does not render content" do
       expect(render.to_html).to be_blank
+    end
+  end
+
+  context 'when there is exactly one search result with no next or previous document' do
+    let(:search_context) { { prev: nil, next: nil } }
+    let(:search_session) { { 'document_id' => current_document_id, 'counter' => 1, 'total' => '1' } }
+
+    it "renders single page count" do
+      expect(render.to_html).to include '<strong>1</strong> of <strong>1</strong>'
+      expect(render.css('span.previous').to_html).to be_blank
+      expect(render.css('span.next').to_html).to be_blank
     end
   end
 


### PR DESCRIPTION
fixes #3314

This is an alternative to https://github.com/projectblacklight/blacklight/pull/3315 trying  to address jcoyne's comment: https://github.com/projectblacklight/blacklight/pull/3315#discussion_r1761250210

