### PR TITLE
Remove unnecessary styles

### DIFF
--- a/app/assets/stylesheets/blacklight/_icons.scss
+++ b/app/assets/stylesheets/blacklight/_icons.scss
@@ -1,11 +1,3 @@
-.btn.btn-icon {
-  padding: $btn-padding-y;
-
-  &.btn-sm {
-    padding: $btn-padding-y-sm;
-  }
-}
-
 .remove .bi {
   height: 1em;
   width: 1em;


### PR DESCRIPTION
Bootstrap already handles padding on .btn.  We never use .btn-sm in Blacklight.