### PR TITLE
Revert + revise "Deprecate render_document_sidebar_partial and catalog/show_sidebar partial"

### DIFF
--- a/app/helpers/blacklight/document_helper_behavior.rb
+++ b/app/helpers/blacklight/document_helper_behavior.rb
@@ -31,10 +31,15 @@ module Blacklight::DocumentHelperBehavior
   # See: https://github.com/geoblacklight/geoblacklight/blob/7d3c31c7af3362879b97e2c1351a2496c728c59c/app/helpers/blacklight_helper.rb#L7
   #
   # @param [SolrDocument] document
+  # @deprecated
   # @return [String]
   def render_document_sidebar_partial(document)
     render 'show_sidebar', document: document
   end
+
+  Blacklight.deprecation.deprecate_methods(self,
+                                           render_document_sidebar_partial: 'has been replaced by calling the sidebar component (Blacklight::Search::SidebarComponent) directly. ' \
+                                                                            'Set sidebar_component in the view config.')
 
   ##
   # return the Bookmarks on a set of documents (all bookmarks on the page)

--- a/app/helpers/blacklight/document_helper_behavior.rb
+++ b/app/helpers/blacklight/document_helper_behavior.rb
@@ -35,9 +35,6 @@ module Blacklight::DocumentHelperBehavior
   def render_document_sidebar_partial(document)
     render 'show_sidebar', document: document
   end
-  Blacklight.deprecation.deprecate_methods(self,
-                                           render_document_sidebar_partial: 'has been replaced by calling the sidebar component (Blacklight::Search::SidebarComponent) directly. ' \
-                                                                            'Set sidebar_component in the view config.')
 
   ##
   # return the Bookmarks on a set of documents (all bookmarks on the page)

--- a/app/helpers/blacklight/document_helper_behavior.rb
+++ b/app/helpers/blacklight/document_helper_behavior.rb
@@ -34,6 +34,15 @@ module Blacklight::DocumentHelperBehavior
   # @deprecated
   # @return [String]
   def render_document_sidebar_partial(document)
+    unless @render_document_sidebar_partials_deprecation_warning_shown
+      partials = lookup_context.find_all('show_sidebar', lookup_context.prefixes, true, [], {})
+      unless partials.first.identifier.starts_with? Blacklight.root
+        Blacklight.deprecation.warn('The partial catalog/_show_sidebar.html.erb will not be rendered by #render_document_sidebar_partial in Blacklight 9.0.' \
+                                    'Configure blacklight_config.show.sidebar_component instead (default Blacklight::Search::SidebarComponent).')
+        @render_document_sidebar_partials_deprecation_warning_shown = true
+      end
+    end
+
     render 'show_sidebar', document: document
   end
 

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,3 +1,2 @@
-<% Blacklight.deprecation.warn('The partial catalog/_show_sidebar.html.erb will be removed in Blacklight 9.0. Configure blacklight_config.show.sidebar_component instead (default Blacklight::Search::SidebarComponent).') unless local_assigns[:silence_deprecation] %>
 <% presenter = document_presenter(document) %>
 <%= render presenter.view_config.sidebar_component.new(presenter: presenter) %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,2 +1,3 @@
+<% Blacklight.deprecation.warn('The partial catalog/_show_sidebar.html.erb will be removed in Blacklight 9.0. Configure blacklight_config.show.sidebar_component instead (default Blacklight::Search::SidebarComponent).') unless local_assigns[:silence_deprecation] %>
 <% presenter = document_presenter(document) %>
 <%= render presenter.view_config.sidebar_component.new(presenter: presenter) %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,6 +1,5 @@
 <%= render 'show_main_content' %>
 
 <% content_for(:sidebar) do %>
-  <% presenter = document_presenter(@document) %>
-  <%= render presenter.view_config.sidebar_component.new(presenter: presenter) %>
+  <%= render_document_sidebar_partial @document %>
 <% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,7 @@
 <%= render 'show_main_content' %>
 
 <% content_for(:sidebar) do %>
-  <%= render_document_sidebar_partial @document %>
+  <% Blacklight.deprecation.silence do %>
+    <%= render_document_sidebar_partial @document %>
+  <% end %>
 <% end %>

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "catalog/show.html.erb" do
 
   before do
     allow(presenter).to receive(:html_title).and_return('Heading')
-    allow(document).to receive(:more_like_this).and_return([])
     allow(view).to receive_messages(has_user_authentication_provider?: false)
+    allow(view).to receive_messages(render_document_sidebar_partial: "Sidebar")
     allow(view).to receive_messages(current_search_session: nil, search_session: {})
     assign :document, document
     allow(view).to receive_messages(document_presenter: presenter, action_name: 'show', blacklight_config: blacklight_config)


### PR DESCRIPTION
This reverts commit a1f8edf8880542ae27264586163b19d1517d91a9.

This commit breaks backwards compatibility for applications that have overridden render_document_sidebar_partial (or show_sidebar), like applications like the geoblacklight example in the commit comment:

https://github.com/geoblacklight/geoblacklight/blob/7d3c31c7af3362879b97e2c1351a2496c728c59c/app/helpers/blacklight_helper.rb#L7

(Although geoblacklight 5 uses a custom sidebar component, requiring  some work in the downstream gem/app seems like a big problem to me, so maybe this isn't ripe for deprecation in 8.x or needs a more sophisticated deprecation path.)