### PR TITLE
Remove styles that add unnecessary border around collapsed facets.

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -3,12 +3,6 @@
   --bl-facet-active-item-color: #{$facet-active-item-color};
   --bl-facet-remove-color: var(--bs-secondary-color);
 
-  --bl-facets-smallish-padding: 0.25rem;
-  --bl-facets-smallish-border: var(--bs-border-width) solid
-    var(--bs-border-color);
-  --bl-facets-smallish-margin-bottom: #{$spacer};
-  --bl-facets-smallish-border-radius: #{$border-radius};
-
   .facet-toggle-button {
     [data-hide-label] {
       display: inline;
@@ -26,13 +20,6 @@
       }
     }
   }
-}
-
-.facets-toggleable-md {
-  border: var(--bl-facets-smallish-border);
-  padding: var(--bl-facets-smallish-padding);
-  margin-bottom: var(--bl-facets-smallish-margin-bottom);
-  border-radius: var(--bl-facets-smallish-border-radius);
 }
 
 .no-js {


### PR DESCRIPTION
Before:
<img width="732" alt="Screenshot 2024-10-25 at 9 32 02 AM" src="https://github.com/user-attachments/assets/4625c2b6-4443-4499-9437-b93e45173825">

After:
<img width="739" alt="Screenshot 2024-10-25 at 9 32 14 AM" src="https://github.com/user-attachments/assets/8720602b-5fc0-4663-ba68-b51f501b5c1b">


We often override this to remove these styles:
    https://github.com/sul-dlss/stanford-arclight/blob/a323e8108d14a9876873705ccd53a68db03c7b69/app/assets/stylesheets/sulCollection.scss#L227-L229

It would be better not to have them and let people add them if necessary.
