### PR TITLE
Remove non-existing class navbar-toggler-right

### DIFF
--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -4,7 +4,7 @@
     <%= content_tag :h2, @title, class: 'facets-heading h4' if @title %>
 
     <%= content_tag :button,
-      class:'navbar-toggler navbar-toggler-right d-block d-lg-none',
+      class:'navbar-toggler d-block d-lg-none',
       type: 'button',
       data: {
         toggle: 'collapse',

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" aria-label="<%= aria_label %>">
   <div class="<%= container_classes %>">
     <%= logo_link %>
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 


### PR DESCRIPTION
I have no idea where this came from.  It doesn't appear in any version of bootstrap.