### PR TITLE
Create a custom css class for the facet toggle button

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -9,18 +9,7 @@
   --bl-facets-smallish-margin-bottom: #{$spacer};
   --bl-facets-smallish-border-radius: #{$border-radius};
 
-  .navbar-toggler {
-    --bs-navbar-toggler-padding-x: #{$navbar-toggler-padding-x};
-    --bs-navbar-toggler-padding-y: #{$navbar-toggler-padding-y};
-    --bs-navbar-toggler-border-color: #{$navbar-light-toggler-border-color};
-    --bs-navbar-toggler-border-radius: #{$navbar-toggler-border-radius};
-    color: $navbar-light-active-color;
-
-    &:hover,
-    &:focus {
-      color: $navbar-light-active-color;
-    }
-
+  .facet-toggle-button {
     [data-hide-label] {
       display: inline;
     }

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -4,7 +4,7 @@
     <%= content_tag :h2, @title, class: 'facets-heading h4' if @title %>
 
     <%= content_tag :button,
-      class:'navbar-toggler d-block d-lg-none',
+      class: 'btn btn-outline-secondary facet-toggle-button d-block d-lg-none',
       type: 'button',
       data: {
         toggle: 'collapse',


### PR DESCRIPTION
It's odd to use navbar-toggler for a button that doesn't exist in a .navbar.  This lead us to setting a bunch of properties we wouldn't need to set if we just use a .btn