### PR TITLE
Restore modal events that were dropped in Blacklight 8

### DIFF
--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -164,6 +164,10 @@ const Modal = (() => {
     const dom = modal.target();
 
     if (!dom.open) return
+
+    var e = new CustomEvent('hide.blacklight.blacklight-modal', { bubbles: true, cancelable: true });
+    dom.dispatchEvent(e)
+
     dom.close()
   }
 
@@ -171,6 +175,10 @@ const Modal = (() => {
     const dom = modal.target();
 
     if (dom.open) return
+
+    var e = new CustomEvent('show.blacklight.blacklight-modal', { bubbles: true, cancelable: true });
+    dom.dispatchEvent(e)
+
     dom.showModal()
   }
 

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -114,6 +114,13 @@ const Modal = (() => {
     
     modal.target().querySelector('.modal-content').replaceChildren(frag)
 
+    // send custom event with the modal dialog div as the target
+    var e = new CustomEvent('loaded.blacklight.blacklight-modal', { bubbles: true, cancelable: true });
+    modal.target().dispatchEvent(e)
+
+    // if they did preventDefault, don't show the dialog
+    if (e.isDefaultPrevented()) return;
+
     modal.show();
   };
 

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -91,7 +91,7 @@ const Modal = (() => {
           <pre>${this.url}\n${error}</pre>
         </div>`
 
-      document.querySelector(`${modal.modalSelector} .modal-content`).innerHTML = contents
+      modal.target().querySelector('.modal-content').innerHTML = contents
 
       modal.show();
   }
@@ -112,7 +112,7 @@ const Modal = (() => {
     elements.forEach((el) => frag.appendChild(el))
     modal.activateScripts(frag)
     
-    document.querySelector(`${modal.modalSelector} .modal-content`).replaceChildren(frag)
+    modal.target().querySelector('.modal-content').replaceChildren(frag)
 
     modal.show();
   };
@@ -154,17 +154,21 @@ const Modal = (() => {
   };
 
   modal.hide = function (el) {
-    const dom = document.querySelector(modal.modalSelector)
+    const dom = modal.target();
 
     if (!dom.open) return
     dom.close()
   }
 
   modal.show = function(el) {
-    const dom = document.querySelector(modal.modalSelector)
+    const dom = modal.target();
 
     if (dom.open) return
     dom.showModal()
+  }
+
+  modal.target = function() {
+    return document.querySelector(modal.modalSelector);
   }
 
   modal.setupModal()


### PR DESCRIPTION
I understand why the bootstrap-triggered events were removed with the switch to HTML5-native modals, but I'm not sure why the `loaded.blacklight.blacklight-modal`. This was a very useful extension point for plugins and other applications, and requiring all of them to set up mutation observers (e.g https://github.com/projectblacklight/blacklight_range_limit/pull/249) isn't very satisfying.

I also added show + hide events (the `<dialog>` emits its own `close` event) to restore some other useful extension points too.