### PR TITLE
Use css variables for sort-pagination

### DIFF
--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -4,7 +4,7 @@
 
 .sort-pagination,
 .pagination-search-widgets {
-  border-bottom: $pagination-border-width solid $pagination-border-color;
+  border-bottom: var(--bs-border-width) solid var(--bs-border-color);
   margin-bottom: 1em;
   padding-bottom: 1em;
 }


### PR DESCRIPTION
We used to use the pagination variables, but that wasn't appropriate as this border is not enclosed in a .pagination class. This also enables us to scope any customization.