### PR TITLE
Use --bs-border-color rather than -border-color for document separator

### DIFF
--- a/app/assets/stylesheets/blacklight/_search_results.scss
+++ b/app/assets/stylesheets/blacklight/_search_results.scss
@@ -5,7 +5,7 @@
 
   .document {
     display: flex;
-    border-bottom: 1px dotted $table-border-color;
+    border-bottom: 1px dotted var(--bs-border-color);
     margin-top: var(--bl-results-document-margin-top);
     padding-top: var(--bl-results-document-padding-top);
 


### PR DESCRIPTION
It's not appropriate to use table-border-color outside of a .table