### PR TITLE
Remove default partial slot value.

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -126,14 +126,11 @@ module Blacklight
       set_slot(:thumbnail, nil) unless thumbnail || show?
       set_slot(:metadata, nil, fields: presenter.field_presenters, show: @show) unless metadata
       set_slot(:embed, nil) unless embed
-      if view_partials.present?
-        view_partials.each do |view_partial|
-          with_partial(view_partial) do
-            helpers.render_document_partial @document, view_partial, component: self, document_counter: @counter
-          end
+
+      view_partials.each do |view_partial|
+        with_partial(view_partial) do
+          helpers.render_document_partial @document, view_partial, component: self, document_counter: @counter
         end
-      else
-        set_slot(:partials, nil)
       end
     end
 

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -224,6 +224,12 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     expect(rendered).to have_content 'Partials'
   end
 
+  it 'has no partials by default' do
+    component.render_in(view_context)
+
+    expect(component.partials?).to be false
+  end
+
   context 'with before_titles' do
     let(:render) do
       component.render_in(view_context) do


### PR DESCRIPTION
I don't think the blank partial slot is useful, and makes it harder to check if there's any partials using e.g. `partials?`