### PR TITLE
Use a labeled <aside> for show tools sidebar

### DIFF
--- a/app/views/layouts/catalog_result.html.erb
+++ b/app/views/layouts/catalog_result.html.erb
@@ -3,9 +3,9 @@
     <%= yield %>
   </section>
 
-  <section class="<%= show_sidebar_classes %>">
+  <aside class="<%= show_sidebar_classes %>" aria-label="<%= t('.aria.sidebar') %>">
     <%= content_for(:sidebar) %>
-  </section>
+  </aside>
 <% end %>
 
 <%= render template: "layouts/blacklight/base" %>

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -222,6 +222,10 @@ ar:
       aria:
         container_label: التنقل الرئيسي
     welcome: مرحبًا!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: أدوات
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -209,6 +209,10 @@ de:
       aria:
         container_label: Hauptnavigation
     welcome: Willkommen!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Werkzeuge
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -245,3 +245,7 @@ en:
     pagination_compact:
       next: Next &raquo;
       previous: "&laquo; Previous"
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Tools

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -208,6 +208,10 @@ es:
       aria:
         container_label: Navegación principal
     welcome: "¡Bienvenido!"
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Herramientas
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -208,6 +208,10 @@ fr:
       aria:
         container_label: Navigation principale
     welcome: Welcome!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Outils
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -206,6 +206,10 @@ hu:
       aria:
         container_label: Fő navigáció
     welcome: Üdvözöljük!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Eszközök
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -209,6 +209,10 @@ it:
       aria:
         container_label: Navigazione principale
     welcome: Benvenuti!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Utensili
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -206,6 +206,10 @@ nl:
       aria:
         container_label: Hoofdnavigatie
     welcome: Welkom!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Hulpmiddelen
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -207,6 +207,10 @@ pt-BR:
       aria:
         container_label: Navegação principal
     welcome: Bem-Vindo!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Ferramentas
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -206,6 +206,10 @@ sq:
       aria:
         container_label: Lundrimi kryesor
     welcome: Mirësevini!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: Mjetet
   views:
     pagination:
       aria:

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -206,6 +206,10 @@ zh:
       aria:
         container_label: 主导航
     welcome: 欢迎!
+  layouts:
+    catalog_result:
+      aria:
+        sidebar: 工具
   views:
     pagination:
       aria:


### PR DESCRIPTION
The show page sidebar is currently displayed
inside a `<section>`; this changes it to use the `<aside>` element,
which is arguably more appropriate for a sidebar.

The search sidebar had an aria-label already set, but the show
sidebar did not, which also meant that it had no accessible name
despite having a landmark role.

Thus this also adds a configurable aria-label for the show page sidebar
similar to the one for the search sidebar.
