### PR TITLE
Remove unnecessary css that pushes pagination out of alignment

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -143,12 +143,6 @@
 /* Sidenav
 -------------------------------------------------- */
 
-.facet-pagination {
-  &.top {
-    padding: $modal-inner-padding;
-  }
-}
-
 .pivot-facet {
   &.show {
     display: flex;


### PR DESCRIPTION
I don't think this is required or necessarily desirable. Remove it as it's easier to add in this pagination in a local app than it is to remove it when it's not desired

Before
<img width="767" alt="Screenshot 2024-11-08 at 9 32 17 AM" src="https://github.com/user-attachments/assets/24fa4421-8ded-4d6e-a88a-16691bd165da">

After
<img width="1018" alt="Screenshot 2024-11-08 at 9 33 52 AM" src="https://github.com/user-attachments/assets/edc2f05f-bf26-4bd5-96ca-c7a1c0087670">
