### PR TITLE
ClausePresenter: don't attempt to call #display_label on a non-existant field configuration

### DIFF
--- a/app/presenters/blacklight/clause_presenter.rb
+++ b/app/presenters/blacklight/clause_presenter.rb
@@ -13,7 +13,7 @@ module Blacklight
     end
 
     def field_label
-      field_config.display_label('search')
+      field_config&.display_label('search')
     end
 
     ##

--- a/spec/presenters/blacklight/clause_presenter_spec.rb
+++ b/spec/presenters/blacklight/clause_presenter_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Blacklight::ClausePresenter, type: :presenter do
     it 'returns a label for the field' do
       expect(subject.field_label).to eq 'Some Field'
     end
+
+    context 'when the field config does not exist' do
+      let(:field_config) { nil }
+
+      it 'returns nil' do
+        expect(subject.field_label).to be_nil
+      end
+
+      it 'does not raise an error' do
+        expect { subject.field_label }.not_to raise_error
+      end
+    end
   end
 
   describe '#label' do


### PR DESCRIPTION
closes #3441 