### PR TITLE
Make modal facet "more" pagination controls be on either side of screen

### DIFF
--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,6 +1,6 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
   <% component.with_prefix do %>
-    <div class="facet-pagination top justify-content-between">
+    <div class="facet-pagination top d-flex w-100 justify-content-between">
       <%= render :partial=>'facet_pagination' %>
     </div>
   <% end %>


### PR DESCRIPTION
The bootstrap utility `justify-content-between` class was there, but not actually doing anything since the div wasn't display flex. It's presence makes me think it was always intended to do this, which I think looks better/more legible. 

## Before

![Screenshot 2024-11-19 at 3 00 16 PM](https://github.com/user-attachments/assets/0103f02d-d604-4d37-9e7b-98be089f25f0)


## After

![Screenshot 2024-11-19 at 3 01 27 PM](https://github.com/user-attachments/assets/8888a9b4-ff96-4a99-bbad-0fd4ac03dfa8)
