### PR TITLE
Fix scrolling of longer-than-viewport bootstrap modal in a <dialog>

### DIFF
--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -2,10 +2,16 @@
   white-space: nowrap;
 }
 
-.modal[open] {
+// Blacklight's decision to try to use bootstrap modal CSS with an html5 dialog --
+// in such a way the <dialog> element actually serves as the modal backdrop --
+// requires some fixes to both bootstrap CSS and user-agent default css
+dialog.modal[open] {
   // override bootstrap .modal class default display: none
   // since we aren't using bootstrap JS that sets and unsets the display
   display: block;
   background: none;
   border: none;
+
+  max-height: unset; // override user-agent dialog
+  max-width: unset; // override user-agent dialog
 }


### PR DESCRIPTION
Blacklight uses Bootstrap [modal](https://getbootstrap.com/docs/5.3/components/modal/) css (I'm not sure about the JS), but uses an HTML5 `<dialog>` element for the modal, which bootstrap isnt' really expecting. 

Specifically, it looks like the `<dialog>` with the class `modal` serves as a sort of full-screen 'wrapper'. 

Before this PR, scrolling a higher-than-viewport modal would have this odd behavior:


https://github.com/user-attachments/assets/35f76f63-3fa5-4493-8739-0c28c0b60830

Note how the modal disappears under some kind of "invisible" blockers at top and bottom. This is an unnatural and undesirable effect. 

Also notice how the scrollbar is floating som distance from the right edge?

This is caused because at least in Chrome, there's a default **user-agent** stylesheet on `dialog` that sets:

```
    max-width: calc(100% - 2em - 6px);
    max-height: calc(100% - 2em - 6px);
```

Presumably becuase it expects the dialog will be an actual `dialog` not a wrapper/overlay?  

Unsetting these makes the scroll seem closer to normal again. 

https://github.com/user-attachments/assets/a1d4f1fc-6239-4d65-9cf0-7dd63b0a2ebd

There are a couple more oddities, one of which you can see at the end of there. 

1. In Blacklight's implementation, once the modal is fully scrolled, if you keep scrolling, you can scroll the hidden overlaid body underneath it.... that's [not how the Bootstrap modal works](https://getbootstrap.com/docs/5.3/components/modal/#scrolling-long-content).
2. In Bootstrap modal, ciicking somewhere outside the modal will close the modal, whereas this is not a feature of html5 native `<dialog>`.  (I wonder if this is an accessibilty issue?)

I wonder if we want to revisit the choice to try to marry a bootstrap dialog to an `html5` dialog? But in the meantime, I think this helps?
