### PR TITLE
Set search bar border rounded class for number of configured search fields

### DIFF
--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -22,12 +22,12 @@
 
       <%= f.label @query_param, scoped_t('search.label'), class: 'visually-hidden' %>
       <% if autocomplete_path.present? %>
-        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper form-control">
-          <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
+        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper form-control <%= rounded_border_class %>">
+          <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control #{rounded_border_class}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
           <ul id="autocomplete-popup" class="dropdown-menu" role="listbox" aria-label="<%= scoped_t('search.label') %>" hidden></ul>
         </auto-complete>
       <% else %>
-        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control #{rounded_border_class}", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
       <% end %>
 
       <%= append %>

--- a/app/components/blacklight/search_bar_component.rb
+++ b/app/components/blacklight/search_bar_component.rb
@@ -60,6 +60,12 @@ module Blacklight
       blacklight_config.advanced_search.enabled
     end
 
+    def rounded_border_class
+      return 'rounded-0' if search_fields.length > 1
+
+      'rounded-start'
+    end
+
     private
 
     def blacklight_config

--- a/spec/components/blacklight/search_bar_component_spec.rb
+++ b/spec/components/blacklight/search_bar_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Blacklight::SearchBarComponent, type: :component do
   let(:blacklight_config) do
     Blacklight::Configuration.new.configure do |config|
       config.view = { list: nil, abc: nil }
+      config.add_search_field('test_field', label: 'Test Field')
     end
   end
 
@@ -77,6 +78,30 @@ RSpec.describe Blacklight::SearchBarComponent, type: :component do
     it 'renders the extra inputs' do
       expect(render.css("input[name='foo']")).to be_present
       expect(render.css("input[name='bar']")).to be_present
+    end
+  end
+
+  context 'with one search field' do
+    subject(:render) { render_inline(instance) }
+
+    it 'sets the rounded border class' do
+      expect(render.css('.rounded-start')).to be_present
+    end
+  end
+
+  context 'with multiple search fields' do
+    subject(:render) { render_inline(instance) }
+
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.configure do |config|
+        config.view = { list: nil, abc: nil }
+        config.add_search_field('test_field', label: 'Test Field')
+        config.add_search_field('another_field', label: 'Another Field')
+      end
+    end
+
+    it 'sets the rounded border class' do
+      expect(render.css('.rounded-0')).to be_present
     end
   end
 end


### PR DESCRIPTION
Fixes #3448 

With one configured search field:

Before:
<img width="835" alt="Screenshot 2024-11-21 at 8 35 24 AM" src="https://github.com/user-attachments/assets/6555622f-5012-49a9-9978-c0b75671959f">

After:
<img width="926" alt="Screenshot 2024-11-21 at 9 08 58 AM" src="https://github.com/user-attachments/assets/136b21e1-d7b0-44f5-94ce-bb17ef7bef1c">
