### PR TITLE
When modal is open, turn off body scrolling

### DIFF
--- a/app/javascript/blacklight-frontend/modal.js
+++ b/app/javascript/blacklight-frontend/modal.js
@@ -57,6 +57,9 @@ import ModalForm from 'blacklight-frontend/modalForm'
 const Modal = (() => {
   const modal = {}
 
+  // bootstrap class that will stop body scrolling when modal is open
+  const bootstrapBodyClassOpen = "modal-open";
+
   // a Bootstrap modal div that should be already on the page hidden
   modal.modalSelector = '#blacklight-modal';
 
@@ -168,6 +171,12 @@ const Modal = (() => {
     dom.dispatchEvent(e)
 
     dom.close()
+
+    // Turn body scrolling back to what it was
+    document.body.style["overflow"] = modal.originalBodyOverflow;
+    document.body.style["padding-right"] = modal.originalBodyPaddingRight;
+    modal.originalBodyOverflow = undefined;
+    modal.originalBodyPaddingRight = undefined;
   }
 
   modal.show = function(el) {
@@ -179,6 +188,12 @@ const Modal = (() => {
     dom.dispatchEvent(e)
 
     dom.showModal()
+
+    // Turn off body scrolling
+    modal.originalBodyOverflow = document.body.style['overflow'];
+    modal.originalBodyPaddingRight = document.body.style['padding-right'];
+    document.body.style["overflow"] = "hidden"
+    document.body.style["padding-right"] = "0px"
   }
 
   modal.target = function() {


### PR DESCRIPTION
These inline styles are what bootstrap 4 does, discovered through reverse-engineering, although it uses a lot more abstraction to do it. (A ScrollHelper object that can do a lot more things).

This behavior now matches Bootstrap modal behavior, and avoids some weird double scroll within scroll.

## Before

https://github.com/user-attachments/assets/0d544e9f-ebc7-4cb8-b199-4974ed5a47ad


* Not sure why my test app has nav elements weirdly placed at top, ignore that, unrelated to this PR
* Also note the weird invisible spots on top and scrollbar being out from edge are addressed in #3447 
* Note unpleasant weird double visible scrollbars

## After

https://github.com/user-attachments/assets/90c0f1b5-4650-49f2-9641-9e997fdba3f4

* Only one visible scrollbar
* It does not scroll the body behind the modal, it only scrolls enough to see modal
* This matches bootstrap modal behavior

