### PR TITLE
Backport: remove invalid CSS. Fixes #3444

### DIFF
--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -39,16 +39,6 @@
   }
 }
 
-.search-input-group {
-  width: 80%;
-}
-
-@media (max-width: breakpoint-max(xs)) {
-  .search-input-group {
-    width: auto;
-  }
-}
-
 .modal_form {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Using `(max-width: ) { ... }` (without a value specified) is not valid syntax, but it's currently getting written into the compiled CSS in Blacklight 8. The offending block was removed from `main` in d7416f4 which I've cherry-picked here. I think it's worth backporting to 8.x since it 1) is a small, isolated commit; 2) fixes a bug that affects at least some CSS preprocessor tooling. See #3444 for details. 