### PR TITLE
Backport: Remove redundant aria role from nav element #3457

### DIFF
--- a/app/components/blacklight/skip_link_component.html.erb
+++ b/app/components/blacklight/skip_link_component.html.erb
@@ -1,4 +1,4 @@
-<nav id="skip-link" role="navigation" class="visually-hidden-focusable sr-only sr-only-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
+<nav id="skip-link" class="visually-hidden-focusable sr-only sr-only-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
   <div class="container-xl">
     <%= link_to_main %>
     <%= link_to_search %>


### PR DESCRIPTION
Backport https://github.com/projectblacklight/blacklight/pull/3457 to release-8.x