### PR TITLE
Strip markup from html_safe selected facet values in the html title.

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -132,7 +132,11 @@ module Blacklight::CatalogHelperBehavior
     facet_config = facet_configuration_for_field(facet)
     filter_label = facet_field_label(facet_config.key)
     filter_value = if values.size < 3
-                     values.map { |value| facet_item_presenter(facet_config, value, facet).label }.to_sentence
+                     values.map do |value|
+                       label = facet_item_presenter(facet_config, value, facet).label
+                       label = strip_tags(label) if label.html_safe?
+                       label
+                     end.to_sentence
                    else
                      t('blacklight.search.page_title.many_constraint_values', values: values.size)
                    end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -261,6 +261,14 @@ RSpec.describe CatalogHelper do
     it "renders a facet with more than two values" do
       expect(helper.render_search_to_page_title_filter('foo', %w[bar baz foobar])).to eq "Foo: 3 selected"
     end
+
+    it "strips tags from html_safe values" do
+      expect(helper.render_search_to_page_title_filter('Year', ['<span class="from" data-blrl-begin="1990">1990</span> to <span class="to" data-blrl-end="1999">1999</span>'.html_safe])).to eq "Year: 1990 to 1999"
+    end
+
+    it "does not strip tags from non-html_safe values" do
+      expect(helper.render_search_to_page_title_filter('Folder', ['Some > Nested > <span>Hierarchy</span>'])).to eq "Folder: Some > Nested > <span>Hierarchy</span>"
+    end
   end
 
   describe "#render_search_to_page_title" do


### PR DESCRIPTION
- E.g., span/data-attributes rendered for selected range facet values by blacklight_range_limit
- Fixes https://github.com/projectblacklight/blacklight_range_limit/issues/189

I'm not aware of cases outside of the `blacklight_range_limit` plugin that render markup in the selected value. However, there's a precedent for using `strip_tags` on the selected facet value in core in the `ConstraintLayoutComponent` [here](https://github.com/projectblacklight/blacklight/blob/main/app/components/blacklight/constraint_layout_component.html.erb#L7).

Solution in Action:
<img width="932" alt="Screenshot 2024-12-06 at 8 23 27 AM" src="https://github.com/user-attachments/assets/a0dcacd0-a928-4efe-a73a-3794fa28bade">
