### PR TITLE
[8.x] Import and export modalForm.js so it is included in the rollup build

### DIFF
--- a/app/javascript/blacklight/index.js
+++ b/app/javascript/blacklight/index.js
@@ -1,6 +1,7 @@
 import BookmarkToggle from 'blacklight/bookmark_toggle'
 import ButtonFocus from 'blacklight/button_focus'
 import Modal from 'blacklight/modal'
+import ModalForm from 'blacklight/modalForm'
 import SearchContext from 'blacklight/search_context'
 import Core from 'blacklight/core'
 
@@ -8,6 +9,7 @@ export default {
   BookmarkToggle,
   ButtonFocus,
   Modal,
+  ModalForm,
   SearchContext,
   Core,
   onLoad: Core.onLoad

--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -52,7 +52,6 @@
   can be a turbo-stream that defines some HTML fragementsand where on the page to put them:
   https://turbo.hotwired.dev/handbook/streams
 */
-import ModalForm from 'blacklight/modalForm'
 
 const Modal = (() => {
   const modal = {}


### PR DESCRIPTION
Before this commit, modalForm.js was not included in the rollup build, which meant that applications with forms in the modal would not work properly, even if they had the required `data-blacklight-modal=trigger`

To confirm the fix, you can run:
```
npm install && npm run prepare && grep triggerFormSelector app/assets/javascripts/blacklight/blacklight.js
```

If you get a match, that means that the file is included in the javascript build and applications can use it.

This affects both the release-8.x branch and main.  It is blocking our upgrade to Blacklight 8 (see https://github.com/pulibrary/orangelight/issues/4567).  We will also open up a pull request for main.