### PR TITLE
[main] Import and export modalForm.js so it is included in the rollup build

### DIFF
--- a/app/javascript/blacklight-frontend/index.js
+++ b/app/javascript/blacklight-frontend/index.js
@@ -2,6 +2,7 @@ import BookmarkToggle from 'blacklight-frontend/bookmark_toggle'
 import ButtonFocus from 'blacklight-frontend/button_focus'
 import FacetSuggest from 'blacklight-frontend/facet_suggest'
 import Modal from 'blacklight-frontend/modal'
+import ModalForm from 'blacklight-frontend/modalForm'
 import SearchContext from 'blacklight-frontend/search_context'
 import Core from 'blacklight-frontend/core'
 
@@ -10,6 +11,7 @@ export default {
   ButtonFocus,
   FacetSuggest,
   Modal,
+  ModalForm,
   SearchContext,
   Core,
   onLoad: Core.onLoad

--- a/app/javascript/blacklight-frontend/modal.js
+++ b/app/javascript/blacklight-frontend/modal.js
@@ -52,7 +52,6 @@
   can be a turbo-stream that defines some HTML fragementsand where on the page to put them:
   https://turbo.hotwired.dev/handbook/streams
 */
-import ModalForm from 'blacklight-frontend/modalForm'
 
 const Modal = (() => {
   const modal = {}


### PR DESCRIPTION
Before this commit, modalForm.js was not included in the rollup build, which meant that applications with forms in the modal would not work properly, even if they had the required `data-blacklight-modal=trigger`

To confirm the fix, you can run:
```
npm install && npm run prepare && grep triggerFormSelector app/assets/javascripts/blacklight/blacklight.js
```

If you get a match, that means that the file is included in the javascript build and applications can use it.

See also #3466, which backports this fix to release-8.x.