### PR TITLE
Remove hover style from non-controllable element

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -27,10 +27,6 @@
       margin-left: 0.25rem;
       transition: background-color 0.15s ease-in-out;
     }
-
-    &:hover .filter-name:after {
-      background-color: var(--bs-btn-hover-color);
-    }
   }
 
   .remove {


### PR DESCRIPTION
The hover style indicates to the user that the currently hovered element is a clickable control. However in this case it is not a control, so removing the hover style improves UX.

Fixes #3469 