### PR TITLE
[backport 8.x] Remove hover style from non-controllable element

### DIFF
--- a/app/assets/stylesheets/blacklight/_constraints.scss
+++ b/app/assets/stylesheets/blacklight/_constraints.scss
@@ -29,13 +29,6 @@
     @media (min-width: breakpoint-min(lg)) {
       max-width: breakpoint-min(lg) * 0.5;
     }
-
-    &:hover,
-    &:active {
-      background-color: $secondary;
-      border-color: $secondary;
-      box-shadow: none;
-    }
   }
 
   .filter-name:after {


### PR DESCRIPTION
The hover style indicates to the user that the currently hovered element is a clickable control. However in this case it is not a control, so removing the hover style improves UX.

Ref #3470 