### PR TITLE
Extract a SkipLinkItemComponent

### DIFF
--- a/app/components/blacklight/skip_link_component.rb
+++ b/app/components/blacklight/skip_link_component.rb
@@ -3,11 +3,11 @@
 module Blacklight
   class SkipLinkComponent < Blacklight::Component
     def link_to_search
-      link_to t('blacklight.skip_links.search_field'), search_id, class: link_classes
+      render skip_link_item_component.new(text: t('blacklight.skip_links.search_field'), href: search_id)
     end
 
     def link_to_main
-      link_to t('blacklight.skip_links.main_content'), '#main-container', class: link_classes
+      render skip_link_item_component.new(text: t('blacklight.skip_links.main_content'), href: '#main-container')
     end
 
     def search_id
@@ -16,7 +16,11 @@ module Blacklight
       '#q'
     end
 
+    delegate :blacklight_config, to: :helpers
+    delegate :skip_link_item_component, to: :blacklight_config
+
     def link_classes
+      Blacklight.deprecation.warn("Use SkipLinkItemComponent instead")
       'visually-hidden-focusable rounded-bottom py-2 px-3'
     end
   end

--- a/app/components/blacklight/skip_link_item_component.rb
+++ b/app/components/blacklight/skip_link_item_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class SkipLinkItemComponent < Blacklight::Component
+    def initialize(text:, href:)
+      @text = text
+      @href = href
+    end
+
+    def call
+      link_to @text, @href, class: link_classes
+    end
+
+    def link_classes
+      'visually-hidden-focusable rounded-bottom py-2 px-3'
+    end
+  end
+end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for(:skip_links) do -%>
-    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'd-inline-flex p-2 m-1' %>
+  <%= render Blacklight::SkipLinkItemComponent.new(text: t('blacklight.skip_links.first_result'), href: '#documents') %>
 <% end %>
 
 <% content_for(:container_header) do -%>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -43,6 +43,7 @@ module Blacklight
     default_configuration do
       property :logo_link, default: nil
       property :skip_link_component, default: Blacklight::SkipLinkComponent
+      property :skip_link_item_component, default: Blacklight::SkipLinkItemComponent
       property :header_component, default: Blacklight::HeaderComponent
       property :full_width_layout, default: false
 


### PR DESCRIPTION
So that all skip links can use the same css classes

Fixes #3477