### PR TITLE
[backport 8.x] accessibility fix: facet focus ring styles

### DIFF
--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -1,4 +1,3 @@
-/* dood */
 .sidenav {
   --bl-facet-active-bg: #{$facet-active-bg};
   --bl-facet-active-item-color: #{$facet-active-item-color};

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -1,3 +1,4 @@
+/* dood */
 .sidenav {
   --bl-facet-active-bg: #{$facet-active-bg};
   --bl-facet-active-item-color: #{$facet-active-item-color};
@@ -113,6 +114,16 @@
 
   .card-body {
     padding: var(--bl-facet-limit-body-padding);
+  }
+
+  /* Provide a focus ring on the expand/collapse button */
+  .btn {
+    --bs-btn-focus-shadow-rgb: 50, 50, 50;
+    &:focus-visible {
+      border-color: var(--bs-btn-hover-border-color);
+      outline: 0;
+      box-shadow: var(--bs-btn-focus-box-shadow);
+    }
   }
 }
 

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -14,18 +14,7 @@
   --bl-facets-smallish-margin-bottom: #{$spacer};
   --bl-facets-smallish-border-radius: #{$border-radius};
 
-  .navbar-toggler {
-    --bs-navbar-toggler-padding-x: #{$navbar-toggler-padding-x};
-    --bs-navbar-toggler-padding-y: #{$navbar-toggler-padding-y};
-    --bs-navbar-toggler-border-color: #{$navbar-light-toggler-border-color};
-    --bs-navbar-toggler-border-radius: #{$navbar-toggler-border-radius};
-    color: $navbar-light-active-color;
-
-    &:hover,
-    &:focus {
-      color: $navbar-light-active-color;
-    }
-
+  .facet-toggle-button {
     [data-hide-label] {
       display: inline;
     }

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -4,7 +4,7 @@
     <%= content_tag :h2, @title, class: 'facets-heading' if @title %>
 
     <%= content_tag :button,
-      class:'navbar-toggler navbar-toggler-right',
+      class: 'btn btn-outline-secondary facet-toggle-button d-block d-lg-none',
       type: 'button',
       data: {
         toggle: 'collapse',


### PR DESCRIPTION
Backports to 8.x three commits from `main` that together address accessibility problems with the current `release-8.x`; namely that facets are difficult to navigate via keyboard because of missing focus ring styles on the facet headers and mobile toggler button.

### Before: Facet Header with Focus
<img width="364" alt="Screenshot 2024-12-18 at 3 34 13 PM" src="https://github.com/user-attachments/assets/c3da9933-7c8a-4078-8a15-50838fac561e" />

### After: Facet Header with Focus
<img width="438" alt="Screenshot 2024-12-18 at 3 32 53 PM" src="https://github.com/user-attachments/assets/cf2b55f1-b4f7-48b2-9f51-e4a2c7442cc4" />

### Before: Show Facets Toggle with Focus
<img width="494" alt="Screenshot 2024-12-18 at 3 34 25 PM" src="https://github.com/user-attachments/assets/d52099ea-6949-48d6-84fc-26d786293856" />

### After: Show Facets Toggle with Focus
<img width="552" alt="Screenshot 2024-12-18 at 3 33 13 PM" src="https://github.com/user-attachments/assets/0d8d6772-cf4d-4690-965f-3060ec65dad9" />

