### PR TITLE
Improve style of skip links

### DIFF
--- a/app/components/blacklight/skip_link_component.rb
+++ b/app/components/blacklight/skip_link_component.rb
@@ -17,7 +17,7 @@ module Blacklight
     end
 
     def link_classes
-      'visually-hidden-focusable rounded-bottom py-2 px-3'
+      'd-inline-flex py-2 px-3'
     end
   end
 end


### PR DESCRIPTION
Before:

<img width="1410" alt="Screenshot 2024-12-20 at 9 13 26 AM" src="https://github.com/user-attachments/assets/42a59570-1090-4797-a5c5-9fd8e3b1d68e" />



<br><br>
After:
<img width="1146" alt="Screenshot 2024-12-20 at 9 19 05 AM" src="https://github.com/user-attachments/assets/ac370306-984b-454b-ab74-48d9bede56f8" />
