### PR TITLE
[backport 8.x] Update skip links

### DIFF
--- a/app/components/blacklight/skip_link_component.rb
+++ b/app/components/blacklight/skip_link_component.rb
@@ -17,7 +17,7 @@ module Blacklight
     end
 
     def link_classes
-      'd-inline-flex p-2 m-1'
+      'visually-hidden-focusable rounded-bottom py-2 px-3'
     end
   end
 end


### PR DESCRIPTION
This prevents a display issue where the skip links were taking up 1px at the top, even when collapsed.


A backport of #3461