### PR TITLE
Use SOLR_MODULES envvar, rather than solrconfig <lib> entries for Solr 9.8 compatibility

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,7 @@ services:
     environment:
       - SOLR_PORT # Set via environment variable or use default defined in .env file
       - SOLR_VERSION # Set via environment variable or use default defined in .env file
+      - SOLR_MODULES=analysis-extras
     image: "solr:${SOLR_VERSION}"
     volumes:
       - $PWD/lib/generators/blacklight/templates/solr/conf:/opt/solr/conf

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -16,7 +16,7 @@
     </updateLog>
   </updateHandler>
 
-  <!-- solr lib dirs -->
+  <!-- solr lib dirs, which are needed for Solr 8 compatibility but ignored in solr 9.8 and above -->
   <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />


### PR DESCRIPTION
As a result of [this solr patch](https://issues.apache.org/jira/browse/SOLR-16781), `<lib>` entries are now ignored by default.  [The Solr guide recommends](https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html) adding them to the `solr.modules` system property or the `SOLR_MODULES` envvar instead.

Closes #3496 and helps to unbreak CI

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
