### PR TITLE
[Backport 8.x] Backport 3492 for enabling styling for buttons in numerical and A-Z sort

### DIFF
--- a/app/components/blacklight/facet_field_pagination_component.html.erb
+++ b/app/components/blacklight/facet_field_pagination_component.html.erb
@@ -10,10 +10,10 @@
 
 <div class="sort-options btn-group">
   <% if @facet_field.paginator.sort == 'index' -%>
-    <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
-    <%= helpers.link_to(t('blacklight.search.facets.sort.count'), sort_facet_url('count'), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>
+    <span class="active az <%= @button_classes %>"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= helpers.link_to(t('blacklight.search.facets.sort.count'), sort_facet_url('count'), class: "sort_change numeric #{@button_classes}", data: { blacklight_modal: "preserve" }) %>
   <% elsif @facet_field.paginator.sort == 'count' -%>
-    <%= helpers.link_to(t('blacklight.search.facets.sort.index'), sort_facet_url('index'), class: "sort_change az btn btn-outline-secondary",  data: { blacklight_modal: "preserve" }) %>
-    <span class="active numeric btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.count') %></span>
+    <%= helpers.link_to(t('blacklight.search.facets.sort.index'), sort_facet_url('index'), class: "sort_change az #{@button_classes}",  data: { blacklight_modal: "preserve" }) %>
+    <span class="active numeric <%= @button_classes %>"><%= t('blacklight.search.facets.sort.count') %></span>
   <% end -%>
 </div>

--- a/app/components/blacklight/facet_field_pagination_component.rb
+++ b/app/components/blacklight/facet_field_pagination_component.rb
@@ -2,8 +2,9 @@
 
 module Blacklight
   class FacetFieldPaginationComponent < Blacklight::Component
-    def initialize(facet_field:)
+    def initialize(facet_field:, button_classes: %w[btn btn-outline-secondary])
       @facet_field = facet_field
+      @button_classes = button_classes.join(' ')
     end
 
     def sort_facet_url(sort)


### PR DESCRIPTION
This is a backport for : https://github.com/projectblacklight/blacklight/pull/3492 .

What this PR does:

    Allows for passing the button-specific styling for the A-Z and numerical sort buttons as a parameter
    Sets the default classes for styling within the component so _facet_pagination does not need to add a parameter if the default styling is not to be overridden.
    Uses the styling within the html.erb file
