### PR TITLE
[backport 8.x] Fix CI via updating versions of Rails tested & Solr 9.8 fix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.3"]
-        rails_version: ["7.1.3.4", "7.2.0"]
+        rails_version: ["7.1.5.1", "7.2.2.1"]
         bootstrap_version: [null]
         view_component_version: ["~> 3.12"]
         api: [null]
@@ -45,39 +45,37 @@ jobs:
         additional_name: [""]
         include:
           - ruby: "3.3"
-            rails_version: "8.0.0"
+            rails_version: "8.0.1"
             additional_engine_cart_rails_options: --css=bootstrap
           - ruby: "3.3"
-            rails_version: "8.0.0.beta1"
+            rails_version: "8.0.1"
             additional_engine_cart_rails_options: --css=bootstrap --js=esbuild
             additional_name: "/ esbuild"
           - ruby: "3.2"
-            rails_version: "6.1.7.8"
-          - ruby: "3.2"
-            rails_version: "7.1.3.4"
+            rails_version: "7.1.5.1"
             solr_version: "8.11.2"
             additional_name: "Solr 8.11.2"
           - ruby: "3.1"
-            rails_version: "7.1.3.4"
+            rails_version: "7.1.5.1"
           - ruby: "3.1"
-            rails_version: "7.1.3.4"
+            rails_version: "7.1.5.1"
             view_component_version: "~> 2.74"
             additional_name: "/ ViewComponent 2"
           - ruby: "3.1"
-            rails_version: "7.1.3.4"
+            rails_version: "7.1.5.1"
             additional_name: "/ Propshaft"
             additional_engine_cart_rails_options: -a propshaft --css=bootstrap
           - ruby: "3.1"
-            rails_version: "7.1.3.4"
+            rails_version: "7.1.5.1"
             bootstrap_version: "~> 4.0"
             additional_name: "/ Bootstrap 4"
           - ruby: "3.3"
-            rails_version: "7.1.3.4"
+            rails_version: "7.1.5.1"
             api: "true"
             additional_engine_cart_rails_options: --api --skip-yarn
             additional_name: "/ API"
           - ruby: "3.3"
-            rails_version: "7.2.1"
+            rails_version: "7.2.2.1"
             additional_engine_cart_rails_options: -a propshaft --css=bootstrap --js=esbuild
             additional_name: "/ Propshaft, esbuild"
     env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test (ruby ${{ matrix.ruby }} / rails ${{ matrix.rails_version }} ${{ matrix.additional_name }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["3.3"]
         rails_version: ["7.1.3.4", "7.2.0"]
@@ -46,6 +47,10 @@ jobs:
           - ruby: "3.3"
             rails_version: "8.0.0"
             additional_engine_cart_rails_options: --css=bootstrap
+          - ruby: "3.3"
+            rails_version: "8.0.0.beta1"
+            additional_engine_cart_rails_options: --css=bootstrap --js=esbuild
+            additional_name: "/ esbuild"
           - ruby: "3.2"
             rails_version: "6.1.7.8"
           - ruby: "3.2"
@@ -71,6 +76,10 @@ jobs:
             api: "true"
             additional_engine_cart_rails_options: --api --skip-yarn
             additional_name: "/ API"
+          - ruby: "3.3"
+            rails_version: "7.2.1"
+            additional_engine_cart_rails_options: -a propshaft --css=bootstrap --js=esbuild
+            additional_name: "/ Propshaft, esbuild"
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       SOLR_VERSION: ${{ matrix.solr_version || 'latest' }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,7 @@ services:
     environment:
       - SOLR_PORT # Set via environment variable or use default defined in .env file
       - SOLR_VERSION # Set via environment variable or use default defined in .env file
+      - SOLR_MODULES=analysis-extras
     image: "solr:${SOLR_VERSION}"
     volumes:
       - $PWD/lib/generators/blacklight/templates/solr/conf:/opt/solr/conf

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -16,7 +16,7 @@
     </updateLog>
   </updateHandler>
 
-  <!-- solr lib dirs -->
+  <!-- solr lib dirs, which are needed for Solr 8 compatibility but ignored in solr 9.8 and above -->
   <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />


### PR DESCRIPTION
* Backport changes from #3497 to fix Solr 9.8 compatibility
* Backport changes from #3360 to add testing with `propshaft` & `esbuild`
* Stop testing on Rails 6.x in CI
* Update CI matrix to latest Rails 8.0, 7.2, 7.1 versions

_Note_: This PR's primary aim is to get the test suite passing again in CI for the `release-8.x` branch, especially to facilitate future backports. Rails versions below 7.1 are all now EOL. There's a bug at the Rails core level in pre-7.1 (see #3493) that complicates testing. This PR removes the last vestiges of pre-7.1 versions from the CI matrix for Blacklight 8.x but still retains  existing `>= 6.1` compatibility via the `.gemspec`.

Implementers using Blacklight 8 with EOL Rails < 7.1 may need to pin the `concurrent-ruby` gem to `< 1.3.5`