### PR TITLE
[Backport 8.x] Backport #3495: Ensure that facet suggestions are relevant to the user's query

### DIFF
--- a/app/javascript/blacklight/facet_suggest.js
+++ b/app/javascript/blacklight/facet_suggest.js
@@ -6,7 +6,7 @@ const FacetSuggest = async (e) => {
     const facetField = e.target.dataset.facetField;
     if (!facetField) { return; }
 
-    const urlToFetch = `/catalog/facet_suggest/${facetField}/${queryFragment}`
+    const urlToFetch = `/catalog/facet_suggest/${facetField}/${queryFragment}${window.location.search}`
     const response = await fetch(urlToFetch);
     if (response.ok) {
         const blob = await response.blob()

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -117,14 +117,14 @@ RSpec.describe "Facets" do
         expect(page).to have_link 'Old age'
         expect(page).to have_css 'a.facet-select', count: 2
       end
-    end
 
-    it 'shows the user facet suggestions that are relevant to their q param', :js do
-      visit '/catalog/facet/subject_ssim?q=tibet&search_field=all_fields'
-      fill_in 'facet_suggest_subject_ssim', with: 'la'
+      it 'shows the user facet suggestions that are relevant to their q param', :js do
+        visit '/catalog/facet/subject_ssim?q=tibet&search_field=all_fields'
+        fill_in 'facet_suggest_subject_ssim', with: 'la'
 
-      expect(page).to have_link 'Tibetan language'
-      expect(page).to have_css 'a.facet-select', count: 1
+        expect(page).to have_link 'Tibetan language'
+        expect(page).to have_css 'a.facet-select', count: 1
+      end
     end
   end
 end

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -118,5 +118,13 @@ RSpec.describe "Facets" do
         expect(page).to have_css 'a.facet-select', count: 2
       end
     end
+
+    it 'shows the user facet suggestions that are relevant to their q param', :js do
+      visit '/catalog/facet/subject_ssim?q=tibet&search_field=all_fields'
+      fill_in 'facet_suggest_subject_ssim', with: 'la'
+
+      expect(page).to have_link 'Tibetan language'
+      expect(page).to have_css 'a.facet-select', count: 1
+    end
   end
 end


### PR DESCRIPTION
This is a backport of https://github.com/projectblacklight/blacklight/pull/3495

Before this commit, the facet suggest javascript sent HTTP requests that included only the name of the facet and the fragment that the user entered to filter down the facets.

This commit also sends any URL params that were in the user's original search, so that the facet suggestions are relevant to the search, rather than being just the most popular facet values from the entire corpus.

See issue #3494

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
