### PR TITLE
[8.x] Add blacklight-frontend pin to importmap

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 pin_all_from File.expand_path("../app/javascript/blacklight", __dir__), under: "blacklight"
+
+# Allow importing Blacklight via blacklight-frontend. See https://github.com/projectblacklight/blacklight/pull/3371
+pin "blacklight-frontend", to: "blacklight/index.js"


### PR DESCRIPTION
It's too close to the end of the day to undraft, but curious if this seems useful.

I think https://github.com/projectblacklight/blacklight/pull/3371 was a good idea. Blacklight Gallery is already using `blacklight-frontend` to import Blacklight. We noticed that in the Spotlight test app, the blacklight-gallery JavaScript stopped loading in the importmap only build. One of the reasons is the `blacklight` -> `blacklight-frontend` rename isn't in an 8.x release, so that importmap doesn't exist.

I think it could be useful to provide an entry point with that name in 8.x so that other code can 
```js
import Blacklight from 'blacklight-frontend'
```
without having to worry too much about what version of Blacklight is being used.