### PR TITLE
[backport 8.x] Strip markup from html_safe selected facet values in the html title.

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior.rb
@@ -142,7 +142,11 @@ module Blacklight::CatalogHelperBehavior
     facet_config = facet_configuration_for_field(facet)
     filter_label = facet_field_label(facet_config.key)
     filter_value = if values.size < 3
-                     values.map { |value| facet_item_presenter(facet_config, value, facet).label }.to_sentence
+                     values.map do |value|
+                       label = facet_item_presenter(facet_config, value, facet).label
+                       label = strip_tags(label) if label.html_safe?
+                       label
+                     end.to_sentence
                    else
                      t('blacklight.search.page_title.many_constraint_values', values: values.size)
                    end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -261,6 +261,14 @@ RSpec.describe CatalogHelper do
     it "renders a facet with more than two values" do
       expect(helper.render_search_to_page_title_filter('foo', %w[bar baz foobar])).to eq "Foo: 3 selected"
     end
+
+    it "strips tags from html_safe values" do
+      expect(helper.render_search_to_page_title_filter('Year', ['<span class="from" data-blrl-begin="1990">1990</span> to <span class="to" data-blrl-end="1999">1999</span>'.html_safe])).to eq "Year: 1990 to 1999"
+    end
+
+    it "does not strip tags from non-html_safe values" do
+      expect(helper.render_search_to_page_title_filter('Folder', ['Some > Nested > <span>Hierarchy</span>'])).to eq "Folder: Some > Nested > <span>Hierarchy</span>"
+    end
   end
 
   describe "#render_search_to_page_title" do


### PR DESCRIPTION
Backports #3464 to 8.x
- E.g., span/data-attributes rendered for selected range facet values by blacklight_range_limit
