### PR TITLE
Strip out new facet-only request keys

### DIFF
--- a/app/models/blacklight/facet_paginator.rb
+++ b/app/models/blacklight/facet_paginator.rb
@@ -16,7 +16,7 @@ module Blacklight
     # and need to make them accessible in a list so we can easily
     # strip em out before redirecting to catalog/index.
     mattr_accessor :request_keys do
-      { sort: :'facet.sort', page: :'facet.page', prefix: :'facet.prefix' }
+      { sort: :'facet.sort', page: :'facet.page', prefix: :'facet.prefix', fragment: :query_fragment, only: :only_values }
     end
 
     attr_reader :offset, :limit, :sort, :prefix

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -118,5 +118,16 @@ RSpec.describe "Facets" do
       expect(page).to have_link 'Tibetan language'
       expect(page).to have_css 'a.facet-select', count: 1
     end
+
+    it 'allows the user to filter more than once', :js do
+      visit '/catalog/facet/subject_ssim'
+      expect(page).to have_no_link 'Old age' # This is on the second page of facet values
+      expect(page).to have_css 'a.facet-select', count: 20
+
+      fill_in 'facet_suggest_subject_ssim', with: "ag"
+
+      expect(page).to have_link 'Old age'
+      expect(page).to have_link('Old age', href: '/?f%5Bsubject_ssim%5D%5B%5D=Old+age')
+    end
   end
 end


### PR DESCRIPTION
By stripping out the new facet-only request keys, used for doing faster Solr queries for facet counts during facet suggestions, we can perform a second facet-suggest without issue.

![image](https://github.com/user-attachments/assets/545e4e5b-cb16-4b0b-ae04-99a4da0a4eeb)

Connected to #3507