### PR TITLE
Forward-port improvements to the facet suggest feature

### DIFF
--- a/app/components/blacklight/search/facet_suggest_input.html.erb
+++ b/app/components/blacklight/search/facet_suggest_input.html.erb
@@ -1,9 +1,9 @@
-<label for="facet-suggest-<%= facet.key %>">
+<label for="facet_suggest_<%= facet.key %>">
   <%= I18n.t('blacklight.search.facets.suggest.label', field_label: presenter&.label) %>
 </label>
-<input class="facet-suggest form-control"
-       id="facet-suggest-<%= facet.key %>"
-       data-facet-field="<%= facet.key %>"
-       name="facet_suggest_<%= facet.key %>"
-       placeholder="<%= I18n.t('blacklight.search.form.search.placeholder') %>">
-</input>
+<%= text_field_tag "facet_suggest_#{facet.key}",
+  nil,
+  class: "facet-suggest form-control",
+  data: {facet_field: facet.key},
+  placeholder: I18n.t('blacklight.search.form.search.placeholder')
+%>

--- a/app/components/blacklight/search/facet_suggest_input.rb
+++ b/app/components/blacklight/search/facet_suggest_input.rb
@@ -11,6 +11,10 @@ module Blacklight
       private
 
       attr_accessor :facet, :presenter
+
+      def render?
+        facet&.suggest != false
+      end
     end
   end
 end

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -83,11 +83,10 @@ module Blacklight::Catalog
     @facet = blacklight_config.facet_fields[params[:id]]
     raise ActionController::RoutingError, 'Not Found' unless @facet
 
-    query_fragment = params[:query_fragment] || ''
-    @response = if query_fragment.present?
+    @response = if params[:query_fragment].present?
                   search_service.facet_suggest_response(@facet.key, params[:query_fragment])
                 else
-                  @response = search_service.facet_field_response(@facet.key)
+                  search_service.facet_field_response(@facet.key)
                 end
     @display_facet = @response.aggregations[@facet.field]
 

--- a/app/javascript/blacklight-frontend/debounce.js
+++ b/app/javascript/blacklight-frontend/debounce.js
@@ -3,7 +3,7 @@
 // const basicFunction = (entry) => console.log(entry)
 // const debounced = debounce(basicFunction("I should only be called once"));
 //
-// debounced // does NOT print to the screen becase it is invoked again less than 200 milliseconds later
+// debounced // does NOT print to the screen because it is invoked again less than 200 milliseconds later
 // debounced // does print to the screen
 // ```
 export default function debounce(func, timeout = 200) {

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -112,8 +112,8 @@ ar:
           count: ترتيب رقمي
           index: ترتيب أبجدي
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: الفلتر %{field_label}
+          placeholder: فلتر...
         title: تحديد نطاق البحث
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -102,8 +102,8 @@ es:
           count: Ordenación numérica
           index: Ordenación A-Z
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: Filtro %{field_label}
+          placeholder: Filtrar...
         title: Limite su búsqueda
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -102,8 +102,8 @@ fr:
           count: Du + au - fréquent
           index: Tri de A à Z
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: Filtre %{field_label}
+          placeholder: Filtre...
         title: Limiter votre recherche
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -100,8 +100,8 @@ hu:
           count: Numerikus rendezés
           index: A-Z rendezés
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: Szűrő %{field_label}
+          placeholder: Szűrő...
         title: Szűrje tovább a keresését
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -103,8 +103,8 @@ it:
           count: Ordina per numero
           index: Ordina A-Z
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: Filtro %{field_label}
+          placeholder: Filtro...
         title: Affina la ricerca
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -100,7 +100,7 @@ nl:
           count: Numeriek sorteren
           index: A-Z Sorteren
         suggest:
-          label: Filter %{field_label}
+          label: Filteren %{field_label}
           placeholder: Filter...
         title: Verfijn uw zoekopdracht
       filters:

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -101,8 +101,8 @@ pt-BR:
           count: Ordenar por Número
           index: Ordem Alfabética A-Z
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: Filtro %{field_label}
+          placeholder: Filtro...
         title: Filtre sua busca
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -100,8 +100,8 @@ sq:
           count: Renditja numerike
           index: A-Z Renditja
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: Filtri %{field_label}
+          placeholder: Filtro...
         title: Kufizo këkimin
       filters:
         label: "%{label}:"

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -100,8 +100,8 @@ zh:
           count: 按数量排序
           index: 按字母排序
         suggest:
-          label: Filter %{field_label}
-          placeholder: Filter...
+          label: 过滤器 %{field_label}
+          placeholder: 筛选...
         title: 限定搜索
       filters:
         label: "%{label}:"

--- a/spec/components/blacklight/search/facet_suggest_input_spec.rb
+++ b/spec/components/blacklight/search/facet_suggest_input_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::Search::FacetSuggestInput, type: :component do
-  let(:facet) { Blacklight::Configuration::FacetField.new key: 'language_facet' }
+  let(:facet) { Blacklight::Configuration::FacetField.new key: 'language_facet', suggest: true }
   let(:presenter) { instance_double(Blacklight::FacetFieldPresenter) }
 
   before do
@@ -26,8 +26,25 @@ RSpec.describe Blacklight::Search::FacetSuggestInput, type: :component do
     expect(label.text.strip).to eq 'Filter Language'
 
     id_in_label_for = label.attribute('for').text
-    expect(id_in_label_for).to eq('facet-suggest-language_facet')
+    expect(id_in_label_for).to eq('facet_suggest_language_facet')
 
     expect(rendered.css('input').first.attribute('id').text).to eq id_in_label_for
+  end
+
+  context 'when the facet is explicitly configured to suggest: false' do
+    let(:facet) { Blacklight::Configuration::FacetField.new key: 'language_facet', suggest: false }
+
+    it 'does not display' do
+      expect(render_inline(described_class.new(facet: facet, presenter: presenter)).to_s).to eq ''
+    end
+  end
+
+  context 'when the facet is not explicitly configured with a suggest key' do
+    let(:facet) { Blacklight::Configuration::FacetField.new key: 'language_facet' }
+
+    it 'displays' do
+      rendered = render_inline(described_class.new(facet: facet, presenter: presenter))
+      expect(rendered.css("input.facet-suggest").count).to eq 1
+    end
   end
 end

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -129,5 +129,18 @@ RSpec.describe "Facets" do
       expect(page).to have_link 'Old age'
       expect(page).to have_link('Old age', href: '/?f%5Bsubject_ssim%5D%5B%5D=Old+age')
     end
+
+    context 'when facet is configured with suggest: false' do
+      before do
+        enabled = CatalogController.blacklight_config.dup
+        enabled.facet_fields[:subject_ssim].merge!({ suggest: false })
+        allow(CatalogController).to receive(:blacklight_config).and_return enabled
+      end
+
+      it 'does not offer the user a way to filter the list of facet values' do
+        visit '/catalog/facet/subject_ssim'
+        expect(page).to have_no_field 'facet_suggest_subject_ssim'
+      end
+    end
   end
 end


### PR DESCRIPTION
While backporting #3367, @cbeer and @maxkadel identified some issues, which were addressed before merging it to release-8x.  This PR "forward-ports" those corrections, so that main and 9.x also can benefit from them.

Thanks to @cbeer and @maxkadel for identifying these issues while backporting this feature to release-8.x!

* Provide the option to opt out of this feature (in 8.x, it is opt-in).  You can add `suggest: false` to your facet config in the catalog controller if you don't want to use it for a particular field.
* Use `text_field_tag`
* Correct typo in debounce.js
* Run `i18n-tasks translate-missing`, rather than `add-missing`. This pulls preliminary translations from the Google Cloud Translate API.
* Remove redundant assignment
* Remove unnecessary assignment

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
