### PR TITLE
rubocop -a

### DIFF
--- a/app/components/blacklight/document/action_component.rb
+++ b/app/components/blacklight/document/action_component.rb
@@ -61,9 +61,7 @@ module Blacklight
         end
       end
 
-      def key
-        @action.key
-      end
+      delegate :key, to: :@action
     end
   end
 end

--- a/app/presenters/blacklight/json_presenter.rb
+++ b/app/presenters/blacklight/json_presenter.rb
@@ -13,9 +13,7 @@ module Blacklight
 
     delegate :facet_field_names, :facet_configuration_for_field, to: :blacklight_config
 
-    def documents
-      @response.documents
-    end
+    delegate :documents, to: :@response
 
     # @return [Array<Blacklight::Solr::Response::Facets::FacetField>]
     def search_facets


### PR DESCRIPTION
Fixes two cases of Rails/Delegate, which are now caught thanks to an [enhancement in rubocop-rails 2.30.0](https://github.com/rubocop/rubocop-rails/releases/tag/v2.30.0).


<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
