### PR TITLE
[8.x] Backport: Remove incomplete implementation of menu aria role from Blacklight::System::DropdownComponent

### DIFF
--- a/app/components/blacklight/system/dropdown_component.html.erb
+++ b/app/components/blacklight/system/dropdown_component.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag :div, id: @id, class: @classes.join(' ') do %>
   <%= button %>
 
-  <div class="dropdown-menu" role="menu">
+  <div class="dropdown-menu">
     <% options.each do |option| %>
       <%= option %>
     <% end %>

--- a/app/components/blacklight/system/dropdown_component.rb
+++ b/app/components/blacklight/system/dropdown_component.rb
@@ -6,7 +6,7 @@ module Blacklight
       renders_one :button, DropdownButtonComponent
 
       renders_many :options, (lambda do |text:, url:, selected: false|
-        link_to(text, url, class: "dropdown-item #{'active' if selected}", role: 'menuitem', aria: { current: ('page' if selected) })
+        link_to(text, url, class: "dropdown-item #{'active' if selected}", aria: { current: ('page' if selected) })
       end)
 
       # rubocop:disable Metrics/ParameterLists

--- a/spec/components/blacklight/system/dropdown_component_spec.rb
+++ b/spec/components/blacklight/system/dropdown_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::System::DropdownComponent, type: :component do
+  it 'includes a link for each choice' do
+    search_state = double(Blacklight::SearchState)
+    allow(search_state).to receive(:params_for_search).and_return('http://example.com')
+    rendered = render_inline(described_class.new(
+                               param: :per_page,
+                               choices: [
+                                 ['10 per page', 10],
+                                 ['20 per page', 20]
+                               ],
+                               search_state: search_state,
+                               selected: 20,
+                               interpolation: :count
+                             ))
+
+    expect(rendered.css('a').length).to eq 2
+    expect(rendered.css('a')[0].text).to eq '10 per page'
+    expect(rendered.css('a')[0].attributes).not_to have_key 'aria-current'
+    expect(rendered.css('a')[1].text).to eq '20 per page'
+    expect(rendered.css('a')[1].attributes).to have_key 'aria-current'
+  end
+end


### PR DESCRIPTION
This is a backport of #3519 
<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
