### PR TITLE
Fix facet prev/next nav link appearance when the link is disabled. Fi…

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -434,9 +434,6 @@ main {
 .modal-content .blacklight-modal-close {
   display: block;
 }
-.modal-content .prev_next_links.btn-group .btn {
-  border: 0;
-}
 
 .blacklight-modal-close {
   display: none;

--- a/app/assets/stylesheets/blacklight/_modal.scss
+++ b/app/assets/stylesheets/blacklight/_modal.scss
@@ -14,10 +14,6 @@
   .blacklight-modal-close {
     display: block;
   }
-
-  .prev_next_links.btn-group .btn {
-    border: 0;
-  }
 }
 
 // app/views/catalog/facet.html.erb may be rendered as a modal or a whole page.

--- a/app/components/blacklight/facet_field_pagination_component.html.erb
+++ b/app/components/blacklight/facet_field_pagination_component.html.erb
@@ -1,10 +1,10 @@
 <div class="prev_next_links btn-group">
   <%= helpers.link_to_previous_page @facet_field.paginator, raw(t('views.pagination.previous')), params: @facet_field.search_state.to_h, param_name: param_name, class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
-    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn' %>
+    <%= content_tag :a, raw(t('views.pagination.previous')), class: 'disabled btn btn-link text-decoration-none', aria: { disabled: true } %>
   <% end %>
 
   <%= helpers.link_to_next_page @facet_field.paginator, raw(t('views.pagination.next')), params: @facet_field.search_state.to_h, param_name: param_name, class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
-    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn' %>
+    <%= content_tag :a, raw(t('views.pagination.next')), class: 'disabled btn btn-link text-decoration-none', aria: { disabled: true } %>
   <% end %>
 </div>
 


### PR DESCRIPTION
…xes #3532

- BS5 btn classes are not meant for span tags (see https://getbootstrap.com/docs/5.3/components/buttons/#button-tags)
- BS5 disabled buttons should not have an href, and should use aria-disabled="true" (see https://getbootstrap.com/docs/5.3/components/buttons/#disabled-state)
