### PR TITLE
Allow use of request builder

### DIFF
--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -56,15 +56,11 @@ module Blacklight::Solr
     end
 
     ##
-    # Execute a solr query
+    # Execute a solr query at the given path with the parameters
     # TODO: Make this private after we have a way to abstract admin/luke and ping
     # @see [RSolr::Client#send_and_receive]
-    # @overload find(solr_path, params)
-    #   Execute a solr query at the given path with the parameters
-    #   @param [String] solr path (defaults to blacklight_config.solr_path)
-    #   @param [Hash] parameters for RSolr::Client#send_and_receive
-    # @overload find(params)
-    #   @param [Hash] parameters for RSolr::Client#send_and_receive
+    # @param [String] path solr path (defaults to blacklight_config.solr_path)
+    # @param [Hash, Blacklight::SearchBuilder] solr_params parameters for RSolr::Client#send_and_receive
     # @return [Blacklight::Solr::Response] the solr response object
     def send_and_receive(path, solr_params = {})
       benchmark("Solr fetch", level: :debug) do

--- a/lib/blacklight/solr/response.rb
+++ b/lib/blacklight/solr/response.rb
@@ -8,12 +8,16 @@ class Blacklight::Solr::Response < ActiveSupport::HashWithIndifferentAccess
   include MoreLikeThis
   include Params
 
-  attr_reader :request_params
+  attr_reader :request_params, :search_builder
   attr_accessor :blacklight_config, :options
 
   delegate :document_factory, to: :blacklight_config
 
+  # @param [Hash] data
+  # @param [Hash, Blacklight::SearchBuilder] request_params a SearchBuilder or a Hash of parameters
   def initialize(data, request_params, options = {})
+    @search_builder = request_params if request_params.is_a?(Blacklight::SearchBuilder)
+
     super(force_to_utf8(ActiveSupport::HashWithIndifferentAccess.new(data)))
     @request_params = ActiveSupport::HashWithIndifferentAccess.new(request_params)
     self.blacklight_config = options[:blacklight_config]

--- a/lib/blacklight/solr/response/params.rb
+++ b/lib/blacklight/solr/response/params.rb
@@ -52,10 +52,6 @@ module Blacklight::Solr::Response::Params
 
   private
 
-  def search_builder
-    request_params if request_params.is_a?(Blacklight::SearchBuilder)
-  end
-
   # Extract JSON Request API parameters from the response header or the request itself
   def json_params
     encoded_json_params = header&.dig('params', 'json')


### PR DESCRIPTION
This fixes behavior introduced in #2435. The conditional was never satisfied because `request_params` was cast to a `ActiveSupport::HashWithIndifferentAccess` in the initializer

