### PR TITLE
Bugfix: allow facet filter/suggest input to work with the sort toggle…

### DIFF
--- a/app/components/blacklight/search/facet_suggest_input.html.erb
+++ b/app/components/blacklight/search/facet_suggest_input.html.erb
@@ -4,6 +4,9 @@
 <%= text_field_tag "facet_suggest_#{facet.key}",
   nil,
   class: "facet-suggest form-control mb-3",
-  data: {facet_field: facet.key},
+  data: {
+    facet_field: facet.key,
+    facet_search_context: presenter.view_context.search_facet_path(id: facet.key)
+  },
   placeholder: I18n.t('blacklight.search.form.search.placeholder')
 %>

--- a/app/javascript/blacklight-frontend/facet_suggest.js
+++ b/app/javascript/blacklight-frontend/facet_suggest.js
@@ -4,20 +4,40 @@ const FacetSuggest = async (e) => {
   if (e.target.matches('.facet-suggest')) {
     const queryFragment = e.target.value?.trim();
     const facetField = e.target.dataset.facetField;
+    const facetArea = document.querySelector('.facet-extended-list');
+    const prevNextLinks = document.querySelectorAll('.prev_next_links');
+
     if (!facetField) { return; }
 
-    const urlToFetch = `/catalog/facet_suggest/${facetField}/${queryFragment}${window.location.search}`
+    // Get the search params from the current query so the facet suggestions
+    // can retain that context.
+    const facetSearchContext = e.target.dataset.facetSearchContext;
+    const url = new URL(facetSearchContext, window.location.origin);
+
+    // Drop facet.page so a filtered suggestion list will always start on page 1
+    url.searchParams.delete('facet.page');
+    const facetSearchParams = url.searchParams.toString();
+
+    const urlToFetch = `/catalog/facet_suggest/${facetField}/${queryFragment}?${facetSearchParams}`;
+
     const response = await fetch(urlToFetch);
     if (response.ok) {
         const blob = await response.blob()
         const text = await blob.text()
 
-        const facetArea = document.querySelector('.facet-extended-list');
-
         if (text && facetArea) {
             facetArea.innerHTML = text
         }
     }
+
+    // Hide the prev/next links when a user enters text in the facet
+    // suggestion input. They don't work with a filtered list.
+    prevNextLinks.forEach(element => {
+      element.classList.toggle('invisible', !!queryFragment);
+    });
+
+    // Add a class to distinguish suggested facet values vs. regular.
+    facetArea.classList.toggle('facet-suggestions', !!queryFragment);
   }
 };
 

--- a/spec/components/blacklight/search/facet_suggest_input_spec.rb
+++ b/spec/components/blacklight/search/facet_suggest_input_spec.rb
@@ -5,9 +5,11 @@ require 'spec_helper'
 RSpec.describe Blacklight::Search::FacetSuggestInput, type: :component do
   let(:facet) { Blacklight::Configuration::FacetField.new key: 'language_facet', suggest: true }
   let(:presenter) { instance_double(Blacklight::FacetFieldPresenter) }
+  let(:view_context) { double(ActionView::Base) }
 
   before do
-    allow(presenter).to receive(:label).and_return 'Language'
+    allow(presenter).to receive_messages(label: 'Language', view_context: view_context)
+    allow(view_context).to receive(:search_facet_path).and_return('/catalog/facet/language_facet')
   end
 
   it 'has an input with the facet-suggest class, which the javascript needs to find it' do
@@ -18,6 +20,12 @@ RSpec.describe Blacklight::Search::FacetSuggestInput, type: :component do
   it 'has an input with the data-facet-field attribute, which the javascript needs to determine the correct query' do
     rendered = render_inline(described_class.new(facet: facet, presenter: presenter))
     expect(rendered.css('input[data-facet-field="language_facet"]').count).to eq 1
+  end
+
+  it 'has an input with the data-facet-search-context attribute, which the javascript needs to determine the current search context' do
+    allow(view_context).to receive(:search_facet_path).and_return('/catalog/facet/language_facet?f%5Bformat%5D%5B%5D=Book&facet.prefix=R&facet.sort=index&q=tibet&search_field=all_fields')
+    rendered = render_inline(described_class.new(facet: facet, presenter: presenter))
+    expect(rendered.css('input[data-facet-search-context="/catalog/facet/language_facet?f%5Bformat%5D%5B%5D=Book&facet.prefix=R&facet.sort=index&q=tibet&search_field=all_fields"]').count).to eq 1
   end
 
   it 'has a visible label that is associated with the input' do

--- a/spec/views/catalog/facet.html.erb_spec.rb
+++ b/spec/views/catalog/facet.html.erb_spec.rb
@@ -4,11 +4,14 @@ RSpec.describe 'catalog/facet.html.erb' do
   let(:display_facet) { double }
   let(:blacklight_config) { Blacklight::Configuration.new }
   let(:component) { instance_double(Blacklight::FacetComponent) }
+  let(:facet_suggest_input) { instance_double(Blacklight::Search::FacetSuggestInput) }
 
   before do
     allow(Blacklight::FacetComponent).to receive(:new).and_return(component)
+    allow(Blacklight::Search::FacetSuggestInput).to receive(:new).and_return(facet_suggest_input)
     allow(view).to receive(:render).and_call_original
     allow(view).to receive(:render).with(component)
+    allow(view).to receive(:render).with(facet_suggest_input)
 
     blacklight_config.add_facet_field 'xyz', label: "Facet title"
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
@@ -20,6 +23,11 @@ RSpec.describe 'catalog/facet.html.erb' do
   it "has the facet title" do
     render
     expect(rendered).to have_css 'h1', text: "Facet title"
+  end
+
+  it "renders the facet suggest input" do
+    render
+    expect(view).to have_received(:render).with(facet_suggest_input)
   end
 
   it "renders facet pagination" do


### PR DESCRIPTION
… and starting letter nav. Fixes #3515.

- pass the search_facet_path into the input as a data-attribute; it has the facet's current search context
- hide the facet's prev/next nav links when a user has entered text in the facet filter
- add a .facet-suggestions class to distinguish suggested facet values from regular
- check for .facet-suggestions in JS specs before checking other expectations, otherwise the debounce makes timing unpredictable