### PR TITLE
Fix wrapping for A-Z facet nav. Fixes #3523; relates to #2072.

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -180,10 +180,8 @@ main {
   padding-left: 0;
 }
 
-@media (max-width: 575.98px) {
-  .pagination {
-    flex-wrap: wrap;
-  }
+.pagination {
+  flex-wrap: wrap;
 }
 
 .group-key {

--- a/app/assets/stylesheets/blacklight/_pagination.scss
+++ b/app/assets/stylesheets/blacklight/_pagination.scss
@@ -6,7 +6,5 @@
 }
 
 .pagination {
-  @media (max-width: breakpoint-max(sm)) {
-    flex-wrap: wrap;
-  }
+  flex-wrap: wrap;
 }


### PR DESCRIPTION
- original fix only added wrap for .pagination up to sm breakpoint; no harm in it applying at all widths



