### PR TITLE
Fix importmap generator so it loads blacklight css using @import rath…

### DIFF
--- a/lib/generators/blacklight/assets/importmap_generator.rb
+++ b/lib/generators/blacklight/assets/importmap_generator.rb
@@ -49,9 +49,7 @@ module Blacklight
         else
           append_to_file 'app/assets/stylesheets/application.css' do
             <<~CONTENT
-              /*
-               *= require blacklight
-               */
+              @import url("blacklight.css");
               @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css);
             CONTENT
           end


### PR DESCRIPTION
…er than a deprecated Sprockets directive. Fixes #3550.