### PR TITLE
Ensure facet filter gray box (in modal or facet browse page) doesn't …

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -404,6 +404,12 @@ main {
   background: transparent url('data:image/svg+xml,%3csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-dash-square" viewBox="0 0 16 16"%3e%3cpath d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z" /%3e%3cpath d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z" /%3e%3c/svg%3e') center/1em auto no-repeat;
 }
 
+/* Facet browse pages & modals
+-------------------------------------------------- */
+.facet-filters:not(:has(*)) {
+  display: none !important;
+}
+
 /* Search History */
 .search-history {
   --bl-history-filter-name-color: var(--bs-secondary-color);

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -205,3 +205,9 @@ $facet-toggle-height: $facet-toggle-width !default;
       $facet-toggle-width auto no-repeat;
   }
 }
+
+/* Facet browse pages & modals
+-------------------------------------------------- */
+.facet-filters:not(:has(*)) {
+  display: none !important;
+}

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,10 +1,9 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
+  <% component.with_title { facet_field_label(@facet.key) } %>
 
-  <div class="card card-body bg-light p-3 mb-3 border-0">
-    <% component.with_title { facet_field_label(@facet.key) } %>
+  <div class="facet-filters card card-body bg-light p-3 mb-3 border-0">
     <%= render Blacklight::Search::FacetSuggestInput.new(facet: @facet, presenter: @presenter) %>
     <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
-
   </div>
 
   <div class="facet-pagination top d-flex flex-wrap w-100 justify-content-between border-bottom pb-3 mb-3">


### PR DESCRIPTION
…appear if it's empty. Fixes #3552.

- this area will be empty for facets configured with suggest: false
- uses a simple :has CSS rule rather than complicate the template rendering
