### PR TITLE
Darken modal backdrops, to match Bootstrap opacity. Fixes #3561.

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -18,6 +18,8 @@
   --bl-constraint-remove-hover-bg: #bb2d3b;
   --bl-constraint-remove-hover-border-color: #bb2d3b;
   --bl-field-name-color: var(--bs-secondary-color);
+  /* emulate Bootstrap backdrop bg & opacity */
+  --bl-modal-backdrop-bg: rgba(0, 0, 0, 0.5);
 }
 
 .page-link {
@@ -30,6 +32,9 @@ dialog.modal[open] {
   border: none;
   max-height: unset;
   max-width: unset;
+}
+dialog.modal[open]::backdrop {
+  background-color: var(--bl-modal-backdrop-bg);
 }
 
 /* Generic layout stuff */

--- a/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss
@@ -14,4 +14,8 @@ dialog.modal[open] {
 
   max-height: unset; // override user-agent dialog
   max-width: unset; // override user-agent dialog
+
+  &::backdrop {
+    background-color: var(--bl-modal-backdrop-bg);
+  }
 }

--- a/app/assets/stylesheets/blacklight/blacklight_defaults.scss
+++ b/app/assets/stylesheets/blacklight/blacklight_defaults.scss
@@ -15,4 +15,7 @@
   --bl-constraint-remove-hover-border-color: #bb2d3b;
 
   --bl-field-name-color: var(--bs-secondary-color);
+
+  /* emulate Bootstrap backdrop bg & opacity */
+  --bl-modal-backdrop-bg: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
- Uses black w/0.5 opacity by default to match BS4 & BS5 modals (native dialog uses 0.1)
- Adds --bl-modal-backdrop-bg CSS variable for downstream customization
