### PR TITLE
Fix importmap generator order for blacklight & bootstrap CSS so black…

### DIFF
--- a/lib/generators/blacklight/assets/importmap_generator.rb
+++ b/lib/generators/blacklight/assets/importmap_generator.rb
@@ -49,8 +49,8 @@ module Blacklight
         else
           append_to_file 'app/assets/stylesheets/application.css' do
             <<~CONTENT
-              @import url("blacklight.css");
               @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css);
+              @import url("blacklight.css");
             CONTENT
           end
         end


### PR DESCRIPTION
…light takes precedence. Fixes #3564.
