### PR TITLE
Remove unnecessary !important CSS rule. Followup for #3552.

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -412,7 +412,7 @@ main {
 /* Facet browse pages & modals
 -------------------------------------------------- */
 .facet-filters:not(:has(*)) {
-  display: none !important;
+  display: none;
 }
 
 /* Search History */

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -209,5 +209,5 @@ $facet-toggle-height: $facet-toggle-width !default;
 /* Facet browse pages & modals
 -------------------------------------------------- */
 .facet-filters:not(:has(*)) {
-  display: none !important;
+  display: none;
 }


### PR DESCRIPTION
- With #3566 in place, the blacklight CSS takes precedence over bootstrap
