### PR TITLE
[7.x] Fix testing in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,19 +22,19 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.2
         bundler: 'default'
     - name: Install dependencies
       run: bundle install
     - name: Run linter
       run: bundle exec rake rubocop
-  test:
+  test_rails7_1:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.1, 3.2]
+        ruby: [3.2, 3.3]
     env:
-      RAILS_VERSION: 7.0.8
+      RAILS_VERSION: 7.1.5.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0']
+        ruby: [3.3]
     env:
-      RAILS_VERSION: 7.0.8
+      RAILS_VERSION: 7.1.5.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -69,33 +69,13 @@ jobs:
       env:
         BOOTSTRAP_VERSION: '~> 5.0'
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test'
-  test_rails6_1:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: ['3.0']
-    env:
-      RAILS_VERSION: 6.1.6.1
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler: 'default'
-    - name: Install dependencies
-      run: bundle install
-    - name: Run tests
-      run: bundle exec rake ci
-      env:
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-keeps --skip-action-cable --skip-test'
   test_rails7_2:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.1, 3.2]
+        ruby: [3.3, 3.4]
     env:
-      RAILS_VERSION: 7.2.0
+      RAILS_VERSION: 7.2.2.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -113,9 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2']
+        ruby: [3.3]
     env:
-      RAILS_VERSION: 7.0.8
+      RAILS_VERSION: 7.1.5.1
       VIEW_COMPONENT_VERSION: "~> 2.74"
     steps:
     - uses: actions/checkout@v2
@@ -134,9 +114,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, '3.0']
+        ruby: [3.2, 3.3]
     env:
-      RAILS_VERSION: 7.0.8
+      RAILS_VERSION: 7.1.5.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     environment:
       - SOLR_PORT # Set via environment variable or use default defined in .env file
       - SOLR_VERSION # Set via environment variable or use default defined in .env file
+      - SOLR_MODULES=analysis-extras
     image: "solr:${SOLR_VERSION}"
     volumes:
       - $PWD/lib/generators/blacklight/templates/solr/conf:/opt/solr/conf

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -16,7 +16,7 @@
     </updateLog>
   </updateHandler>
 
-  <!-- solr lib dirs -->
+  <!-- solr lib dirs, which are needed for Solr 8 compatibility but ignored in solr 9.8 and above -->
   <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />


### PR DESCRIPTION
- backports same Solr 9.8 compatibility fix that was previously backported to 8.x
- bumps versions of ruby & rails tested via CI to supported versions, drops EOL versions