### PR TITLE
Separate into reusable workflows so we can schedule CI for release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ''
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Build docker image
+        run: docker compose build app

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ''
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler: "latest"
+      - name: Change permissions
+        run: "chmod -f -R o-w /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems | :"
+      - name: Install dependencies
+        run: bundle install
+      - name: Run linter
+        run: bundle exec rake rubocop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "release-*"
+  pull_request:
+  schedule:
+    # Weekly at 9:35 on Friday
+    # Somewhat weird timing so that it isn't delayed too much
+    - cron: '35 9 * * 5'
+jobs:
+  lint:
+    uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
+  # test:
+  #   uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
+  #   with:
+  #     ruby: '["3.4"]'
+  # docker_build:
+  #   uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,16 +13,12 @@ on:
       - main
       - "release-*"
   pull_request:
-  schedule:
-    # Weekly at 9:35 on Friday
-    # Somewhat weird timing so that it isn't delayed too much
-    - cron: '35 9 * * 5'
 jobs:
   lint:
     uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
-  # test:
-  #   uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
-  #   with:
-  #     ruby: '["3.4"]'
-  # docker_build:
-  #   uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run
+  test:
+    uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
+    with:
+      ruby: '["3.4"]'
+  docker_build:
+    uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run

--- a/.github/workflows/release_8_x_scheduled.yml
+++ b/.github/workflows/release_8_x_scheduled.yml
@@ -8,35 +8,28 @@
 name: release-8.x scheduled
 
 on:
-  # remove pull request once we know this is working
-  pull_request:
   schedule:
     # Weekly at 9:35 on Friday
     # Somewhat weird timing so that it isn't delayed too much
     - cron: '35 9 * * 5'
 jobs:
-  # lint:
-  #   uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
-  #   with:
-  #     ref: release-8.x
-  # test:
-  #   uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
-  #   with:
-  #     ref: release-8.x
-  #     ruby: '["3.3"]'
-  # docker_build:
-  #   uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run
-  #   with:
-  #     ref: release-8.x
-  fail-on-purpose:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 1
+  lint:
+    uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
+    with:
+      ref: release-8.x
+  test:
+    uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
+    with:
+      ref: release-8.x
+      ruby: '["3.3"]'
+  docker_build:
+    uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run
+    with:
+      ref: release-8.x
   report:
     runs-on: ubuntu-latest
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
-    needs: [fail-on-purpose]
-    # needs: [lint, test, docker_build]
+    needs: [lint, test, docker_build]
     steps:
       - name: Report on failure of any dependent job
         env:
@@ -47,4 +40,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "TESTING!!! The weekly CI run of the release-8.x branch has failed TESTING!!!"
+            text: "The weekly CI run of the release-8.x branch has failed"

--- a/.github/workflows/release_8_x_scheduled.yml
+++ b/.github/workflows/release_8_x_scheduled.yml
@@ -34,14 +34,13 @@ jobs:
       - run: exit 1
   report:
     runs-on: ubuntu-latest
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
     needs: [fail-on-purpose]
     # needs: [lint, test, docker_build]
     steps:
       - name: Report on failure of any dependent job
         env:
           NEEDS: ${{ toJSON(needs) }}
-        if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -49,13 +48,3 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
             text: "TESTING!!! The weekly CI run of the release-8.x branch has failed TESTING!!!"
-  ensure-report-runs:
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [report]
-    steps:
-      - name: Hello World        
-        env:
-          NEEDS: ${{ toJSON(needs) }}     
-        run: |
-          echo "$NEEDS"

--- a/.github/workflows/release_8_x_scheduled.yml
+++ b/.github/workflows/release_8_x_scheduled.yml
@@ -1,0 +1,61 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: release-8.x scheduled
+
+on:
+  # remove pull request once we know this is working
+  pull_request:
+  schedule:
+    # Weekly at 9:35 on Friday
+    # Somewhat weird timing so that it isn't delayed too much
+    - cron: '35 9 * * 5'
+jobs:
+  # lint:
+  #   uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
+  #   with:
+  #     ref: release-8.x
+  # test:
+  #   uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
+  #   with:
+  #     ref: release-8.x
+  #     ruby: '["3.3"]'
+  # docker_build:
+  #   uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run
+  #   with:
+  #     ref: release-8.x
+  fail-on-purpose:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+  report:
+    runs-on: ubuntu-latest
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    needs: [fail-on-purpose]
+    # needs: [lint, test, docker_build]
+    steps:
+      - name: Report on failure of any dependent job
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "TESTING!!! The weekly CI run of the release-8.x branch has failed TESTING!!!"
+  ensure-report-runs:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [report]
+    steps:
+      - name: Hello World        
+        env:
+          NEEDS: ${{ toJSON(needs) }}     
+        run: |
+          echo "$NEEDS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,42 +1,23 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
-name: CI
-
 on:
-  push:
-    branches:
-      - main
-      - "release-*"
-  pull_request:
-
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ''
+        description: The branch or reference to run the workflow against
+      ruby:
+        required: true
+        type: string
+        description: The Ruby or Rubies used in the matrix. Must be in format '["ruby.version"]'
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.2
-          bundler: "latest"
-      - name: Change permissions
-        run: "chmod -f -R o-w /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems | :"
-      - name: Install dependencies
-        run: bundle install
-      - name: Run linter
-        run: bundle exec rake rubocop
   test:
     runs-on: ubuntu-latest
-    name: test (ruby ${{ matrix.ruby }} / rails ${{ matrix.rails_version }} ${{ matrix.additional_name }})
+    name: ruby ${{ matrix.ruby }} | rails ${{ matrix.rails_version }} ${{ matrix.additional_name }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.4"]
+        ruby: ${{ fromJSON(inputs.ruby) }}
         rails_version: ["7.1.5.1", "7.2.2.1"]
         bootstrap_version: [null]
         view_component_version: ["~> 3.12"]
@@ -50,24 +31,24 @@ jobs:
           - ruby: "3.3"
             rails_version: "8.0.1"
             additional_engine_cart_rails_options: --css=bootstrap --js=esbuild
-            additional_name: "/ esbuild"
+            additional_name: "| esbuild"
           - ruby: "3.2"
             rails_version: "7.1.5.1"
             solr_version: "8.11.2"
-            additional_name: "Solr 8.11.2"
+            additional_name: "| Solr 8.11.2"
           - ruby: "3.3"
             rails_version: "7.1.5.1"
-            additional_name: "/ Propshaft"
+            additional_name: "| Propshaft"
             additional_engine_cart_rails_options: -a propshaft --css=bootstrap
           - ruby: "3.3"
             rails_version: "7.1.5.1"
             api: "true"
             additional_engine_cart_rails_options: --api --skip-yarn
-            additional_name: "/ API"
+            additional_name: "| API"
           - ruby: "3.3"
             rails_version: "7.2.2.1"
             additional_engine_cart_rails_options: -a propshaft --css=bootstrap --js=esbuild
-            additional_name: "/ Propshaft, esbuild"
+            additional_name: "| Propshaft, esbuild"
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       SOLR_VERSION: ${{ matrix.solr_version || 'latest' }}
@@ -77,6 +58,8 @@ jobs:
       ENGINE_CART_RAILS_OPTIONS: "--skip-git --skip-listen --skip-spring --skip-keeps --skip-kamal --skip-solid --skip-coffee --skip-test ${{ matrix.additional_engine_cart_rails_options }}"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -88,9 +71,3 @@ jobs:
         run: bundle install
       - name: Run tests
         run: bundle exec rake ci
-  docker_build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build docker image
-        run: docker compose build app


### PR DESCRIPTION
See this [workflow run](https://github.com/projectblacklight/blacklight/actions/runs/14522877941) for an example of what will happen if one of the release-8.x CI runs fails.

In order to re-use workflows, separated existing configuration into reusable workflows. 

TODO: Allow more of the matrix to be configurable, especially the "include" stanza. Once the release-7.x branch is green, this will be needed to add that branch to this configuration.

It could also be worth it to put these actions into their own repo in the projectblacklight namespace, and try to configure some of the plugins to use them as well, which could help with compatibility snarls, but that's a bigger project.