### PR TITLE
Use relative paths for workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ on:
   pull_request:
 jobs:
   lint:
-    uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
+    uses: ./.github/workflows/lint.yml
   test:
-    uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
+    uses: ./.github/workflows/test.yml
     with:
       ruby: '["3.4"]'
   docker_build:
-    uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release_8_x_scheduled.yml
+++ b/.github/workflows/release_8_x_scheduled.yml
@@ -14,16 +14,15 @@ on:
     - cron: '35 9 * * 5'
 jobs:
   lint:
-    uses: projectblacklight/blacklight/.github/workflows/lint.yml@weekly_ci_run
+    uses: ./.github/workflows/lint.yml
     with:
       ref: release-8.x
   test:
-    uses: projectblacklight/blacklight/.github/workflows/test.yml@weekly_ci_run
+    uses: ./.github/workflows/lint.yml
     with:
       ref: release-8.x
-      ruby: '["3.3"]'
   docker_build:
-    uses: projectblacklight/blacklight/.github/workflows/build.yml@weekly_ci_run
+    uses: ./.github/workflows/lint.yml
     with:
       ref: release-8.x
   report:

--- a/app/controllers/concerns/blacklight/search_context.rb
+++ b/app/controllers/concerns/blacklight/search_context.rb
@@ -40,7 +40,7 @@ module Blacklight::SearchContext
         @page_link_data[:prev] = page_links_document_path(documents.first, index)
         @page_link_data[:next] = page_links_document_path(documents.last, index + 2)
       end
-      if response&.total && response.total.positive?
+      if response&.total&.positive?
         @page_link_data[:counterRaw] = counter_param
         @page_link_data[:counterDelimited] = helpers.number_with_delimiter(counter_param.to_i)
         @page_link_data[:totalRaw] = response.total

--- a/lib/blacklight/configuration/field.rb
+++ b/lib/blacklight/configuration/field.rb
@@ -33,6 +33,7 @@ module Blacklight
       raise ArgumentError, "Must supply a field name" if self.field.nil?
     end
 
+    # rubocop:disable Style/RedundantParentheses
     def display_label(context = nil, **)
       field_label(
         (:"blacklight.search.fields.#{context}.#{key}" if context),
@@ -42,6 +43,7 @@ module Blacklight
         **
       )
     end
+    # rubocop:enable Style/RedundantParentheses
 
     def default_label
       if self.key.respond_to?(:titleize)


### PR DESCRIPTION
We should point to a relative path in the repository, not a specific branch.

Once we get the release-8.x branch updated, we can run against the actions on that branch, making versioning easier.

This PR also fixes rubocop errors.