### PR TITLE
Run release-8.x on actions from branch

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -1,0 +1,60 @@
+{
+  "ruby": ["3.4"],
+  "rails_version": [
+    "7.1.5.1",
+    "7.2.2.1"
+  ],
+  "bootstrap_version": [
+    null
+  ],
+  "view_component_version": [
+    "~> 3.12"
+  ],
+  "api": [
+    null
+  ],
+  "additional_engine_cart_rails_options": [
+    ""
+  ],
+  "additional_name": [
+    ""
+  ],
+  "include": [
+    {
+      "ruby": "3.3",
+      "rails_version": "8.0.1",
+      "additional_engine_cart_rails_options": "--css=bootstrap"
+    },
+    {
+      "ruby": "3.3",
+      "rails_version": "8.0.1",
+      "additional_engine_cart_rails_options": "--css=bootstrap --js=esbuild",
+      "additional_name": "| esbuild"
+    },
+    {
+      "ruby": "3.2",
+      "rails_version": "7.1.5.1",
+      "solr_version": "8.11.2",
+      "additional_name": "| Solr 8.11.2"
+    },
+    {
+      "ruby": "3.3",
+      "rails_version": "7.1.5.1",
+      "additional_name": "| Propshaft",
+      "additional_engine_cart_rails_options": "-a propshaft --css=bootstrap"
+    },
+    {
+      "ruby": "3.3",
+      "rails_version": "7.1.5.1",
+      "api": "true",
+      "additional_engine_cart_rails_options": "--api --skip-yarn",
+      "additional_name": "| API"
+    },
+    {
+      "ruby": "3.3",
+      "rails_version": "7.2.2.1",
+      "additional_engine_cart_rails_options": "-a propshaft --css=bootstrap --js=esbuild",
+      "additional_name": "| Propshaft, esbuild"
+    }
+  ]
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,5 @@ jobs:
     uses: ./.github/workflows/lint.yml
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      ruby: '["3.4"]'
   docker_build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/release_8_x_scheduled.yml
+++ b/.github/workflows/release_8_x_scheduled.yml
@@ -1,9 +1,5 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+# If there are failures running this workflow, please resolve them on the release-8.x branch
+# and then port any necessary changes to this branch.
 
 name: release-8.x scheduled
 
@@ -14,15 +10,15 @@ on:
     - cron: '35 9 * * 5'
 jobs:
   lint:
-    uses: ./.github/workflows/lint.yml
+    uses: projectblacklight/blacklight/.github/workflows/lint.yml@release-8.x
     with:
       ref: release-8.x
   test:
-    uses: ./.github/workflows/lint.yml
+    uses: projectblacklight/blacklight/.github/workflows/test.yml@release-8.x
     with:
       ref: release-8.x
   docker_build:
-    uses: ./.github/workflows/lint.yml
+    uses: projectblacklight/blacklight/.github/workflows/build.yml@release-8.x
     with:
       ref: release-8.x
   report:

--- a/.github/workflows/release_8_x_scheduled.yml
+++ b/.github/workflows/release_8_x_scheduled.yml
@@ -4,6 +4,7 @@
 name: release-8.x scheduled
 
 on:
+  workflow_dispatch:
   schedule:
     # Weekly at 9:35 on Friday
     # Somewhat weird timing so that it isn't delayed too much

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,49 +6,29 @@ on:
         type: string
         default: ''
         description: The branch or reference to run the workflow against
-      ruby:
-        required: true
-        type: string
-        description: The Ruby or Rubies used in the matrix. Must be in format '["ruby.version"]'
 jobs:
+  set_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Echo ./.github/matrix.json
+        id: matrix
+        run: |
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          cat ./.github/matrix.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
   test:
+    needs: set_matrix
     runs-on: ubuntu-latest
     name: ruby ${{ matrix.ruby }} | rails ${{ matrix.rails_version }} ${{ matrix.additional_name }}
     strategy:
       fail-fast: false
-      matrix:
-        ruby: ${{ fromJSON(inputs.ruby) }}
-        rails_version: ["7.1.5.1", "7.2.2.1"]
-        bootstrap_version: [null]
-        view_component_version: ["~> 3.12"]
-        api: [null]
-        additional_engine_cart_rails_options: [""]
-        additional_name: [""]
-        include:
-          - ruby: "3.3"
-            rails_version: "8.0.1"
-            additional_engine_cart_rails_options: --css=bootstrap
-          - ruby: "3.3"
-            rails_version: "8.0.1"
-            additional_engine_cart_rails_options: --css=bootstrap --js=esbuild
-            additional_name: "| esbuild"
-          - ruby: "3.2"
-            rails_version: "7.1.5.1"
-            solr_version: "8.11.2"
-            additional_name: "| Solr 8.11.2"
-          - ruby: "3.3"
-            rails_version: "7.1.5.1"
-            additional_name: "| Propshaft"
-            additional_engine_cart_rails_options: -a propshaft --css=bootstrap
-          - ruby: "3.3"
-            rails_version: "7.1.5.1"
-            api: "true"
-            additional_engine_cart_rails_options: --api --skip-yarn
-            additional_name: "| API"
-          - ruby: "3.3"
-            rails_version: "7.2.2.1"
-            additional_engine_cart_rails_options: -a propshaft --css=bootstrap --js=esbuild
-            additional_name: "| Propshaft, esbuild"
+      matrix: ${{fromJson(needs.set_matrix.outputs.matrix)}}
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       SOLR_VERSION: ${{ matrix.solr_version || 'latest' }}


### PR DESCRIPTION
- Use the github actions from the release-8.x branch for the release-8.x scheduled job. 
- Put the matrix in a separate matrix.json file for ease of re-use.
