### PR TITLE
[Backport 8.x] Permit markup on prev/next session context buttons

### DIFF
--- a/app/javascript/blacklight/search_context.js
+++ b/app/javascript/blacklight/search_context.js
@@ -1,6 +1,7 @@
 const SearchContext = (e) => {
-  if (e.target.matches('[data-context-href]')) {
-    SearchContext.handleSearchContextMethod.call(e.target, e)
+  const contextLink = e.target.closest('[data-context-href]')
+  if (contextLink) {
+    SearchContext.handleSearchContextMethod.call(contextLink, e)
   }
 }
 


### PR DESCRIPTION
Previously, if a button was customized to have child DOM elements, such as:
```html
<a href="..." data-context-href="..."><span>Text</span></a>
```

it would not receive the intended behavior.  Becuase the click target would be a child element (the span in this case), not the element with the required dataset attributes


From #3583
<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
