### PR TITLE
[8.x] Remove unnecessary rubocop ignore

### DIFF
--- a/lib/blacklight/configuration/field.rb
+++ b/lib/blacklight/configuration/field.rb
@@ -33,7 +33,6 @@ module Blacklight
       raise ArgumentError, "Must supply a field name" if self.field.nil?
     end
 
-    # rubocop:disable Style/RedundantParentheses
     def display_label(context = nil, **options)
       field_label(
         (:"blacklight.search.fields.#{context}.#{key}" if context),
@@ -43,7 +42,6 @@ module Blacklight
         **options
       )
     end
-    # rubocop:enable Style/RedundantParentheses
 
     def default_label
       if self.key.respond_to?(:titleize)


### PR DESCRIPTION
<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
