### PR TITLE
Stop passing both presenter and document around

### DIFF
--- a/app/components/blacklight/document/thumbnail_component.rb
+++ b/app/components/blacklight/document/thumbnail_component.rb
@@ -9,19 +9,16 @@ module Blacklight
       # @param [Blacklight::DocumentPresenter] presenter
       # @param [Integer] counter
       # @param [Hash] image_options options for the thumbnail presenter's image tag
-      def initialize(counter:, presenter: nil, document: nil, image_options: {})
+      def initialize(counter:, presenter: nil, image_options: {})
         @presenter = presenter
-        @document = presenter&.document || document
         @counter = counter
         @image_options = { alt: '' }.merge(image_options)
       end
 
+      attr_accessor :presenter
+
       def render?
         presenter.thumbnail.exists?
-      end
-
-      def presenter
-        @presenter ||= helpers.document_presenter(@document)
       end
     end
   end

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -36,7 +36,7 @@ module Blacklight
     renders_one :title, (lambda do |*args, component: nil, **kwargs|
       component ||= view_config.title_component || Blacklight::DocumentTitleComponent
 
-      component.new(*args, counter: @counter, document: @document, presenter: @presenter, as: @title_component, actions: !@show, link_to_document: !@show, document_component: self, **kwargs)
+      component.new(*args, counter: @counter, presenter: @presenter, as: @title_component, actions: !@show, link_to_document: !@show, document_component: self, **kwargs)
     end)
 
     renders_one :embed, (lambda do |static_content = nil, *args, component: nil, **kwargs|
@@ -46,7 +46,7 @@ module Blacklight
 
       next unless component
 
-      component.new(*args, document: @document, presenter: @presenter, document_counter: @document_counter, **kwargs)
+      component.new(*args, presenter: @presenter, document_counter: @document_counter, **kwargs)
     end)
 
     # The primary metadata section
@@ -66,7 +66,7 @@ module Blacklight
 
       component ||= view_config.thumbnail_component || Blacklight::Document::ThumbnailComponent
 
-      component.new(*args, document: @document, presenter: @presenter, counter: @counter, image_options: image_options_or_static_content, **kwargs)
+      component.new(*args, presenter: @presenter, counter: @counter, image_options: image_options_or_static_content, **kwargs)
     end)
 
     # A container for partials rendered using the view config partials configuration. Its use is discouraged, but necessary until

--- a/app/components/blacklight/document_title_component.rb
+++ b/app/components/blacklight/document_title_component.rb
@@ -7,12 +7,9 @@ module Blacklight
     renders_many :actions
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(title = nil, document: nil, presenter: nil, as: :h3, counter: nil, classes: 'index_title document-title-heading col h5', link_to_document: true, document_component: nil,
+    def initialize(title = nil, presenter:, as: :h3, counter: nil, classes: 'index_title document-title-heading col h5', link_to_document: true, document_component: nil,
                    actions: true)
-      raise ArgumentError, 'missing keyword: :document or :presenter' if presenter.nil? && document.nil?
-
       @title = title
-      @document = document
       @presenter = presenter
       @as = as || :h3
       @counter = counter
@@ -22,6 +19,8 @@ module Blacklight
       @actions = actions
     end
     # rubocop:enable Metrics/ParameterLists
+
+    attr_accessor :presenter
 
     # Content for the document title area; should be an inline element
     def title
@@ -52,12 +51,6 @@ module Blacklight
       content_tag :span, class: 'document-counter' do
         t('blacklight.search.documents.counter', counter: @counter)
       end
-    end
-
-    private
-
-    def presenter
-      @presenter ||= helpers.document_presenter(@document)
     end
   end
 end


### PR DESCRIPTION
Presenter is a wrapper around the document, so we can just call presenter.document if we need the SolrDocument.  This helps reduce the number of parameters and unnecessary complexity

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
