### PR TITLE
Permit markup on prev/next facet pagination buttons

### DIFF
--- a/app/javascript/blacklight-frontend/modal.js
+++ b/app/javascript/blacklight-frontend/modal.js
@@ -137,7 +137,7 @@ const Modal = (() => {
 
   modal.modalAjaxLinkClick = function(e) {
     e.preventDefault();
-    const href = e.target.getAttribute('href')
+    const href = e.target.closest('a').getAttribute('href')
     fetch(href)
       .then(response => {
          if (!response.ok) {


### PR DESCRIPTION
Previously, if a button was customized to have child DOM elements, such as:
```html
<a href="..."><span>Text</span></a>
```

it would not receive the intended behavior.  Becuase the click target would be a child element (the span in this case), not the link element.

This is similar to #3583