### PR TITLE
Compare document with bookmark using string compairson of class

### DIFF
--- a/app/helpers/blacklight/document_helper_behavior.rb
+++ b/app/helpers/blacklight/document_helper_behavior.rb
@@ -38,10 +38,12 @@ module Blacklight::DocumentHelperBehavior
 
   ##
   # Check if the document is in the user's bookmarks
+  # Note: we do string comparison of the classes, because hot reloading in the development environment may cause each to have
+  #       separate versions of the class loaded (see document.class.object_id and Bookmark#document_type.object_id)
   # @param [Blacklight::Document] document
   # @return [Boolean]
   def bookmarked? document
-    current_bookmarks.any? { |x| x.document_id == document.id && x.document_type == document.class }
+    current_bookmarks.any? { |x| x.document_id == document.id && x.document_type.to_s == document.class.to_s }
   end
 
   ##


### PR DESCRIPTION
Two classes that are of different versions, which can be triggered by changing the source code when using hot reloading, are not equal.  By casting them to_s, then we make them equal even at different versions.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
