### PR TITLE
Remove user_params argument from SearchService

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -284,7 +284,7 @@ module Blacklight::Catalog
   def blacklight_advanced_search_form_search_service
     form_search_state = search_state_class.new(blacklight_advanced_search_form_params, blacklight_config, self)
 
-    search_service_class.new(config: blacklight_config, search_state: form_search_state, user_params: form_search_state.to_h, **search_service_context)
+    search_service_class.new(config: blacklight_config, search_state: form_search_state, **search_service_context)
   end
 
   def blacklight_advanced_search_form_params

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -21,7 +21,7 @@ module Blacklight::Searchable
 
   # @return [Blacklight::SearchService]
   def search_service
-    search_service_class.new(config: blacklight_config, search_state: search_state, user_params: search_state.to_h, **search_service_context)
+    search_service_class.new(config: blacklight_config, search_state: search_state, **search_service_context)
   end
 
   # Override this method on the class that includes Blacklight::Searchable to provide more context to the search service if necessary.

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -3,9 +3,9 @@
 # SearchService returns search results from the repository
 module Blacklight
   class SearchService
-    def initialize(config:, search_state: nil, user_params: nil, search_builder_class: config.search_builder_class, **context)
+    def initialize(config:, search_state:, search_builder_class: config.search_builder_class, **context)
       @blacklight_config = config
-      @search_state = search_state || Blacklight::SearchState.new(user_params || {}, config)
+      @search_state = search_state
       @user_params = @search_state.params
       @search_builder_class = search_builder_class
       @context = context

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Blacklight::SearchService, :api do
   subject { service }
 
   let(:context) { { whatever: :value } }
-  let(:service) { described_class.new(config: blacklight_config, user_params: user_params, **context) }
+  let(:search_state) { Blacklight::SearchState.new(user_params, blacklight_config) }
+  let(:service) { described_class.new(config: blacklight_config, search_state: search_state, **context) }
   let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
   let(:user_params) { {} }
 
@@ -35,8 +36,7 @@ RSpec.describe Blacklight::SearchService, :api do
 
     context 'when the search_builder_class is passed in' do
       let(:klass) { double("Search builder") }
-
-      let(:service) { described_class.new(config: blacklight_config, user_params: user_params, search_builder_class: klass) }
+      let(:context) { { search_builder_class: klass } }
 
       it 'uses the passed value' do
         expect(subject).to eq klass


### PR DESCRIPTION
It's simpler if we always rely on SearchState only

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
