### PR TITLE
Drop jumbotron classes

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,5 +1,5 @@
-<div class="jumbotron text-center p-5 mb-4 bg-light rounded-3">
-  <h1 class="jumbotron-heading"><%= t('blacklight.welcome') %></h1>
+<div class="text-center p-5 mb-4 bg-light rounded-3">
+  <h1 class="fw-bold"><%= t('blacklight.welcome') %></h1>
 
   <p class="lead">Blacklight is a multi-institutional open-source collaboration building a better discovery platform framework.</p>
 


### PR DESCRIPTION
This component is no longer a part of Bootstrap 5 https://getbootstrap.com/docs/5.3/migration/\#jumbotron

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
