### PR TITLE
Remove deprecated navbar-dark class

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -45,6 +45,10 @@ main {
 /*
   Header bar at top (Bootstrap nav-bar)
 */
+.navbar.bg-dark {
+  --bs-emphasis-color-rgb: 255, 255, 255;
+}
+
 .navbar-logo {
   /* The main logo image for the Blacklight instance */
   background: transparent var(--bl-logo-image) no-repeat top left;

--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -2,6 +2,10 @@
   Header bar at top (Bootstrap nav-bar)
 */
 
+.navbar.bg-dark {
+  --bs-emphasis-color-rgb: 255, 255, 255;
+}
+
 .navbar-logo {
   /* The main logo image for the Blacklight instance */
   background: transparent var(--bl-logo-image) no-repeat top left;

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" aria-label="<%= aria_label %>">
+<nav class="navbar navbar-expand-md bg-dark topbar" aria-label="<%= aria_label %>">
   <div class="<%= container_classes %>">
     <%= logo_link %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
See https://getbootstrap.com/docs/5.3/migration/#color-modes-1
<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
