### PR TITLE
Modernized view component testing

### DIFF
--- a/spec/components/blacklight/advanced_search_form_component_spec.rb
+++ b/spec/components/blacklight/advanced_search_form_component_spec.rb
@@ -3,49 +3,42 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::AdvancedSearchFormComponent, type: :component do
-  subject(:render) do
-    component.render_in(view_context)
-  end
-
   let(:component) { described_class.new(url: '/whatever', response: response, params: params) }
   let(:response) { Blacklight::Solr::Response.new({ facet_counts: { facet_fields: { format: { 'Book' => 10, 'CD' => 5 } } } }.with_indifferent_access, {}) }
   let(:params) { {} }
 
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
-  end
-
-  let(:view_context) { controller.view_context }
+  let(:view_context) { vc_test_controller.view_context }
 
   before do
     allow(view_context).to receive(:facet_limit_for).and_return(nil)
+    render_inline component
   end
 
   context 'with additional parameters' do
     let(:params) { { some: :parameter, an_array: [1, 2] } }
 
     it 'adds additional parameters as hidden fields' do
-      expect(rendered).to have_field 'some', with: 'parameter', type: :hidden
-      expect(rendered).to have_field 'an_array[]', with: '1', type: :hidden
-      expect(rendered).to have_field 'an_array[]', with: '2', type: :hidden
+      expect(page).to have_field 'some', with: 'parameter', type: :hidden
+      expect(page).to have_field 'an_array[]', with: '1', type: :hidden
+      expect(page).to have_field 'an_array[]', with: '2', type: :hidden
     end
   end
 
   it 'has text fields for each search field' do
-    expect(rendered).to have_css '.advanced-search-field', count: 4
-    expect(rendered).to have_field 'clause_0_field', with: 'all_fields', type: :hidden
-    expect(rendered).to have_field 'clause_1_field', with: 'title', type: :hidden
-    expect(rendered).to have_field 'clause_2_field', with: 'author', type: :hidden
-    expect(rendered).to have_field 'clause_3_field', with: 'subject', type: :hidden
+    expect(page).to have_css '.advanced-search-field', count: 4
+    expect(page).to have_field 'clause_0_field', with: 'all_fields', type: :hidden
+    expect(page).to have_field 'clause_1_field', with: 'title', type: :hidden
+    expect(page).to have_field 'clause_2_field', with: 'author', type: :hidden
+    expect(page).to have_field 'clause_3_field', with: 'subject', type: :hidden
   end
 
   it 'has filters' do
-    expect(rendered).to have_css '.blacklight-format'
-    expect(rendered).to have_field 'f_inclusive[format][]', with: 'Book'
-    expect(rendered).to have_field 'f_inclusive[format][]', with: 'CD'
+    expect(page).to have_css '.blacklight-format'
+    expect(page).to have_field 'f_inclusive[format][]', with: 'Book'
+    expect(page).to have_field 'f_inclusive[format][]', with: 'CD'
   end
 
   it 'has a sort field' do
-    expect(rendered).to have_select 'sort', options: %w[relevance year author title]
+    expect(page).to have_select 'sort', options: %w[relevance year author title]
   end
 end

--- a/spec/components/blacklight/constraint_layout_component_spec.rb
+++ b/spec/components/blacklight/constraint_layout_component_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new(**params))
+  before do
+    render_inline described_class.new(**params)
   end
 
   describe "for simple display" do
@@ -13,7 +13,7 @@ RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
     end
 
     it "renders label and value" do
-      expect(rendered).to have_css("span.applied-filter.constraint") do |s|
+      expect(page).to have_css("span.applied-filter.constraint") do |s|
         expect(s).to have_css("span.constraint-value")
         expect(s).to have_no_css("a.constraint-value")
         expect(s).to have_css "span.filter-name", text: "my label"
@@ -28,13 +28,13 @@ RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
     end
 
     it "includes remove link" do
-      expect(rendered).to have_css("span.applied-filter") do |s|
+      expect(page).to have_css("span.applied-filter") do |s|
         expect(s).to have_css(".remove[href='http://remove']")
       end
     end
 
     it "has an accessible remove label" do
-      expect(rendered).to have_css(".remove") do |s|
+      expect(page).to have_css(".remove") do |s|
         expect(s).to have_css('.visually-hidden', text: 'Remove constraint my label: my value')
       end
     end
@@ -46,7 +46,7 @@ RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
     end
 
     it "includes them" do
-      expect(rendered).to have_css("span.applied-filter.constraint.class1.class2")
+      expect(page).to have_css("span.applied-filter.constraint.class1.class2")
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe Blacklight::ConstraintLayoutComponent, type: :component do
     end
 
     it "does not escape key and value" do
-      expect(rendered).to have_css("span.applied-filter.constraint span.filter-name span.custom_label")
-      expect(rendered).to have_css("span.applied-filter.constraint span.filter-value span.custom_value")
+      expect(page).to have_css("span.applied-filter.constraint span.filter-name span.custom_label")
+      expect(page).to have_css("span.applied-filter.constraint span.filter-value span.custom_value")
     end
   end
 end

--- a/spec/components/blacklight/constraints_component_spec.rb
+++ b/spec/components/blacklight/constraints_component_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Blacklight::ConstraintsComponent, type: :component do
   subject(:component) { described_class.new(**params) }
 
-  let(:rendered) { render_inline_to_capybara_node(component) }
+  before { render_inline(component) }
 
   let(:params) do
     { search_state: search_state }
@@ -32,19 +32,19 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     let(:query_params) { { q: 'some query' } }
 
     it 'renders a start-over link' do
-      expect(rendered).to have_link 'Start Over', href: '/catalog'
+      expect(page).to have_link 'Start Over', href: '/catalog'
     end
 
     it 'has a header' do
-      expect(rendered).to have_css('h2', text: 'Search Constraints')
+      expect(page).to have_css('h2', text: 'Search Constraints')
     end
 
     it 'wraps the output in a div' do
-      expect(rendered).to have_css('div#appliedParams')
+      expect(page).to have_css('div#appliedParams')
     end
 
     it 'renders the query' do
-      expect(rendered).to have_css('.applied-filter.constraint', text: 'some query')
+      expect(page).to have_css('.applied-filter.constraint', text: 'some query')
     end
   end
 
@@ -52,15 +52,15 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     let(:query_params) { { f: { some_facet: ['some value'] } } }
 
     it 'renders the query' do
-      expect(rendered).to have_css('.constraint-value > .filter-name', text: 'Some Facet').and(have_css('.constraint-value > .filter-value', text: 'some value'))
+      expect(page).to have_css('.constraint-value > .filter-name', text: 'Some Facet').and(have_css('.constraint-value > .filter-value', text: 'some value'))
     end
 
     context 'that is not configured' do
       let(:query_params) { { f: { some_facet: ['some value'], missing: ['another value'] } } }
 
       it 'renders only the configured constraints' do
-        expect(rendered).to have_css('.constraint-value > .filter-name', text: 'Some Facet').and(have_css('.constraint-value > .filter-value', text: 'some value'))
-        expect(rendered).to have_no_css('.constraint-value > .filter-name', text: 'Missing')
+        expect(page).to have_css('.constraint-value > .filter-name', text: 'Some Facet').and(have_css('.constraint-value > .filter-value', text: 'some value'))
+        expect(page).to have_no_css('.constraint-value > .filter-name', text: 'Missing')
       end
     end
   end
@@ -71,15 +71,15 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     let(:query_params) { { q: 'some query', f: { some_facet: ['some value'] } } }
 
     it 'wraps the output in a span' do
-      expect(rendered).to have_css('span .constraint')
+      expect(page).to have_css('span .constraint')
     end
 
     it 'renders the search state as lightly-decorated text' do
-      expect(rendered).to have_css('.constraint > .filter-values', text: 'some query').and(have_css('.constraint', text: 'Some Facet:some value'))
+      expect(page).to have_css('.constraint > .filter-values', text: 'some query').and(have_css('.constraint', text: 'Some Facet:some value'))
     end
 
     it 'omits the headers' do
-      expect(rendered).to have_no_css('h2', text: 'Search Constraints')
+      expect(page).to have_no_css('h2', text: 'Search Constraints')
     end
   end
 end

--- a/spec/components/blacklight/document/group_component_spec.rb
+++ b/spec/components/blacklight/document/group_component_spec.rb
@@ -6,40 +6,35 @@ RSpec.describe Blacklight::Document::GroupComponent, type: :component do
   subject(:component) { described_class.new(group: group, **attr) }
 
   let(:attr) { {} }
-  let(:view_context) { controller.view_context }
-  let(:render) do
-    component.render_in(view_context)
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
-  end
-
-  let(:docs) { 10.times.map { double } }
+  let(:view_context) { vc_test_controller.view_context }
+  let(:docs) { 10.times.map { SolrDocument.new } }
 
   let(:group) do
     instance_double(Blacklight::Solr::Response::Group, key: 'group1', field: 'group_field', total: 15, docs: docs)
   end
 
   before do
+    # Every call to view_context returns a different object. This ensures it stays stable.
+    allow(vc_test_controller).to receive_messages(view_context: view_context)
     allow(view_context).to receive(:render_document_index).with(docs).and_return('results')
+    render_inline component
   end
 
   it 'renders the group with a header' do
-    expect(rendered).to have_css 'div.group'
-    expect(rendered).to have_css 'h2', text: 'group1'
-    expect(rendered).to have_no_link 'more'
+    expect(page).to have_css 'div.group'
+    expect(page).to have_css 'h2', text: 'group1'
+    expect(page).to have_no_link 'more'
   end
 
   it 'renders the group documents' do
-    expect(rendered).to have_content 'results'
+    expect(page).to have_content 'results'
   end
 
   context 'with a limit applied' do
     let(:attr) { { group_limit: 5 } }
 
     it 'renders a control to see more results' do
-      expect(rendered).to have_link 'more'
+      expect(page).to have_link 'more'
     end
   end
 end

--- a/spec/components/blacklight/document/sidebar_component_spec.rb
+++ b/spec/components/blacklight/document/sidebar_component_spec.rb
@@ -5,14 +5,7 @@ require 'spec_helper'
 RSpec.describe Blacklight::Document::SidebarComponent, type: :component do
   subject(:component) { described_class.new(presenter: document) }
 
-  let(:view_context) { controller.view_context }
-  let(:render) do
-    component.render_in(view_context)
-  end
-
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
-  end
+  let(:view_context) { vc_test_controller.view_context }
 
   let(:document) { view_context.document_presenter(presented_document) }
 
@@ -26,7 +19,7 @@ RSpec.describe Blacklight::Document::SidebarComponent, type: :component do
 
   before do
     # Every call to view_context returns a different object. This ensures it stays stable.
-    allow(controller).to receive_messages(view_context: view_context, blacklight_config: blacklight_config)
+    allow(vc_test_controller).to receive_messages(view_context: view_context, blacklight_config: blacklight_config)
   end
 
   describe '#render_show_tools' do
@@ -35,13 +28,14 @@ RSpec.describe Blacklight::Document::SidebarComponent, type: :component do
       allow(component).to receive(:render).with(an_instance_of(Blacklight::Document::MoreLikeThisComponent)).and_return("")
       blacklight_config.show.show_tools_component = show_tools_component
       allow(component).to receive(:render).with(an_instance_of(show_tools_component)).and_return(expected_html)
+      render_inline component
     end
+    # rubocop:enable RSpec/SubjectStub
 
     let(:show_tools_component) { Class.new(Blacklight::Document::ShowToolsComponent) }
 
     it 'renders configured show_tools component' do
-      expect(rendered).to have_css 'div[@class="expected-show_tools"]'
+      expect(page).to have_css 'div[@class="expected-show_tools"]'
     end
-    # rubocop:enable RSpec/SubjectStub
   end
 end

--- a/spec/components/blacklight/facet_component_spec.rb
+++ b/spec/components/blacklight/facet_component_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Blacklight::FacetComponent, type: :component do
   subject(:rendered) do
-    render_inline_to_capybara_node(component)
+    render_inline(component)
   end
 
   let(:component) { described_class.new(**component_kwargs) }
@@ -18,7 +18,8 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
   let(:facet_config) { Blacklight::Configuration::FacetField.new(key: 'field').normalize! }
 
   it 'delegates to the configured component to render something' do
-    expect(rendered).to have_css 'ul.facet-values'
+    rendered
+    expect(page).to have_css 'ul.facet-values'
   end
 
   context 'with a provided component' do
@@ -35,8 +36,10 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
       end
     end
 
+    before { rendered }
+
     it 'renders the provided component' do
-      expect(rendered).to have_content 'Custom facet rendering'
+      expect(page).to have_content 'Custom facet rendering'
     end
   end
 
@@ -53,14 +56,15 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
       replace_hash = { 'catalog/_facet_partial.html.erb' => 'facet partial' }
 
       if Rails.version.to_f >= 7.1
-        controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+        vc_test_controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
       else
-        controller.view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+        vc_test_controller.view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
       end
+      rendered
     end
 
     it 'renders the partial' do
-      expect(rendered).to have_content 'facet partial'
+      expect(page).to have_content 'facet partial'
     end
   end
 
@@ -113,7 +117,7 @@ RSpec.describe Blacklight::FacetComponent, type: :component do
       { display_facet_or_field_config: presenter }
     end
 
-    let(:presenter) { Blacklight::FacetFieldPresenter.new(facet_config, display_facet, controller.view_context) }
+    let(:presenter) { Blacklight::FacetFieldPresenter.new(facet_config, display_facet, vc_test_controller.view_context) }
 
     it 'renders the component with the provided presenter' do
       allow(facet_config.component).to receive(:new).and_call_original

--- a/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/blacklight/facet_field_checkboxes_component_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new(facet_field: facet_field))
+  before do
+    render_inline(described_class.new(facet_field: facet_field))
   end
 
   let(:facet_field) do
@@ -33,18 +33,18 @@ RSpec.describe Blacklight::FacetFieldCheckboxesComponent, type: :component do
   let(:params) { { f: { field: ['a'] } } }
 
   it 'renders an accordion item' do
-    expect(rendered).to have_css '.accordion-item'
-    expect(rendered).to have_button 'Field'
-    expect(rendered).to have_css 'button[data-bs-target="#facet-field"]'
-    expect(rendered).to have_css '#facet-field.collapse.show'
+    expect(page).to have_css '.accordion-item'
+    expect(page).to have_button 'Field'
+    expect(page).to have_css 'button[data-bs-target="#facet-field"]'
+    expect(page).to have_css '#facet-field.collapse.show'
   end
 
   it 'renders the facet items' do
-    expect(rendered).to have_css 'ul.facet-values'
-    expect(rendered).to have_css 'li', count: 3
+    expect(page).to have_css 'ul.facet-values'
+    expect(page).to have_css 'li', count: 3
 
-    expect(rendered).to have_field 'f_inclusive[field][]', with: 'a'
-    expect(rendered).to have_field 'f_inclusive[field][]', with: 'b'
-    expect(rendered).to have_field 'f_inclusive[field][]', with: 'c'
+    expect(page).to have_field 'f_inclusive[field][]', with: 'a'
+    expect(page).to have_field 'f_inclusive[field][]', with: 'b'
+    expect(page).to have_field 'f_inclusive[field][]', with: 'c'
   end
 end

--- a/spec/components/blacklight/facet_field_list_component_spec.rb
+++ b/spec/components/blacklight/facet_field_list_component_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new(facet_field: facet_field))
+  before do
+    render_inline(described_class.new(facet_field: facet_field))
   end
 
   let(:facet_field) do
@@ -31,15 +31,15 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
   end
 
   it 'renders an accordion item' do
-    expect(rendered).to have_css '.accordion-item'
-    expect(rendered).to have_button 'Field'
-    expect(rendered).to have_css 'button[data-bs-target="#facet-field"]'
-    expect(rendered).to have_css '#facet-field.collapse.show'
+    expect(page).to have_css '.accordion-item'
+    expect(page).to have_button 'Field'
+    expect(page).to have_css 'button[data-bs-target="#facet-field"]'
+    expect(page).to have_css '#facet-field.collapse.show'
   end
 
   it 'renders the facet items' do
-    expect(rendered).to have_css 'ul.facet-values'
-    expect(rendered).to have_css 'li', count: 2
+    expect(page).to have_css 'ul.facet-values'
+    expect(page).to have_css 'li', count: 2
   end
 
   context 'with an active facet' do
@@ -58,7 +58,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
     end
 
     it 'adds the facet-limit-active class' do
-      expect(rendered).to have_css 'div.facet-limit-active'
+      expect(page).to have_css 'div.facet-limit-active'
     end
   end
 
@@ -78,13 +78,13 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
     end
 
     it 'renders a collapsed facet' do
-      expect(rendered).to have_css '.facet-content.collapse'
-      expect(rendered).to have_no_css '.facet-content.collapse.show'
+      expect(page).to have_css '.facet-content.collapse'
+      expect(page).to have_no_css '.facet-content.collapse.show'
     end
 
     it 'renders the toggle button in the collapsed state' do
-      expect(rendered).to have_css '.btn.collapsed'
-      expect(rendered).to have_css '.btn[aria-expanded="false"]'
+      expect(page).to have_css '.btn.collapsed'
+      expect(page).to have_css '.btn[aria-expanded="false"]'
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
     end
 
     it 'renders a link to the modal' do
-      expect(rendered).to have_link 'more Field', href: '/catalog/facet/modal'
+      expect(page).to have_link 'more Field', href: '/catalog/facet/modal'
     end
   end
 
@@ -133,13 +133,13 @@ RSpec.describe Blacklight::FacetFieldListComponent, type: :component do
     let(:params) { { f_inclusive: { field: %w[a b c] } } }
 
     it 'displays the constraint above the list' do
-      expect(rendered).to have_content 'Any of:'
-      expect(rendered).to have_css '.inclusive_or .facet-label', text: 'a'
-      expect(rendered).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=b&f_inclusive%5Bfield%5D%5B%5D=c'
-      expect(rendered).to have_css '.inclusive_or .facet-label', text: 'b'
-      expect(rendered).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=a&f_inclusive%5Bfield%5D%5B%5D=c'
-      expect(rendered).to have_css '.inclusive_or .facet-label', text: 'c'
-      expect(rendered).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=a&f_inclusive%5Bfield%5D%5B%5D=b'
+      expect(page).to have_content 'Any of:'
+      expect(page).to have_css '.inclusive_or .facet-label', text: 'a'
+      expect(page).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=b&f_inclusive%5Bfield%5D%5B%5D=c'
+      expect(page).to have_css '.inclusive_or .facet-label', text: 'b'
+      expect(page).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=a&f_inclusive%5Bfield%5D%5B%5D=c'
+      expect(page).to have_css '.inclusive_or .facet-label', text: 'c'
+      expect(page).to have_link '[remove]', href: 'http://test.host/catalog?f_inclusive%5Bfield%5D%5B%5D=a&f_inclusive%5Bfield%5D%5B%5D=b'
     end
   end
 end

--- a/spec/components/blacklight/facet_item_component_spec.rb
+++ b/spec/components/blacklight/facet_item_component_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetItemComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new(facet_item: facet_item))
+  before do
+    render_inline(described_class.new(facet_item: facet_item))
   end
 
   let(:facet_item) do
@@ -19,11 +19,11 @@ RSpec.describe Blacklight::FacetItemComponent, type: :component do
   end
 
   it 'links to the facet and shows the number of hits' do
-    expect(rendered).to have_css 'li'
-    expect(rendered).to have_link 'x', href: '/catalog?f=x' do |link|
+    expect(page).to have_css 'li'
+    expect(page).to have_link 'x', href: '/catalog?f=x' do |link|
       link['rel'] == 'nofollow'
     end
-    expect(rendered).to have_css '.facet-count', text: '10'
+    expect(page).to have_css '.facet-count', text: '10'
   end
 
   context 'with a selected facet' do
@@ -39,12 +39,12 @@ RSpec.describe Blacklight::FacetItemComponent, type: :component do
     end
 
     it 'links to the facet and shows the number of hits' do
-      expect(rendered).to have_css 'li'
-      expect(rendered).to have_css '.selected', text: 'x'
-      expect(rendered).to have_link '[remove]', href: '/catalog' do |link|
+      expect(page).to have_css 'li'
+      expect(page).to have_css '.selected', text: 'x'
+      expect(page).to have_link '[remove]', href: '/catalog' do |link|
         link['rel'] == 'nofollow'
       end
-      expect(rendered).to have_css '.selected.facet-count', text: '10'
+      expect(page).to have_css '.selected.facet-count', text: '10'
     end
   end
 end

--- a/spec/components/blacklight/facet_item_pivot_component_spec.rb
+++ b/spec/components/blacklight/facet_item_pivot_component_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new(facet_item: facet_item))
+  before do
+    render_inline(described_class.new(facet_item: facet_item))
   end
 
   let(:blacklight_config) do
@@ -34,14 +34,14 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
   let(:facet_config) { Blacklight::Configuration::NullField.new(key: 'z', item_component: Blacklight::FacetItemComponent, item_presenter: Blacklight::FacetItemPivotPresenter) }
 
   it 'links to the facet and shows the number of hits' do
-    expect(rendered).to have_css 'li'
-    expect(rendered).to have_link 'x', href: nokogiri_mediated_href(facet_item.href)
-    expect(rendered).to have_css '.facet-count', text: '10'
+    expect(page).to have_css 'li'
+    expect(page).to have_link 'x', href: nokogiri_mediated_href(facet_item.href)
+    expect(page).to have_css '.facet-count', text: '10'
   end
 
   it 'has the facet hierarchy' do
-    expect(rendered).to have_css 'li ul.pivot-facet'
-    expect(rendered).to have_link 'x:1', href: nokogiri_mediated_href(facet_item.facet_item_presenters.first.href)
+    expect(page).to have_css 'li ul.pivot-facet'
+    expect(page).to have_link 'x:1', href: nokogiri_mediated_href(facet_item.facet_item_presenters.first.href)
   end
 
   context 'with a selected facet' do
@@ -60,10 +60,10 @@ RSpec.describe Blacklight::FacetItemPivotComponent, type: :component do
     end
 
     it 'links to the facet and shows the number of hits' do
-      expect(rendered).to have_css 'li'
-      expect(rendered).to have_css '.selected', text: 'x'
-      expect(rendered).to have_link '[remove]', href: '/catalog'
-      expect(rendered).to have_css '.selected.facet-count', text: '10'
+      expect(page).to have_css 'li'
+      expect(page).to have_css '.selected', text: 'x'
+      expect(page).to have_link '[remove]', href: '/catalog'
+      expect(page).to have_css '.selected.facet-count', text: '10'
     end
   end
 end

--- a/spec/components/blacklight/header_component_spec.rb
+++ b/spec/components/blacklight/header_component_spec.rb
@@ -3,14 +3,12 @@
 RSpec.describe Blacklight::HeaderComponent, type: :component do
   before do
     with_controller_class(CatalogController) do
-      allow(controller).to receive_messages(current_user: nil, search_action_url: '/search')
-      render
+      allow(vc_test_controller).to receive_messages(current_user: nil, search_action_url: '/search')
+      render_inline described_class.new(blacklight_config: CatalogController.blacklight_config)
     end
   end
 
   context 'with no slots' do
-    let(:render) { render_inline(described_class.new(blacklight_config: CatalogController.blacklight_config)) }
-
     it 'draws the topbar' do
       expect(page).to have_css 'nav.topbar'
       expect(page).to have_link 'Blacklight', href: '/'

--- a/spec/components/blacklight/hidden_search_state_component_spec.rb
+++ b/spec/components/blacklight/hidden_search_state_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Blacklight::HiddenSearchStateComponent, type: :component do
-  subject(:rendered) { render_inline_to_capybara_node(instance) }
+  before { render_inline(instance) }
 
   let(:params) do
     { q: "query",
@@ -13,11 +13,11 @@ RSpec.describe Blacklight::HiddenSearchStateComponent, type: :component do
   let(:instance) { described_class.new(params: params) }
 
   it "converts a hash with nested complex data to Rails-style hidden form fields" do
-    expect(rendered).to have_css("input[type='hidden'][name='q'][value='query']", visible: :hidden)
-    expect(rendered).to have_css("input[type='hidden'][name='per_page'][value='10']", visible: :hidden)
-    expect(rendered).to have_css("input[type='hidden'][name='extra_arbitrary_key'][value='arbitrary_value']", visible: :hidden)
-    expect(rendered).to have_css("input[type='hidden'][name='f[field2][]'][value='z']", visible: :hidden)
-    expect(rendered).to have_css("input[type='hidden'][name='f[field1][]'][value='a']", visible: :hidden)
-    expect(rendered).to have_css("input[type='hidden'][name='f[field1][]'][value='b']", visible: :hidden)
+    expect(page).to have_css("input[type='hidden'][name='q'][value='query']", visible: :hidden)
+    expect(page).to have_css("input[type='hidden'][name='per_page'][value='10']", visible: :hidden)
+    expect(page).to have_css("input[type='hidden'][name='extra_arbitrary_key'][value='arbitrary_value']", visible: :hidden)
+    expect(page).to have_css("input[type='hidden'][name='f[field2][]'][value='z']", visible: :hidden)
+    expect(page).to have_css("input[type='hidden'][name='f[field1][]'][value='a']", visible: :hidden)
+    expect(page).to have_css("input[type='hidden'][name='f[field1][]'][value='b']", visible: :hidden)
   end
 end

--- a/spec/components/blacklight/metadata_field_component_spec.rb
+++ b/spec/components/blacklight/metadata_field_component_spec.rb
@@ -3,11 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::MetadataFieldComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new(field: field))
-  end
-
-  let(:view_context) { controller.view_context }
+  let(:view_context) { vc_test_controller.view_context }
   let(:document) { SolrDocument.new('field' => ['Value']) }
   let(:field_config) { Blacklight::Configuration::Field.new(key: 'field', field: 'field', label: 'Field label') }
 
@@ -15,23 +11,29 @@ RSpec.describe Blacklight::MetadataFieldComponent, type: :component do
     Blacklight::FieldPresenter.new(view_context, document, field_config)
   end
 
-  it 'renders the field label' do
-    expect(rendered).to have_css 'dt.blacklight-field', text: 'Field label'
-  end
+  context "from index view" do
+    before do
+      render_inline(described_class.new(field: field))
+    end
 
-  it 'renders the field value' do
-    expect(rendered).to have_css 'dd.blacklight-field', text: 'Value'
+    it 'renders the field label' do
+      expect(page).to have_css 'dt.blacklight-field', text: 'Field label'
+    end
+
+    it 'renders the field value' do
+      expect(page).to have_css 'dd.blacklight-field', text: 'Value'
+    end
   end
 
   context 'from a show view' do
-    subject(:rendered) do
-      render_inline_to_capybara_node(described_class.new(field: field, show: true))
+    before do
+      allow(field).to receive(:label).with('show').and_return('custom label')
+
+      render_inline(described_class.new(field: field, show: true))
     end
 
     it 'renders the right field label' do
-      allow(field).to receive(:label).with('show').and_return('custom label')
-
-      expect(rendered).to have_css 'dt.blacklight-field', text: 'custom label'
+      expect(page).to have_css 'dt.blacklight-field', text: 'custom label'
     end
   end
 end

--- a/spec/components/blacklight/response/pagination_component_spec.rb
+++ b/spec/components/blacklight/response/pagination_component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Blacklight::Response::PaginationComponent, type: :component do
 
     context 'when a different configuration that removes deep links is configured in the controller' do
       before do
-        allow(controller.blacklight_config.index)
+        allow(vc_test_controller.blacklight_config.index)
           .to receive(:pagination_options)
           .and_return(theme: 'blacklight', left: 5, right: 0)
         render

--- a/spec/components/blacklight/response/spellcheck_component_spec.rb
+++ b/spec/components/blacklight/response/spellcheck_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Blacklight::Response::SpellcheckComponent, type: :component do
   end
 
   before do
-    allow(controller).to receive(:blacklight_config).and_return(config)
+    allow(vc_test_controller).to receive(:blacklight_config).and_return(config)
   end
 
   context 'when there are many results' do

--- a/spec/components/blacklight/search_bar_component_spec.rb
+++ b/spec/components/blacklight/search_bar_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Blacklight::SearchBarComponent, type: :component do
   end
 
   before do
-    allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(vc_test_controller).to receive(:blacklight_config).and_return(blacklight_config)
   end
 
   context 'with the default button' do
@@ -31,7 +31,7 @@ RSpec.describe Blacklight::SearchBarComponent, type: :component do
     subject(:render) do
       render_inline(instance) do |c|
         c.with_search_button do
-          controller.view_context.tag.button "hello", id: 'custom_search'
+          vc_test_controller.view_context.tag.button "hello", id: 'custom_search'
         end
       end
     end
@@ -70,8 +70,8 @@ RSpec.describe Blacklight::SearchBarComponent, type: :component do
   context 'with extra inputs' do
     subject(:render) do
       render_inline(instance) do |c|
-        c.with_before_input_group { controller.view_context.tag.input name: 'foo' }
-        c.with_before_input_group { controller.view_context.tag.input name: 'bar' }
+        c.with_before_input_group { vc_test_controller.view_context.tag.input name: 'foo' }
+        c.with_before_input_group { vc_test_controller.view_context.tag.input name: 'bar' }
       end
     end
 

--- a/spec/components/blacklight/search_context/server_applied_params_component_spec.rb
+++ b/spec/components/blacklight/search_context/server_applied_params_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Blacklight::SearchContext::ServerAppliedParamsComponent, type: :c
 
   let(:instance) { described_class.new }
   let(:current_search_session) { nil }
-  let(:view_context) { controller.view_context }
+  let(:view_context) { vc_test_controller.view_context }
 
   before do
     # Not sure why we need to re-implement rspec's stub_template, but
@@ -16,7 +16,7 @@ RSpec.describe Blacklight::SearchContext::ServerAppliedParamsComponent, type: :c
     # https://github.com/rspec/rspec-rails/issues/2696
     replace_hash = { 'application/_start_over.html.erb' => 'start over' }
     if Rails.version.to_f >= 7.1
-      controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
+      vc_test_controller.prepend_view_path(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
     else
       view_context.view_paths.unshift(RSpec::Rails::ViewExampleGroup::StubResolverCache.resolver_for(replace_hash))
     end

--- a/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
+++ b/spec/components/blacklight/search_context/server_item_pagination_component_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Blacklight::SearchContext::ServerItemPaginationComponent, type: :
   let(:instance) { described_class.new(search_context: search_context, search_session: search_session, current_document: current_document) }
 
   before do
-    allow(controller).to receive(:current_search_session).and_return(double(id: current_document_id))
-    controller.class.helper_method :current_search_session
+    allow(vc_test_controller).to receive(:current_search_session).and_return(double(id: current_document_id))
+    vc_test_controller.class.helper_method :current_search_session
   end
 
   context 'when there is no next or previous' do
@@ -40,9 +40,7 @@ RSpec.describe Blacklight::SearchContext::ServerItemPaginationComponent, type: :
     let(:next_doc) { SolrDocument.new(id: '888') }
 
     before do
-      # allow(controller).to receive(:controller_tracking_method).and_return('track_catalog_path')
-
-      allow(controller).to receive_messages(controller_name: 'catalog', link_to_previous_document: '', link_to_next_document: '')
+      allow(vc_test_controller).to receive_messages(controller_name: 'catalog', link_to_previous_document: '', link_to_next_document: '')
     end
 
     it "renders content" do

--- a/spec/components/blacklight/skip_link_component_spec.rb
+++ b/spec/components/blacklight/skip_link_component_spec.rb
@@ -3,12 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::SkipLinkComponent, type: :component do
-  subject(:rendered) do
-    render_inline_to_capybara_node(described_class.new)
-  end
-
   before do
-    allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(vc_test_controller).to receive(:blacklight_config).and_return(blacklight_config)
+    render_inline(described_class.new)
   end
 
   context 'with no search fields' do
@@ -19,8 +16,8 @@ RSpec.describe Blacklight::SkipLinkComponent, type: :component do
     end
 
     it 'renders skip links with correct link to search' do
-      expect(rendered).to have_link("Skip to main content", href: '#main-container')
-      expect(rendered).to have_link("Skip to search", href: "#q")
+      expect(page).to have_link("Skip to main content", href: '#main-container')
+      expect(page).to have_link("Skip to search", href: "#q")
     end
   end
 
@@ -32,8 +29,8 @@ RSpec.describe Blacklight::SkipLinkComponent, type: :component do
     end
 
     it 'renders skip links with correct link to search' do
-      expect(rendered).to have_link("Skip to main content", href: "#main-container")
-      expect(rendered).to have_link("Skip to search", href: "#q")
+      expect(page).to have_link("Skip to main content", href: "#main-container")
+      expect(page).to have_link("Skip to search", href: "#q")
     end
   end
 
@@ -45,8 +42,8 @@ RSpec.describe Blacklight::SkipLinkComponent, type: :component do
     end
 
     it 'renders skip links with correct link to search' do
-      expect(rendered).to have_link("Skip to main content", href: "#main-container")
-      expect(rendered).to have_link("Skip to search", href: "#search_field")
+      expect(page).to have_link("Skip to main content", href: "#main-container")
+      expect(page).to have_link("Skip to search", href: "#search_field")
     end
   end
 end

--- a/spec/components/blacklight/start_over_button_component_spec.rb
+++ b/spec/components/blacklight/start_over_button_component_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::StartOverButtonComponent, type: :component do
-  subject(:render) { render_inline(instance) }
+  subject(:render) { render_inline instance }
 
   let(:instance) { described_class.new }
   let(:blacklight_config) do
@@ -13,12 +13,12 @@ RSpec.describe Blacklight::StartOverButtonComponent, type: :component do
   end
 
   before do
-    allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(vc_test_controller).to receive(:blacklight_config).and_return(blacklight_config)
   end
 
   context 'with the current view type' do
     before do
-      controller.params[:view] = 'abc'
+      vc_test_controller.params[:view] = 'abc'
     end
 
     it 'is the catalog path' do
@@ -28,7 +28,7 @@ RSpec.describe Blacklight::StartOverButtonComponent, type: :component do
 
   context 'when the current view type is the default' do
     before do
-      controller.params[:view] = 'list'
+      vc_test_controller.params[:view] = 'list'
     end
 
     it 'does not include the current view type' do

--- a/spec/components/blacklight/system/flash_message_component_spec.rb
+++ b/spec/components/blacklight/system/flash_message_component_spec.rb
@@ -5,26 +5,22 @@ require 'spec_helper'
 RSpec.describe Blacklight::System::FlashMessageComponent, type: :component do
   subject(:component) { described_class.new(message: message, type: type) }
 
-  let(:view_context) { controller.view_context }
-  let(:render) do
-    component.render_in(view_context)
+  before do
+    render_inline(component)
   end
 
-  let(:rendered) do
-    Capybara::Node::Simple.new(render)
-  end
   let(:message) { 'This is an important message' }
   let(:type) { 'whatever' }
 
   it 'renders a message inside an alert' do
-    expect(rendered).to have_css 'div.alert.alert-whatever', text: message
+    expect(page).to have_css 'div.alert.alert-whatever', text: message
   end
 
   context 'with a success message' do
     let(:type) { 'success' }
 
     it 'adds some styling' do
-      expect(rendered).to have_css 'div.alert-success'
+      expect(page).to have_css 'div.alert-success'
     end
   end
 
@@ -32,7 +28,7 @@ RSpec.describe Blacklight::System::FlashMessageComponent, type: :component do
     let(:type) { 'notice' }
 
     it 'adds some styling' do
-      expect(rendered).to have_css 'div.alert-info'
+      expect(page).to have_css 'div.alert-info'
     end
   end
 
@@ -40,7 +36,7 @@ RSpec.describe Blacklight::System::FlashMessageComponent, type: :component do
     let(:type) { 'alert' }
 
     it 'adds some styling' do
-      expect(rendered).to have_css 'div.alert-warning'
+      expect(page).to have_css 'div.alert-warning'
     end
   end
 
@@ -48,7 +44,7 @@ RSpec.describe Blacklight::System::FlashMessageComponent, type: :component do
     let(:type) { 'error' }
 
     it 'adds some styling' do
-      expect(rendered).to have_css 'div.alert-danger'
+      expect(page).to have_css 'div.alert-danger'
     end
   end
 end

--- a/spec/support/view_component_test_helpers.rb
+++ b/spec/support/view_component_test_helpers.rb
@@ -1,24 +1,6 @@
 # frozen_string_literal: true
 
 module ViewComponentTestHelpers
-  # Work around for https://github.com/teamcapybara/capybara/issues/2466
-  def render_inline_to_capybara_node(component)
-    Capybara::Node::Simple.new(render_inline(component).to_s)
-  end
-
-  # Work-around for https://github.com/ViewComponent/view_component/pull/1661
-  # which made the component test's controller method (more) private. This makes
-  # it available so we can set up controller-level state for our tests.
-  def controller
-    # ViewComponent 2.x
-    return super if defined?(super)
-
-    # ViewComponent 3.x
-    return vc_test_controller if defined?(vc_test_controller)
-
-    ApplicationController.new.extend(Rails.application.routes.url_helpers)
-  end
-
   # Nokogiri 1.15.0 upgrades the vendored libxml2 from v2.10.4 to v2.11.3
   # libxml2 v2.11.0 introduces a change to parsing HTML href attributes
   # in nokogiri < 1.15, brackets in href attributes are escaped:


### PR DESCRIPTION
Since we no longer support view_component 2

This removes the support methods (`#controller` & `#render_inline_to_capybara_node`) we had in `ViewComponentTestHelpers`
<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
