### PR TITLE
Remove css that is not applied

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -419,9 +419,6 @@ main {
 .search-history {
   --bl-history-filter-name-color: var(--bs-secondary-color);
 }
-.search-history td {
-  padding: 1rem;
-}
 .search-history .constraint {
   padding-inline-end: 1rem;
   display: block;

--- a/app/assets/stylesheets/blacklight/_search_history.scss
+++ b/app/assets/stylesheets/blacklight/_search_history.scss
@@ -2,10 +2,6 @@
 .search-history {
   --bl-history-filter-name-color: var(--bs-secondary-color);
 
-  td {
-    padding: $spacer;
-  }
-
   .constraint {
     padding-inline-end: $spacer;
     display: block;


### PR DESCRIPTION
The bootstrap padding has higher precidence, so we can remove this and allow consumers to set as they see fit.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
