### PR TITLE
Get rid of unnecessary _facet_pagination template

### DIFF
--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,1 +1,0 @@
-<%= render(Blacklight::FacetFieldPaginationComponent.new(facet_field: facet_field_presenter(@facet, @display_facet))) %>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,5 +1,6 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
   <% component.with_title { facet_field_label(@facet.key) } %>
+  <% view_config = blacklight_config.view_config(document_index_view_type) %>
 
   <div class="facet-filters card card-body bg-light p-3 mb-3 border-0">
     <%= render Blacklight::Search::FacetSuggestInput.new(facet: @facet, presenter: @presenter) %>
@@ -7,7 +8,7 @@
   </div>
 
   <div class="facet-pagination top d-flex flex-wrap w-100 justify-content-between border-bottom pb-3 mb-3">
-    <%= render :partial=>'facet_pagination' %>
+    <%= render view_config.facet_pagination_component.new(facet_field: @presenter) %>
   </div>
 
   <div class="facet-extended-list">
@@ -18,7 +19,7 @@
 
   <% component.with_footer do %>
     <div class="facet-pagination bottom d-flex flex-wrap w-100 justify-content-between">
-      <%= render :partial=>'facet_pagination' %>
+      <%= render view_config.facet_pagination_component.new(facet_field: @presenter) %>
     </div>
   <% end %>
 <% end %>

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -162,6 +162,8 @@ module Blacklight
         respond_to: OpenStructWithHashAccess.new,
         # component class used to render the facet grouping
         facet_group_component: Blacklight::Response::FacetGroupComponent,
+        # component class used to render the facet pagination
+        facet_pagination_component: Blacklight::FacetFieldPaginationComponent,
         # component class used to render search constraints
         constraints_component: Blacklight::ConstraintsComponent,
         # component class used to render the search bar

--- a/spec/views/catalog/facet.html.erb_spec.rb
+++ b/spec/views/catalog/facet.html.erb_spec.rb
@@ -5,17 +5,20 @@ RSpec.describe 'catalog/facet.html.erb' do
   let(:blacklight_config) { Blacklight::Configuration.new }
   let(:component) { instance_double(Blacklight::FacetComponent) }
   let(:facet_suggest_input) { instance_double(Blacklight::Search::FacetSuggestInput) }
+  let(:pagination) { instance_double(Blacklight::FacetFieldPaginationComponent) }
 
   before do
     allow(Blacklight::FacetComponent).to receive(:new).and_return(component)
     allow(Blacklight::Search::FacetSuggestInput).to receive(:new).and_return(facet_suggest_input)
+    allow(Blacklight::FacetFieldPaginationComponent).to receive(:new).and_return(pagination)
+
     allow(view).to receive(:render).and_call_original
     allow(view).to receive(:render).with(component)
     allow(view).to receive(:render).with(facet_suggest_input)
+    allow(view).to receive(:render).with(pagination)
 
     blacklight_config.add_facet_field 'xyz', label: "Facet title"
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
-    stub_template 'catalog/_facet_pagination.html.erb' => 'pagination'
     assign :facet, blacklight_config.facet_fields['xyz']
     assign :display_facet, display_facet
   end
@@ -25,14 +28,10 @@ RSpec.describe 'catalog/facet.html.erb' do
     expect(rendered).to have_css 'h1', text: "Facet title"
   end
 
-  it "renders the facet suggest input" do
+  it "renders the subcomponents" do
     render
     expect(view).to have_received(:render).with(facet_suggest_input)
-  end
-
-  it "renders facet pagination" do
-    render
-    expect(rendered).to have_content 'pagination'
+    expect(view).to have_received(:render).with(pagination).twice
   end
 
   it "renders the facet limit" do


### PR DESCRIPTION
call the component directly

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
