### PR TITLE
Allow setting classes on FacetGroupComponent

### DIFF
--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -6,7 +6,7 @@
     <%= collapse_toggle_button(@panel_id) %>
   </div>
 
-  <div id="<%= @panel_id %>" class="facets-collapse d-lg-block collapse accordion">
+  <div id="<%= @panel_id %>" class="<%= body_classes %>">
     <%= body %>
   </div>
 <% end %>

--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -8,12 +8,15 @@ module Blacklight
 
       # @param [String] id a unique identifier for the group
       # @param [String] title the title of the facet group section
-      def initialize(id:, title: nil)
+      def initialize(id:, title: nil, body_classes: 'facets-collapse d-lg-block collapse accordion')
         @groupname = id
         @id = id ? "facets-#{id}" : 'facets'
         @title = title || I18n.t("blacklight.search.#{@id}.title")
         @panel_id = id ? "facet-panel-#{id}-collapse" : 'facet-panel-collapse'
+        @body_classes = body_classes
       end
+
+      attr_accessor :body_classes
 
       def collapse_toggle_button(panel_id)
         render button_component.new(panel_id: panel_id)
@@ -24,6 +27,7 @@ module Blacklight
       end
 
       def render?
+        # debugger
         body.present?
       end
     end

--- a/spec/components/blacklight/response/facet_group_component_spec.rb
+++ b/spec/components/blacklight/response/facet_group_component_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::Response::FacetGroupComponent, type: :component do
+  before do
+    render_inline(instance)
+  end
+
+  context 'when classes are passed in' do
+    let(:instance) do
+      described_class.new(id: 'foo', title: 'bar', body_classes: 'custom-class').tap do |component|
+        component.with_body { 'body' }
+      end
+    end
+
+    it "uses them" do
+      within '.facets' do
+        expect(page).to have_css 'div.custom-class'
+      end
+    end
+  end
+
+  context 'when classes are not passed in' do
+    let(:instance) do
+      described_class.new(id: 'foo', title: 'bar').tap do |component|
+        component.with_body { 'body' }
+      end
+    end
+
+    it "uses default classes them" do
+      within '.facets' do
+        expect(page).to have_css 'div.facets-collapse.d-lg-block.collapse.accordion'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2733

This allows you to set the facets collapse breakpoint by passing a class other than `d-lg-block`

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
