### PR TITLE
Use SOLR_MODULES in solr_wrapper config for Solr 9.8 compatibility

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+env:
+  SOLR_MODULES: analysis-extras
 collection:
   dir: lib/generators/blacklight/templates/solr/conf
   name: blacklight-core

--- a/lib/generators/blacklight/templates/.solr_wrapper.yml
+++ b/lib/generators/blacklight/templates/.solr_wrapper.yml
@@ -1,5 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+env:
+  SOLR_MODULES: analysis-extras
 collection:
   dir: solr/conf/
   name: blacklight-core


### PR DESCRIPTION
Solr wrapper isn't used that much anymore (since docker is preferred by CI/spec) but out of the box right now it will attempt to start up solr 9.8 and fail due to SOLR_MODULES env var missing.

Based on #3497
