### PR TITLE
Support Rails 8.0 in Blacklight 7.x

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -35,6 +35,10 @@
       "rails_version": "7.2.2.1"
     },
     {
+      "ruby": "3.4",
+      "rails_version": "8.0.2"
+    },
+    {
       "ruby": "3.3",
       "rails_version": "7.1.5.1",
       "view_component_version": "~> 2.74",

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency "rails", '>= 6.1', '< 7.3'
+  s.add_dependency "rails", '>= 6.1', '< 8.1'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results

--- a/lib/blacklight/configuration/field.rb
+++ b/lib/blacklight/configuration/field.rb
@@ -32,7 +32,6 @@ module Blacklight
       raise ArgumentError, "Must supply a field name" if self.field.nil?
     end
 
-    # rubocop:disable Style/RedundantParentheses
     def display_label(context = nil, **options)
       field_label(
         (:"blacklight.search.fields.#{context}.#{key}" if context),
@@ -42,7 +41,6 @@ module Blacklight
         **options
       )
     end
-    # rubocop:enable Style/RedundantParentheses
 
     def default_label
       if self.key.respond_to?(:titleize)

--- a/lib/generators/blacklight/controller_generator.rb
+++ b/lib/generators/blacklight/controller_generator.rb
@@ -30,7 +30,7 @@ module Blacklight
       route <<-EOF
   concern :searchable, Blacklight::Routes::Searchable.new
 
-  resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
+  resource :catalog, only: [], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
   end
       EOF

--- a/lib/generators/blacklight/test_support_generator.rb
+++ b/lib/generators/blacklight/test_support_generator.rb
@@ -17,7 +17,7 @@ module Blacklight
       copy_file "alternate_controller.rb", "app/controllers/alternate_controller.rb"
 
       routing_code = <<-EOF
-    resource :alternate, controller: 'alternate', only: [:index] do
+    resource :alternate, controller: 'alternate', only: [] do
       concerns :searchable
     end
       EOF

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,8 +48,11 @@ RSpec.configure do |config|
   # When we're testing the API, only run the api tests
   config.filter_run api: true if ENV['BLACKLIGHT_API_TEST']
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join("spec/fixtures")
+  if Rails.version.to_f >= 7.1
+    config.fixture_paths = [Rails.root.join("spec/fixtures")]
+  else
+    config.fixture_path = Rails.root.join("spec/fixtures")
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Upgrading one of our apps to BL8 has been a timesink, and we don't want it stuck on Rails 7.2, so this is a quick spike to see if the 7.x release branch can work atop Rails 8.0.