### PR TITLE
Stop looking in the Solr response to determine the request params

### DIFF
--- a/lib/blacklight/solr/response/params.rb
+++ b/lib/blacklight/solr/response/params.rb
@@ -15,17 +15,7 @@ module Blacklight::Solr::Response::Params
     header['params'] || request_params
   end
 
-  def start
-    search_builder&.start || single_valued_param(:start).to_i
-  end
-
-  def rows
-    search_builder&.rows || single_valued_param(:rows).to_i
-  end
-
-  def sort
-    search_builder&.sort || single_valued_param(:sort)
-  end
+  delegate :start, :rows, :sort, to: :search_builder
 
   def facet_field_aggregation_options(facet_field_name)
     defaults = {


### PR DESCRIPTION
We already know which parameters we requested.  This supports elasticsearch, which does not echo the request params

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
