### PR TITLE
Extract a search_builder for a find one search

### DIFF
--- a/lib/blacklight/solr/field_reflection_search_builder.rb
+++ b/lib/blacklight/solr/field_reflection_search_builder.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Blacklight::Solr
+  class FieldReflectionSearchBuilder < SearchBuilder
+    self.default_processor_chain = [:add_params]
+
+    def add_params(request)
+      request.reverse_merge!({ fl: '*', 'json.nl' => 'map' })
+    end
+  end
+end

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -7,8 +7,7 @@ module Blacklight::Solr
     # @param [String] id document's unique key value
     # @param [Hash] params additional solr query parameters
     def find id, params = {}
-      doc_params = params.reverse_merge(blacklight_config.default_document_solr_params)
-                         .merge(blacklight_config.document_unique_id_param => id)
+      doc_params = SingleDocSearchBuilder.new(self, id, params)
 
       solr_response = send_and_receive blacklight_config.document_solr_path || blacklight_config.solr_path, doc_params
       raise Blacklight::Exceptions::RecordNotFound if solr_response.documents.empty?
@@ -24,7 +23,7 @@ module Blacklight::Solr
 
     ##
     # Execute a search query against solr
-    # @param [Hash] params solr query parameters
+    # @param [Hash,Blacklight::SearchBuilder] params solr query parameters
     # @param [String] path solr request handler path
     def search pos_params = nil, path: nil, params: nil, **kwargs
       if pos_params
@@ -47,7 +46,8 @@ module Blacklight::Solr
     # Gets a list of available fields
     # @return [Hash]
     def reflect_fields
-      send_and_receive('admin/luke', params: { fl: '*', 'json.nl' => 'map' })['fields']
+      doc_params = FieldReflectionSearchBuilder.new(self)
+      send_and_receive('admin/luke', doc_params)['fields']
     end
 
     ##

--- a/lib/blacklight/solr/single_doc_search_builder.rb
+++ b/lib/blacklight/solr/single_doc_search_builder.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Blacklight::Solr
+  class SingleDocSearchBuilder < SearchBuilder
+    self.default_processor_chain = [:add_defaults, :add_qt, :add_unique_id]
+
+    def initialize(scope, id, other_params)
+      @other_params = other_params
+      @id = id
+      super(scope)
+    end
+
+    def add_defaults(request)
+      request.reverse_merge!(blacklight_config.default_document_solr_params).reverse_merge!(@other_params)
+    end
+
+    def add_qt(request)
+      request[:qt] ||= blacklight_config.document_solr_request_handler if blacklight_config.document_solr_request_handler
+    end
+
+    def add_unique_id(request)
+      request[blacklight_config.document_unique_id_param] = @id
+    end
+  end
+end


### PR DESCRIPTION
This gives us parity with the find many search. It allows us to always go to the search_builder for queries about the request.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
