### PR TITLE
Avoid DeprecatedConstantProxy for classes

### DIFF
--- a/app/components/blacklight/facet_field_checkboxes_component.rb
+++ b/app/components/blacklight/facet_field_checkboxes_component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetFieldCheckboxesComponent < Facets::CheckboxesComponent; end
-  FacetFieldCheckboxesComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetFieldCheckboxesComponent", "Blacklight::Facets::CheckboxesComponent", ActiveSupport::Deprecation.new)
+  class FacetFieldCheckboxesComponent < Facets::CheckboxesComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetFieldCheckboxesComponent is deprecated. Use Blacklight::Facets::CheckboxesComponent instead.")
+      super
+    end
+  end
 end

--- a/app/components/blacklight/facet_field_component.rb
+++ b/app/components/blacklight/facet_field_component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetFieldComponent < Facets::FieldComponent; end
-  FacetFieldComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetFieldComponent", "Blacklight::Facets::FieldComponent", ActiveSupport::Deprecation.new)
+  class FacetFieldComponent < Facets::FieldComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetFieldComponent is deprecated. Use Blacklight::Facets::FacetFieldComponent instead.")
+      super
+    end
+  end
 end

--- a/app/components/blacklight/facet_field_filter_component.rb
+++ b/app/components/blacklight/facet_field_filter_component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetFieldFilterComponent < Facets::IndexNavigationComponent; end
-  FacetFieldFilterComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetFieldFilterComponent", "Blacklight::Facets::IndexNavigationComponent", ActiveSupport::Deprecation.new)
+  class FacetFieldFilterComponent < Facets::IndexNavigationComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetFieldFilterComponent is deprecated. Use Blacklight::Facets::IndexNavigationComponent instead.")
+      super
+    end
+  end
 end

--- a/app/components/blacklight/facet_field_inclusive_constraint_component.rb
+++ b/app/components/blacklight/facet_field_inclusive_constraint_component.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetFieldInclusiveConstraintComponent < Facets::InclusiveConstraintComponent; end
-  FacetFieldInclusiveConstraintComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetFieldInclusiveConstraintComponent",
-                                                                                                   "Blacklight::Facets::InclusiveConstraintComponent",
-                                                                                                   ActiveSupport::Deprecation.new)
+  class FacetFieldInclusiveConstraintComponent < Facets::InclusiveConstraintComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetFieldInclusiveConstraintComponent is deprecated. Use Blacklight::Facets::InclusiveConstraintComponent instead.")
+      super
+    end
+  end
 end

--- a/app/components/blacklight/facet_field_list_component.rb
+++ b/app/components/blacklight/facet_field_list_component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetFieldListComponent < Facets::ListComponent; end
-  FacetFieldListComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetFieldListComponent", "Blacklight::Facets::ListComponent", ActiveSupport::Deprecation.new)
+  class FacetFieldListComponent < Facets::ListComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetFieldListComponent is deprecated. Use Blacklight::Facets::ListComponent instead.")
+      super
+    end
+  end
 end

--- a/app/components/blacklight/facet_field_no_layout_component.rb
+++ b/app/components/blacklight/facet_field_no_layout_component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetFieldNoLayoutComponent < Facets::NoLayoutComponent; end
-  FacetFieldNoLayoutComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetFieldNoLayoutComponent", "Blacklight::Facets::NoLayoutComponent", ActiveSupport::Deprecation.new)
+  class FacetFieldNoLayoutComponent < Facets::NoLayoutComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetFieldNoLayoutComponent is deprecated. Use Blacklight::Facets::NoLayoutComponent instead.")
+      super
+    end
+  end
 end

--- a/app/components/blacklight/facet_item_component.rb
+++ b/app/components/blacklight/facet_item_component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Blacklight
-  class FacetItemComponent < Facets::ItemComponent; end
-  FacetItemComponent = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("FacetItemComponent", "Blacklight::Facets::ItemComponent", ActiveSupport::Deprecation.new)
+  class FacetItemComponent < Facets::ItemComponent
+    def initialize(...)
+      Rails.logger.warn("Blacklight::FacetItemComponent is deprecated. Use Blacklight::Facets::ItemComponent instead.")
+      super
+    end
+  end
 end


### PR DESCRIPTION
You can't extends from it, so it doesn't really serve our use case. Fixes #3640

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
