### PR TITLE
Avoid transforming the size of the icon

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -445,8 +445,3 @@ main {
   padding-top: 1rem;
   margin-top: 1rem;
 }
-
-.remove .bi {
-  height: 1em;
-  width: 1em;
-}

--- a/app/assets/stylesheets/blacklight/_blacklight_base.scss
+++ b/app/assets/stylesheets/blacklight/_blacklight_base.scss
@@ -21,4 +21,3 @@
 @import "facets";
 @import "search_history";
 @import "modal";
-@import "icons";

--- a/app/assets/stylesheets/blacklight/_icons.scss
+++ b/app/assets/stylesheets/blacklight/_icons.scss
@@ -1,4 +1,0 @@
-.remove .bi {
-  height: 1em;
-  width: 1em;
-}


### PR DESCRIPTION
This is something a downstream user can do if they want it bigger, but we don't want to force someone to override blacklight.  They may also choose to use bi-x-lg instead.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
