### PR TITLE
add bookmarks keyboard navigation listener

### DIFF
--- a/app/components/blacklight/document/bookmark_component.html.erb
+++ b/app/components/blacklight/document/bookmark_component.html.erb
@@ -9,8 +9,8 @@
                inprogress: t('blacklight.search.bookmarks.inprogress')
             }) do %>
   <div class="toggle-bookmark">
-    <label class="toggle-bookmark-label" data-checkboxsubmit-target="label">
-      <input type="checkbox" class="toggle-bookmark-input <%= bookmark_icon ? 'd-none' : '' %>" data-checkboxsubmit-target="checkbox" <%= 'checked="checked"' if bookmarked? %>>
+    <label class="toggle-bookmark-label" data-checkboxsubmit-target="label" <% if bookmark_icon %>tabindex="0"<% end %>>
+      <input type="checkbox" class="toggle-bookmark-input <%= bookmark_icon ? 'd-none' : '' %>" data-checkboxsubmit-target="checkbox" <%= 'checked=checked' if bookmarked? %>>
       <%= bookmark_icon %>
       <span data-checkboxsubmit-target="span"><%= bookmarked? ? t('blacklight.search.bookmarks.present') : t('blacklight.search.bookmarks.absent') %></span>
     </label>

--- a/app/javascript/blacklight-frontend/bookmark_toggle.js
+++ b/app/javascript/blacklight-frontend/bookmark_toggle.js
@@ -1,12 +1,17 @@
 import CheckboxSubmit from 'blacklight-frontend/checkbox_submit'
 
 const BookmarkToggle = (e) => {
-  if (e.target.matches('[data-checkboxsubmit-target="checkbox"]')) {
-    const form = e.target.closest('form')
+  const elementType = e.target.getAttribute('data-checkboxsubmit-target');
+  if (elementType == 'checkbox' || elementType == 'label') {
+    const form = e.target.closest('form');
     if (form) new CheckboxSubmit(form).clicked(e);
+    if (e.code == 'Space') e.preventDefault();
   }
 };
 
 document.addEventListener('click', BookmarkToggle);
+document.addEventListener('keydown', function (e) {
+  if (e.key === 'Enter' || e.code == 'Space') { BookmarkToggle(e); } }
+);
 
 export default BookmarkToggle

--- a/app/javascript/blacklight-frontend/checkbox_submit.js
+++ b/app/javascript/blacklight-frontend/checkbox_submit.js
@@ -77,7 +77,8 @@ export default class CheckboxSubmit {
   }
 
   updateStateFor(state) {
-    this.checkboxTarget.checked = state
+    if (state) { this.checkboxTarget.setAttribute('checked', state) }
+    else { this.checkboxTarget.removeAttribute('checked') }
 
     if (state) {
       this.labelTarget.classList.add('checked')


### PR DESCRIPTION
closes #3555 

Also fixes the checked state not being updated properly.

This is actually also an issue for checkboxes. Without this JS change the page will reload when the user uses keyboard navigation to bookmark an item. The screenshot below is when I used the checkboxes to bookmark the 4th result.
![Screenshot 2025-06-18 at 4 49 55 PM](https://github.com/user-attachments/assets/06f3c554-01b4-4345-baae-47740beb5526)

![Screenshot 2025-06-23 at 3 53 11 PM](https://github.com/user-attachments/assets/6e28247d-45bb-4ca1-bda9-925aff312b7a)
![Screenshot 2025-06-23 at 3 53 07 PM](https://github.com/user-attachments/assets/bd7da1ec-9d66-4ed7-8747-edcc6b1c2e01)
