### PR TITLE
fix remove alignment for selected facet

### DIFF
--- a/app/components/blacklight/constraint_layout_component.rb
+++ b/app/components/blacklight/constraint_layout_component.rb
@@ -25,7 +25,7 @@ module Blacklight
     def remove_button
       return unless @remove_path
 
-      link_to(@remove_path, class: 'btn btn-outline-secondary remove') do
+      link_to(@remove_path, class: 'btn btn-outline-secondary remove d-flex align-items-center justify-content-center') do
         render(Blacklight::Icons::RemoveComponent.new(aria_hidden: true)) +
           tag.span(remove_aria_label, class: "visually-hidden")
       end


### PR DESCRIPTION
Alignment seems to be slightly off in safari
Before:
![Screenshot 2025-06-18 at 5 33 15 PM](https://github.com/user-attachments/assets/3352a674-6a0f-4dd8-84ce-90a18a9e165d)

After:
![Screenshot 2025-06-18 at 5 32 48 PM](https://github.com/user-attachments/assets/4526b768-da30-402c-bff3-89dbc38937cb)
