### PR TITLE
The JSON presenter should use all facets

### DIFF
--- a/app/presenters/blacklight/json_presenter.rb
+++ b/app/presenters/blacklight/json_presenter.rb
@@ -11,7 +11,7 @@ module Blacklight
 
     attr_reader :blacklight_config
 
-    delegate :facet_field_names, :facet_configuration_for_field, to: :blacklight_config
+    delegate :facet_fields, :facet_configuration_for_field, to: :blacklight_config
 
     delegate :documents, to: :@response
 
@@ -21,6 +21,12 @@ module Blacklight
         .map { |field| @response.aggregations[facet_configuration_for_field(field).field] }
         .compact
         .select { |display_facet| display_facet.items.present? }
+    end
+
+    # NOTE: we don't use the facet_field_names method in Blacklight::Configuration because that
+    # only returns the field names of the group where the name is nil.
+    def facet_field_names
+      facet_fields.values.map(&:field)
     end
 
     # extract the pagination info from the response object

--- a/spec/presenters/blacklight/json_presenter_spec.rb
+++ b/spec/presenters/blacklight/json_presenter_spec.rb
@@ -56,5 +56,22 @@ RSpec.describe Blacklight::JsonPresenter, :api do
         expect(search_facets.map(&:name)).to eq ['format_si']
       end
     end
+
+    context 'when facets are in multiple groups' do
+      before do
+        config.add_facet_field 'author_tsim', label: 'author', group: 'other-group'
+      end
+
+      let(:aggregations) do
+        {
+          'format_si' => Blacklight::Solr::Response::Facets::FacetField.new("format_si", [{ label: "Book", value: 'Book', hits: 20 }]),
+          'author_tsim' => Blacklight::Solr::Response::Facets::FacetField.new("author_tsim", [{ label: "Julie", value: 'Julie', hits: 1 }])
+        }
+      end
+
+      it 'filters out the facets that are not defined' do
+        expect(search_facets.map(&:name)).to eq %w[format_si author_tsim]
+      end
+    end
   end
 end


### PR DESCRIPTION
not just those in the default group

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
