### PR TITLE
Allow the repository class to be configured on a per-class basiss

### DIFF
--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -29,14 +29,16 @@ module Blacklight
   # the class Blacklight::(name of the adapter)::Repository, e.g.
   #   elastic_search => Blacklight::ElasticSearch::Repository
   def self.repository_class
-    case connection_config[:adapter]
+    if connection_config && !connection_config.key?(:adapter)
+      raise "The value for :adapter was not found in the blacklight.yml config"
+    end
+
+    case connection_config&.fetch(:adapter) || 'solr' # rubocop:disable Lint/LiteralAsCondition
     when 'solr'
       Blacklight::Solr::Repository
     when /::/
       connection_config[:adapter].constantize
     else
-      raise "The value for :adapter was not found in the blacklight.yml config" unless connection_config.key? :adapter
-
       Blacklight.const_get("#{connection_config.fetch(:adapter)}/Repository".classify)
     end
   end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -96,6 +96,10 @@ module Blacklight
       ##
       # == Response models
 
+      # @!attribute repository_class
+      # @return [Class] Class for sending and receiving requests from a search index
+      #                 defaults to the class configured in blacklight.yml
+      property :repository_class, default: Blacklight.repository_class
       # @!attribute search_builder_class
       # @return [Class] class for converting Blacklight parameters to request parameters for the repository_class
       property :search_builder_class, default: ::SearchBuilder
@@ -379,7 +383,7 @@ module Blacklight
 
     # @return [Blacklight::Repository]
     def repository
-      Blacklight.repository_class.new(self)
+      repository_class.new(self)
     end
 
     # @return [String] The destination for the link around the logo in the header

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -5,6 +5,26 @@ RSpec.describe Blacklight::Configuration, :api do
     described_class.new
   end
 
+  describe "#repository" do
+    context 'when the class is configured in blacklight.yml' do
+      it "uses the default repository class" do
+        expect(config.repository).to be_a(Blacklight::Solr::Repository)
+      end
+    end
+
+    context 'when the class is set in the configuration' do
+      let(:custom_repository_class) { Class.new(Blacklight::Solr::Repository) }
+
+      before do
+        config.repository_class = custom_repository_class
+      end
+
+      it "uses the custom repository class" do
+        expect(config.repository).to be_a(custom_repository_class)
+      end
+    end
+  end
+
   it "supports arbitrary configuration values" do
     config.a = 1
 


### PR DESCRIPTION
This reverts part of #3526 which causes a regression when we had a configuration that set the repository class.  #3526 only allowed configuring one repository_class per application.  Our application requires two different repository classes.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
