### PR TITLE
add blacklight event for bookmarks

### DIFF
--- a/app/javascript/blacklight-frontend/checkbox_submit.js
+++ b/app/javascript/blacklight-frontend/checkbox_submit.js
@@ -43,6 +43,9 @@ export default class CheckboxSubmit {
       this.bookmarksCounter().forEach(counter => {
         counter.innerHTML = json.bookmarks.count;
       });
+
+      var e = new CustomEvent('bookmark.blacklight', { detail: { checked: !this.checked } });
+      window.dispatchEvent(e)
     }).catch((error) => {
       this.handleError(error)
     })


### PR DESCRIPTION
We want to add a toast in our local Blacklight implementation for when a bookmark is added/removed. Adding a customevent will allow all Blacklight implementers to be able to apply custom alerts when a bookmark is added/removed without having to do overrides.