### PR TITLE
Use a larger Bootstrap close icon for constraint removal. Fixes #3660.

### DIFF
--- a/app/components/blacklight/icons/remove_component.rb
+++ b/app/components/blacklight/icons/remove_component.rb
@@ -7,8 +7,8 @@ module Blacklight
     #   Blacklight::Icons::RemoveComponent.svg = '<svg>your SVG here</svg>'
     class RemoveComponent < Blacklight::Icons::IconComponent
       self.svg = <<~SVG
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
-          <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
+          <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z"/>
         </svg>
       SVG
     end


### PR DESCRIPTION
- the bi-x-lg icon fills the SVG bounding box and can be more easily scaled/aligned as needed in downstream apps
