### PR TITLE
Fix pivot facet accessibility by using tree, treeitem aria roles. Fix…

### DIFF
--- a/app/components/blacklight/facet_item_pivot_component.rb
+++ b/app/components/blacklight/facet_item_pivot_component.rb
@@ -32,7 +32,7 @@ module Blacklight
 
       id = "h-#{self.class.mint_id}" if @collapsing && has_items?
 
-      content_tag @wrapping_element, class: 'treeitem' do
+      content_tag @wrapping_element, class: 'treeitem', role: 'treeitem' do
         concat(content_tag('span', class: "d-flex flex-row align-items-center") do
           concat facet_toggle_button(id) if has_items? && @collapsing
           concat content_tag('span', render(facet), class: "facet-values d-flex flex-row flex-grow-1 #{'facet-leaf-node' if has_items? && @collapsing}", id: id && "#{id}_label")

--- a/app/components/blacklight/facets/list_component.html.erb
+++ b/app/components/blacklight/facets/list_component.html.erb
@@ -4,8 +4,8 @@
   <% end %>
   <% component.with_body do %>
     <%= render(Blacklight::Facets::InclusiveConstraintComponent.new(facet_field: @facet_field)) %>
-    <ul class="facet-values list-unstyled">
+    <%= content_tag :ul, class: 'facet-values list-unstyled', role: @role do %>
       <%= render facet_items %>
-    </ul>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/blacklight/facets/list_component.rb
+++ b/app/components/blacklight/facets/list_component.rb
@@ -3,12 +3,13 @@
 module Blacklight
   module Facets
     class ListComponent < Blacklight::Component
-      def initialize(facet_field:, layout: nil)
+      def initialize(facet_field:, role: nil, layout: nil)
         @facet_field = facet_field
+        @role = role
         @layout = layout == false ? Blacklight::Facets::NoLayoutComponent : Blacklight::Facets::FieldComponent
       end
 
-      attr_accessor :layout
+      attr_accessor :layout, :role
 
       def facet_items(wrapping_element: :li, **item_args)
         facet_item_component_class.with_collection(facet_item_presenters, wrapping_element: wrapping_element, **item_args)

--- a/app/components/blacklight/facets/pivot_list_component.rb
+++ b/app/components/blacklight/facets/pivot_list_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Facets
+    class PivotListComponent < Blacklight::Facets::ListComponent
+      def initialize(facet_field:, role: 'tree', layout: nil)
+        super
+      end
+    end
+  end
+end

--- a/lib/blacklight/configuration/facet_field.rb
+++ b/lib/blacklight/configuration/facet_field.rb
@@ -95,6 +95,7 @@ module Blacklight
     def normalize_pivot_config!
       self.item_presenter ||= Blacklight::FacetItemPivotPresenter
       self.item_component ||= Blacklight::FacetItemPivotComponent
+      self.component ||= Blacklight::Facets::PivotListComponent
       self.filter_class ||= Blacklight::SearchState::PivotFilterField
       self.filter_query_builder ||= Blacklight::SearchState::PivotFilterField::QueryBuilder
     end

--- a/spec/components/blacklight/facets/list_component_spec.rb
+++ b/spec/components/blacklight/facets/list_component_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe Blacklight::Facets::ListComponent, type: :component do
     expect(page).to have_css 'li', count: 2
   end
 
+  it 'does not add a role attribute by default' do
+    expect(page).to have_css 'ul.facet-values'
+    expect(page).to have_no_css 'ul.facet-values[role]'
+  end
+
   context 'with an active facet' do
     let(:facet_field) do
       instance_double(

--- a/spec/components/blacklight/facets/pivot_list_component_spec.rb
+++ b/spec/components/blacklight/facets/pivot_list_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Blacklight::Facets::PivotListComponent, type: :component do
+  before do
+    render_inline(described_class.new(facet_field: facet_field))
+  end
+
+  let(:facet_field) do
+    instance_double(
+      Blacklight::FacetFieldPresenter,
+      paginator: paginator,
+      facet_field: facet_config,
+      key: 'pivot_field',
+      label: 'Pivot Field',
+      active?: false,
+      collapsed?: false,
+      modal_path: nil,
+      values: []
+    )
+  end
+
+  let(:facet_config) do
+    Blacklight::Configuration::NullField.new(
+      key: 'pivot_field',
+      item_component: Blacklight::FacetItemPivotComponent,
+      item_presenter: Blacklight::FacetItemPivotPresenter,
+      pivot: %w[field_a field_b]
+    )
+  end
+
+  let(:paginator) do
+    instance_double(Blacklight::FacetPaginator, items: [
+                      double(value: 'x', hits: 10),
+                      double(value: 'y', hits: 33)
+                    ])
+  end
+
+  it 'renders the facet items with role="tree"' do
+    expect(page).to have_css 'ul.facet-values[role="tree"]'
+  end
+end


### PR DESCRIPTION
…es #3559.

- Sets a pivot facet's root ul to role="tree", leaves regular facets without role
- Restores the pivot facet li role="treeitem" that was removed in #3359
