### PR TITLE
Set requested with header on fetch request

### DIFF
--- a/app/javascript/blacklight-frontend/modal.js
+++ b/app/javascript/blacklight-frontend/modal.js
@@ -134,7 +134,7 @@ const Modal = (() => {
   modal.modalAjaxLinkClick = function(e) {
     e.preventDefault();
     const href = e.target.closest('a').getAttribute('href')
-    fetch(href)
+    fetch(href, { headers: { 'X-Requested-With': 'XMLHttpRequest' }})
       .then(response => {
          if (!response.ok) {
            throw new TypeError("Request failed");


### PR DESCRIPTION
This allows the Rails back end to use `request.xhr?` to see if this was initiated by the front end and respond appropriately.  Sometimes you may have a single route, but you want to return different markup depending on whether it's displayed in a modal or not.

