### PR TITLE
Ensure facets on advanced search form styles are consistent with side…

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -253,7 +253,7 @@ main {
   }
 }
 
-.sidenav {
+.facets {
   --bl-facet-active-bg: var(--bs-success);
   --bl-facet-active-color: var(--bs-white);
   --bl-facet-active-item-color: var(--bs-success);
@@ -264,16 +264,16 @@ main {
   --bl-facet-header-padding-y: 0.5rem;
   --bl-facet-value-padding-y: 0.2rem;
 }
-.sidenav .facet-toggle-button [data-hide-label] {
+.facets .facet-toggle-button [data-hide-label] {
   display: inline;
 }
-.sidenav .facet-toggle-button [data-show-label] {
+.facets .facet-toggle-button [data-show-label] {
   display: none;
 }
-.sidenav .facet-toggle-button[aria-expanded=false] [data-hide-label] {
+.facets .facet-toggle-button[aria-expanded=false] [data-hide-label] {
   display: none;
 }
-.sidenav .facet-toggle-button[aria-expanded=false] [data-show-label] {
+.facets .facet-toggle-button[aria-expanded=false] [data-show-label] {
   display: inline;
 }
 

--- a/app/assets/stylesheets/blacklight/_facets.scss
+++ b/app/assets/stylesheets/blacklight/_facets.scss
@@ -1,4 +1,4 @@
-.sidenav {
+.facets {
   --bl-facet-active-bg: var(--bs-success);
   --bl-facet-active-color: var(--bs-white);
   --bl-facet-active-item-color: var(--bs-success);

--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -27,8 +27,8 @@
       <div class="limit-criteria mb-4">
         <h2 class="limit-criteria-heading h3"><%= t('blacklight.advanced_search.form.limit_criteria_heading_html')%></h2>
 
-        <div id="advanced_search_facets" class="limit_input row">
-          <div class="advanced-facet-limits panel-group col-md-9 offset-md-3">
+        <div id="advanced_search_facets" class="facets limit_input row">
+          <div class="advanced-facet-limits accordion col-md-9 offset-md-3">
             <% search_filter_controls.each do |control| %>
               <%= control %>
             <% end %>

--- a/app/components/blacklight/facets/checkboxes_component.html.erb
+++ b/app/components/blacklight/facets/checkboxes_component.html.erb
@@ -7,13 +7,13 @@
     <ul class="facet-values list-unstyled blacklight-facet-checkboxes">
       <% presenters.each_with_index do |presenter, idx| -%>
         <li>
-          <span class="facet-checkbox">
+          <span class="facet-checkbox flex-shrink-0">
             <%= check_box_tag "f_inclusive[#{@facet_field.key}][]", presenter.value, presenter.selected?, id: "f_inclusive_#{@facet_field.key}_#{idx}"%>
           </span>
 
-          <span>
-            <%= label_tag "f_inclusive_#{@facet_field.key}_#{idx}" do %>
-              <span class="facet-label"><%= presenter.label %></span>
+          <span class="facet-label-and-count flex-grow-1">
+            <%= label_tag "f_inclusive_#{@facet_field.key}_#{idx}", class: 'd-flex' do %>
+              <span class="facet-label flex-grow-1"><%= presenter.label %></span>
               <span class="facet-count"><%= t('blacklight.search.facets.count', number: number_with_delimiter(presenter.hits)) %></span>
             <% end %>
           </span>


### PR DESCRIPTION
…bar facets. Fixes #3673

- replaces deprecated BS4 panel-group with BS5 accordion class
- ensures BL facet css variables get set for all facets, not just sidenav (fixes #3308)
- makes checkbox facet value+count use BS5 flexbox styles (as intended by #2783)
