### PR TITLE
Remove all remaining vestiges of Bootstrap 3 & 4 classes/attributes. Resolves #3675

### DIFF
--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -39,7 +39,7 @@
   </div>
 
   <% if sort_fields_select %>
-    <div class="form-group row mb-4">
+    <div class="row mb-4">
       <%= content_tag :h2, t('blacklight.advanced_search.form.sort_label'), id: 'advanced-search-sort-label', class: 'col-md-3 text-md-right' %>
       <div class="col-md-9">
         <%= sort_fields_select %>
@@ -47,7 +47,7 @@
     </div>
   <% end %>
 
-  <div class="form-group row">
+  <div class="row">
     <div class="submit-buttons col-md-9 offset-md-3">
       <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
       <%= link_to t('blacklight.advanced_search.form.start_over_html'), request.path, :class =>"btn btn-link advanced-search-start-over" %>

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -46,7 +46,7 @@ module Blacklight
       search_fields.values.each.with_index do |field, i|
         with_search_field_control do
           fields_for('clause[]', i, include_id: false) do |f|
-            content_tag(:div, class: 'form-group advanced-search-field row mb-3') do
+            content_tag(:div, class: 'advanced-search-field row mb-3') do
               f.label(:query, field.display_label('search'), class: "col-sm-3 col-form-label text-md-right") +
                 content_tag(:div, class: 'col-sm-9') do
                   f.hidden_field(:field, value: field.key) +

--- a/app/components/blacklight/advanced_search_form_component.rb
+++ b/app/components/blacklight/advanced_search_form_component.rb
@@ -31,7 +31,7 @@ module Blacklight
       options = sort_fields.values.map { |field_config| [helpers.sort_field_label(field_config.key), field_config.key] }
       return unless options.any?
 
-      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-select custom-select sort-select w-auto", aria: { labelledby: 'advanced-search-sort-label' })
+      select_tag(:sort, options_for_select(options, params[:sort]), class: "form-select sort-select w-auto", aria: { labelledby: 'advanced-search-sort-label' })
     end
 
     # Filtered params to pass to hidden search fields

--- a/app/components/blacklight/document/group_component.html.erb
+++ b/app/components/blacklight/document/group_component.html.erb
@@ -4,6 +4,6 @@
     <%= grouped_documents %>
   </div>
   <%- if @group_limit > 0 && @group.total > @group_limit %>
-    <%= helpers.link_to t('blacklight.search.group.more'), add_group_facet_params_and_redirect(@group), class: 'more-in-group float-right' %>
+    <%= helpers.link_to t('blacklight.search.group.more'), add_group_facet_params_and_redirect(@group), class: 'more-in-group float-end' %>
   <%- end %>
 </div>

--- a/app/components/blacklight/facets/field_component.html.erb
+++ b/app/components/blacklight/facets/field_component.html.erb
@@ -3,9 +3,7 @@
     <button
       type="button"
       class="btn accordion-button <%= "collapsed" if @facet_field.collapsed? %>"
-      data-toggle="collapse"
       data-bs-toggle="collapse"
-      data-target="#<%= html_id %>"
       data-bs-target="#<%= html_id %>"
       aria-expanded="<%= @facet_field.collapsed? ? 'false' : 'true' %>"
       aria-controls="<%= html_id %>"

--- a/app/components/blacklight/facets/suggest_component.html.erb
+++ b/app/components/blacklight/facets/suggest_component.html.erb
@@ -1,4 +1,4 @@
-<label for="facet_suggest_<%= key %>">
+<label class="form-label" for="facet_suggest_<%= key %>">
   <%= I18n.t('blacklight.search.facets.suggest.label', field_label: label) %>
 </label>
 <%= text_field_tag "facet_suggest_#{key}",

--- a/app/components/blacklight/search_bar_component.html.erb
+++ b/app/components/blacklight/search_bar_component.html.erb
@@ -15,7 +15,7 @@
                     options_for_select(search_fields, h(@search_field)),
                     {},
                     title: scoped_t('search_field.title'),
-                    class: "custom-select form-select search-field") %>
+                    class: "form-select search-field") %>
       <% elsif search_fields.length == 1 %>
         <%= f.hidden_field :search_field, value: search_fields.first.last %>
       <% end %>

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-md bg-dark topbar" aria-label="<%= aria_label %>">
   <div class="<%= container_classes %>">
     <%= logo_link %>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/app/javascript/blacklight-frontend/button_focus.js
+++ b/app/javascript/blacklight-frontend/button_focus.js
@@ -2,7 +2,7 @@ const ButtonFocus = (e) => {
   // Button clicks should change focus. As of 10/3/19, Firefox for Mac and
   // Safari both do not set focus to a button on button click.
   // See https://zellwk.com/blog/inconsistent-button-behavior/ for background information
-  if (e.target.matches('[data-toggle="collapse"]') || e.target.matches('[data-bs-toggle="collapse"]')) {
+  if (e.target.matches('[data-bs-toggle="collapse"]')) {
     e.target.focus()
   }
 }

--- a/app/javascript/blacklight-frontend/modal.js
+++ b/app/javascript/blacklight-frontend/modal.js
@@ -32,7 +32,7 @@
 
     <div data-blacklight-modal="container">
       <div class="modal-header">
-        <button type="button" class="close" data-bl-dismiss="modal" aria-hidden="true">×</button>
+        <button type="button" class="btn-close" data-bl-dismiss="modal" aria-hidden="true">×</button>
         <h3 class="modal-title">Request Placed</h3>
       </div>
 

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -7,7 +7,7 @@
   <div class="modal-body">
     <%= render '/shared/flash_msg' %>
     <div class="row">
-      <label class="control-label col-sm-2" for="to">
+      <label class="col-form-label col-sm-2" for="to">
         <%= t('blacklight.email.form.to') %>
       </label>
       <div class="col-sm-10">
@@ -16,7 +16,7 @@
     </div>
 
     <div class="row">
-      <label class="control-label col-sm-2" for="message">
+      <label class="col-form-label col-sm-2" for="message">
         <%= t('blacklight.email.form.message') %>
       </label>
       <div class="col-sm-10">

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -6,7 +6,7 @@
 
   <div class="modal-body">
     <%= render '/shared/flash_msg' %>
-    <div class="form-group row">
+    <div class="row">
       <label class="control-label col-sm-2" for="to">
         <%= t('blacklight.email.form.to') %>
       </label>
@@ -15,7 +15,7 @@
       </div>
     </div>
 
-    <div class="form-group row">
+    <div class="row">
       <label class="control-label col-sm-2" for="message">
         <%= t('blacklight.email.form.message') %>
       </label>

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -6,7 +6,7 @@
 <div class="modal-body">
   <%= render '/shared/flash_msg' %>
     <div class="row">
-      <label class="control-label col-sm-2" for="to">
+      <label class="col-form-label col-sm-2" for="to">
         <%= t('blacklight.sms.form.to') %>
       </label>
       <div class="col-sm-10">
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="row">
-      <label class="control-label col-sm-2" for="carrier">
+      <label class="col-form-label col-sm-2" for="carrier">
         <%= t('blacklight.sms.form.carrier') %>
       </label>
       <div class="col-sm-10">

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -5,7 +5,7 @@
              method: :post do %>
 <div class="modal-body">
   <%= render '/shared/flash_msg' %>
-    <div class="form-group row">
+    <div class="row">
       <label class="control-label col-sm-2" for="to">
         <%= t('blacklight.sms.form.to') %>
       </label>
@@ -13,7 +13,7 @@
         <%= telephone_field_tag :to, params[:to], class: 'form-control', required: true %>
       </div>
     </div>
-    <div class="form-group row">
+    <div class="row">
       <label class="control-label col-sm-2" for="carrier">
         <%= t('blacklight.sms.form.carrier') %>
       </label>

--- a/app/views/catalog/advanced_search.html.erb
+++ b/app/views/catalog/advanced_search.html.erb
@@ -1,7 +1,7 @@
 <% @page_title = t('blacklight.advanced_search.page_title', application_name: application_name) %>
 
 <div class="advanced-search-form col-sm-12">
-  <h1 class="advanced page-header">
+  <h1>
       <%= t('blacklight.advanced_search.form.title') %>
   </h1>
 

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -93,7 +93,7 @@ it:
           open: Mostra sfaccettature
         missing:
           - Mancante
-        more_html: altri <span class="sr-only visually-hidden">%{field_name}</span> »
+        more_html: altri <span class="visually-hidden">%{field_name}</span> »
         pivot:
           hide: Chiudi
           show: Apri


### PR DESCRIPTION
I have stepped through these Bootstrap migration guides to identify all remaining classes/attributes in Blacklight that were deprecated and are no longer used in Bootstrap 5.
- https://getbootstrap.com/docs/5.3/migration/ 
- https://getbootstrap.com/docs/4.1/migration/