### PR TITLE
add doc id for bookmark event

### DIFF
--- a/app/components/blacklight/document/bookmark_component.html.erb
+++ b/app/components/blacklight/document/bookmark_component.html.erb
@@ -6,7 +6,8 @@
              data: {
                present: t('blacklight.search.bookmarks.present'),
                absent: t('blacklight.search.bookmarks.absent'),
-               inprogress: t('blacklight.search.bookmarks.inprogress')
+               inprogress: t('blacklight.search.bookmarks.inprogress'),
+               doc_id: @document.id
             }) do %>
   <div class="toggle-bookmark">
     <label class="toggle-bookmark-label" data-checkboxsubmit-target="label" <% if bookmark_icon %>tabindex="0"<% end %>>

--- a/app/javascript/blacklight-frontend/checkbox_submit.js
+++ b/app/javascript/blacklight-frontend/checkbox_submit.js
@@ -44,7 +44,8 @@ export default class CheckboxSubmit {
         counter.innerHTML = json.bookmarks.count;
       });
 
-      var e = new CustomEvent('bookmark.blacklight', { detail: { checked: this.checked } });
+      var e = new CustomEvent('bookmark.blacklight', { detail: { checked: this.checked, doc_id: this.formTarget.dataset.docId} });
+      console.log(e)
       window.dispatchEvent(e)
     }).catch((error) => {
       this.handleError(error)


### PR DESCRIPTION
The bookmark page currently doesn't up and remove bookmarks if they are deselected on the page. I think this would be a good update to blacklight and it is something Stanford wants now. I plan to bring this up during a call but for now this is the building block of making that functionality work.

