### PR TITLE
Use SOLR_MODULES in solr_wrapper config for Solr 9.8 compatibility (backport of #3626 to 8.x)

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+env:
+  SOLR_MODULES: analysis-extras
 collection:
   dir: lib/generators/blacklight/templates/solr/conf
   name: blacklight-core

--- a/lib/generators/blacklight/templates/.solr_wrapper.yml
+++ b/lib/generators/blacklight/templates/.solr_wrapper.yml
@@ -1,5 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+env:
+  SOLR_MODULES: analysis-extras
 collection:
   dir: solr/conf/
   name: blacklight-core


### PR DESCRIPTION
backport of #3626 to 8.x

Will help unblock Blackight Quickstart to work with current releases of BL and Solr (although may not get us all the way there). 