### PR TITLE
solr_wrapper dir argument is best to parent dir including 'conf'

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -3,5 +3,5 @@
 env:
   SOLR_MODULES: analysis-extras
 collection:
-  dir: lib/generators/blacklight/templates/solr/conf
+  dir: lib/generators/blacklight/templates/solr/
   name: blacklight-core

--- a/lib/generators/blacklight/templates/.solr_wrapper.yml
+++ b/lib/generators/blacklight/templates/.solr_wrapper.yml
@@ -3,5 +3,5 @@
 env:
   SOLR_MODULES: analysis-extras
 collection:
-  dir: solr/conf/
+  dir: solr/
   name: blacklight-core


### PR DESCRIPTION
The command line `solr` command has preferred this for some time; while including conf worked until 9.7.  solr_wrapper has some additional logic to try to keep things working even if you include conf, but we can avoid unnecessary complexity by using a dir argument that is to parent dir including `conf` instead.

Note this is related to https://github.com/cbeer/solr_wrapper/pull/161 -- but that solr_wrapper PR is necessary with or without this to have reliably working because solr_wrapper had bugs either way; and with that solr_wrapper PR this one here isn't actually *required*, it will work either way. But this avoids some complexity in solr_wrapper logic and I think makes future troubleshooting easier.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
