### PR TITLE
[8.x Backport] Restore scrolling and execute other modal hide behavior on modal dismiss by "escape" key

### DIFF
--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -162,6 +162,14 @@ const Modal = (() => {
       else if (e.target.matches(`${modal.modalSelector}`) || e.target.closest('[data-bl-dismiss="modal"]'))
         modal.hide()
     })
+
+    // Make sure user-agent dismissal of html 'dialog', etc `esc` key, triggers
+    // our hide logic, including events and scroll restoration.
+    modal.target().addEventListener('cancel', (e) => {
+      e.preventDefault(); // 'hide' will close the modal unless cancelled
+
+      modal.hide();
+    });
   };
 
   modal.hide = function (el) {


### PR DESCRIPTION
Backport #3694 to 8.x