### PR TITLE
3701 visually show you searched for and remove constraints heading

### DIFF
--- a/app/components/blacklight/constraints_component.html.erb
+++ b/app/components/blacklight/constraints_component.html.erb
@@ -1,7 +1,5 @@
 <%= content_tag @tag || :div, id: @id, class: @classes do %>
-  <% if @render_headers %>
-    <h2 class="constraints-label h6 mb-0"><%= t('blacklight.search.filters.title') %></h2>
-  <% end %>
+  <%= constraints_heading %>
 
   <% if query_constraints_area.present? %>
     <% query_constraints_area.each do |constraint| %>

--- a/app/components/blacklight/constraints_component.html.erb
+++ b/app/components/blacklight/constraints_component.html.erb
@@ -1,10 +1,6 @@
 <%= content_tag @tag || :div, id: @id, class: @classes do %>
   <% if @render_headers %>
-    <h2 class="visually-hidden"><%= t('blacklight.search.search_constraints_header') %></h2>
-  <% end %>
-
-  <% if @render_headers %>
-    <span class="constraints-label visually-hidden"><%= t('blacklight.search.filters.title') %></span>
+    <h2 class="constraints-label h6 mb-0"><%= t('blacklight.search.filters.title') %></h2>
   <% end %>
 
   <% if query_constraints_area.present? %>

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -22,6 +22,7 @@ module Blacklight
     def initialize(search_state:,
                    tag: :div,
                    render_headers: true,
+                   heading_classes: 'constraints-label h6 mb-0',
                    id: 'appliedParams', classes: 'clearfix constraints-container mb-2 align-items-center',
                    query_constraint_component: Blacklight::ConstraintLayoutComponent,
                    query_constraint_component_options: {},
@@ -35,6 +36,7 @@ module Blacklight
       @facet_constraint_component_options = facet_constraint_component_options
       @start_over_component = start_over_component
       @render_headers = render_headers
+      @heading_classes = heading_classes
       @tag = tag
       @id = id
       @classes = classes
@@ -142,14 +144,13 @@ module Blacklight
 
     # Returns a heading tag for the constraints section
     #
-    # @param [Array] array of classes for constraints heading
     # @return [ActiveSupport::SafeBuffer, nil] constraints heading html
-    def constraints_heading(classes: %w[constraints-label h6 mb-0])
+    def constraints_heading
       return unless @render_headers
 
       tag.h2(
         t('blacklight.search.filters.title'),
-        class: classes.join(' ')
+        class: @heading_classes
       )
     end
   end

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -9,7 +9,7 @@ module Blacklight
     # Constraints are stored and used to display search history - with this method, we initialize the ConstraintsComponent
     # in a way that displays well in a table (and without a start-over button)
     def self.for_search_history(**)
-      new(tag: :span, render_heading: false,
+      new(tag: :span, render_headers: false,
           id: nil,
           query_constraint_component: Blacklight::SearchHistoryConstraintLayoutComponent,
           facet_constraint_component_options: { layout: Blacklight::SearchHistoryConstraintLayoutComponent },

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -22,7 +22,7 @@ module Blacklight
     def initialize(search_state:,
                    tag: :div,
                    render_headers: true,
-                   id: 'appliedParams', classes: 'clearfix constraints-container mb-2',
+                   id: 'appliedParams', classes: 'clearfix constraints-container mb-2 align-items-center',
                    query_constraint_component: Blacklight::ConstraintLayoutComponent,
                    query_constraint_component_options: {},
                    facet_constraint_component: Blacklight::ConstraintComponent,

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -9,8 +9,7 @@ module Blacklight
     # Constraints are stored and used to display search history - with this method, we initialize the ConstraintsComponent
     # in a way that displays well in a table (and without a start-over button)
     def self.for_search_history(**)
-      new(tag: :span,
-          render_headers: false,
+      new(tag: :span, render_heading: false,
           id: nil,
           query_constraint_component: Blacklight::SearchHistoryConstraintLayoutComponent,
           facet_constraint_component_options: { layout: Blacklight::SearchHistoryConstraintLayoutComponent },

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -142,13 +142,14 @@ module Blacklight
 
     # Returns a heading tag for the constraints section
     #
-    # @return [ActiveSupport::SafeBuffer, nil]
-    def constraints_heading
+    # @param [Array] array of classes for constraints heading
+    # @return [ActiveSupport::SafeBuffer, nil] constraints heading html
+    def constraints_heading(classes: %w[constraints-label h6 mb-0])
       return unless @render_headers
 
       tag.h2(
         t('blacklight.search.filters.title'),
-        class: 'constraints-label h6 mb-0'
+        class: classes.join(' ')
       )
     end
   end

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -146,7 +146,7 @@ module Blacklight
     def constraints_heading
       return unless @render_headers
 
-      helpers.tag.h2(
+      tag.h2(
         t('blacklight.search.filters.title'),
         class: 'constraints-label h6 mb-0'
       )

--- a/app/components/blacklight/constraints_component.rb
+++ b/app/components/blacklight/constraints_component.rb
@@ -139,5 +139,17 @@ module Blacklight
         field_label: facet_field_presenter.label
       )
     end
+
+    # Returns a heading tag for the constraints section
+    #
+    # @return [ActiveSupport::SafeBuffer, nil]
+    def constraints_heading
+      return unless @render_headers
+
+      helpers.tag.h2(
+        t('blacklight.search.filters.title'),
+        class: 'constraints-label h6 mb-0'
+      )
+    end
   end
 end

--- a/config/locales/blacklight.ar.yml
+++ b/config/locales/blacklight.ar.yml
@@ -120,7 +120,7 @@ ar:
         remove:
           label_value: "إزالة القيد %{label}: %{value}"
           value: إزالة القيد %{value}
-        title: "لقد بحثت عن:"
+        title: "اختياراتك:"
       form:
         search:
           label: ابحث عن
@@ -160,7 +160,6 @@ ar:
         submit: تحديث
         title: عدد النتائج المعروضة في الصفحة
       rss_feed: خلاصات RSS للنتائج
-      search_constraints_header: قيود البحث
       search_results: نتائج البحث
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.ca.yml
+++ b/config/locales/blacklight.ca.yml
@@ -136,7 +136,6 @@ ca:
         many_constraint_values: "%{values} seleccionat"
         joiner: " / "
       header: "Cerca"
-      search_constraints_header: "Filtres de la cerca"
       search_results: "Resultats de la cerca"
       errors:
         invalid_solr_id: "El registre que heu sol·licitat no existeix."
@@ -194,7 +193,7 @@ ca:
       group:
         more: "més »"
       filters:
-        title: "Heu cercat per:"
+        title: "Les teves seleccions:"
         label: "%{label}:"
         remove:
           value: "Eliminar el filtre %{value}"

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -111,7 +111,7 @@ de:
         remove:
           label_value: "Filter %{label}: %{value} entfernen"
           value: Filter %{value} entfernen
-        title: "Sie suchten nach:"
+        title: "Ihre Auswahl:"
       form:
         search:
           label: suchen nach
@@ -147,7 +147,6 @@ de:
         submit: Aktualisieren
         title: Anzahl der Ergebnisse, die pro Seite angezeigt werden
       rss_feed: RSS für Ergebnisse
-      search_constraints_header: Suchen
       search_results: Suchergebnisse
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -129,7 +129,7 @@ en:
         remove:
           label_value: "Remove constraint %{label}: %{value}"
           value: Remove constraint %{value}
-        title: "You searched for:"
+        title: "Your selections:"
       form:
         search:
           label: search for
@@ -165,7 +165,6 @@ en:
         submit: Update
         title: Number of results to display per page
       rss_feed: RSS for results
-      search_constraints_header: Search Constraints
       search_results: Search Results
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -110,7 +110,7 @@ es:
         remove:
           label_value: "Eliminar la restricción%{label}: %{value}"
           value: Eliminar la restricción %{value}
-        title: "Usted ha buscado:"
+        title: "Tus selecciones:"
       form:
         search:
           label: buscar
@@ -146,7 +146,6 @@ es:
         submit: Actualización
         title: El número de resultados a mostrar por página
       rss_feed: RSS de los resultados
-      search_constraints_header: Buscar
       search_results: Resultados de la búsqueda
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -110,7 +110,7 @@ fr:
         remove:
           label_value: "Supprimer la restriction %{label}: %{value}"
           value: Supprimer la restriction %{value}
-        title: "Vous avez demandé :"
+        title: "Vos sélections:"
       form:
         search:
           label: Rechercher
@@ -146,7 +146,6 @@ fr:
         submit: mettre à jour
         title: Nombre de résultats à afficher par page
       rss_feed: RSS pour les résultats
-      search_constraints_header: Recherche
       search_results: Résultats de recherche
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.hu.yml
+++ b/config/locales/blacklight.hu.yml
@@ -108,7 +108,7 @@ hu:
         remove:
           label_value: "Feltétel eltávolítása %{label}: %{value}"
           value: Feltételek eltávolítása %{value}
-        title: "Ön ezt kereste:"
+        title: "Az Ön választása:"
       form:
         search:
           label: keresés
@@ -144,7 +144,6 @@ hu:
         submit: Frissítés
         title: Az eredmények száma oldalanként
       rss_feed: Eredmények RSS-ként
-      search_constraints_header: Keresés feltételei
       search_results: Keresés eredményei
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -111,7 +111,7 @@ it:
         remove:
           label_value: "Cancella il filtro %{label}: %{value}"
           value: Cancella il filtro %{value}
-        title: "Hai cercato per:"
+        title: "Le tue selezioni:"
       form:
         search:
           label: cerca per
@@ -147,7 +147,6 @@ it:
         submit: Aggiorna
         title: Risultati per pagina
       rss_feed: RSS per i risultati
-      search_constraints_header: Ricerca
       search_results: Risultati della ricerca
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.nl.yml
+++ b/config/locales/blacklight.nl.yml
@@ -108,7 +108,7 @@ nl:
         remove:
           label_value: "Verwijder zoekfilter %{label}: %{value}"
           value: Verwijder zoekfilter %{value}
-        title: "U zocht op:"
+        title: "Uw selecties:"
       form:
         search:
           label: zoeken op
@@ -144,7 +144,6 @@ nl:
         submit: Update
         title: Toon aantal zoekresultaten per pagina
       rss_feed: RSS voor zoekresultaten
-      search_constraints_header: Zoek filters
       search_results: Zoek resultaten
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -109,7 +109,7 @@ pt-BR:
         remove:
           label_value: "Remover %{label}: %{value}"
           value: Remover filtro %{value}
-        title: "Sua busca por:"
+        title: "Suas seleções:"
       form:
         search:
           label: busca
@@ -145,7 +145,6 @@ pt-BR:
         submit: Atualizar
         title: Número de resultados para mostrar por página
       rss_feed: RSS para resultadoss
-      search_constraints_header: Busca
       search_results: Resultados da Busca
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.sq.yml
+++ b/config/locales/blacklight.sq.yml
@@ -108,7 +108,7 @@ sq:
         remove:
           label_value: "Fshij kufizimin %{label}: %{value}"
           value: Fshij kufizimin %{value}
-        title: "Ju keni kërkuar për:"
+        title: "Zgjedhjet tuaja:"
       form:
         search:
           label: kërko për
@@ -144,7 +144,6 @@ sq:
         submit: Përditëso
         title: Numri i rezultateve që do të shfaqen për faqe
       rss_feed: RSS për rezultatet
-      search_constraints_header: Kufizimet e kërkimit
       search_results: Rezultatet e kërkimit
       show:
         label: "%{label}:"

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -108,7 +108,7 @@ zh:
         remove:
           label_value: "删除限定条件 %{label}: %{value}"
           value: 删除限定条件 %{value}
-        title: 你在搜索：
+        title: 您的选择：
       form:
         search:
           label: 搜索
@@ -144,7 +144,6 @@ zh:
         submit: 更新
         title: 每页显示结果数
       rss_feed: 搜索结果RSS
-      search_constraints_header: 搜索条件
       search_results: 搜索结果
       show:
         label: "%{label}:"

--- a/spec/components/blacklight/constraints_component_spec.rb
+++ b/spec/components/blacklight/constraints_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     end
 
     it 'has a header' do
-      expect(page).to have_css('h2', text: 'Search Constraints')
+      expect(page).to have_css('h2', text: I18n.t('blacklight.search.filters.title'))
     end
 
     it 'wraps the output in a div' do

--- a/spec/components/blacklight/constraints_component_spec.rb
+++ b/spec/components/blacklight/constraints_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     end
 
     it 'has a header' do
-      expect(page).to have_css('h2', text: I18n.t('blacklight.search.filters.title'))
+      expect(page).to have_css('h2', text: 'Your selections:')
     end
 
     it 'wraps the output in a div' do
@@ -76,10 +76,6 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
 
     it 'renders the search state as lightly-decorated text' do
       expect(page).to have_css('.constraint > .filter-values', text: 'some query').and(have_css('.constraint', text: 'Some Facet:some value'))
-    end
-
-    it 'omits the headers' do
-      expect(page).to have_no_css('h2', text: 'Search Constraints')
     end
   end
 end

--- a/spec/components/blacklight/constraints_component_spec.rb
+++ b/spec/components/blacklight/constraints_component_spec.rb
@@ -77,5 +77,9 @@ RSpec.describe Blacklight::ConstraintsComponent, type: :component do
     it 'renders the search state as lightly-decorated text' do
       expect(page).to have_css('.constraint > .filter-values', text: 'some query').and(have_css('.constraint', text: 'Some Facet:some value'))
     end
+
+    it 'omits the headers' do
+      expect(page).to have_no_css('h2', text: 'Your selections:')
+    end
   end
 end

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_css('h2', text: 'Your selections:')
+      expect(page).to have_content "Your selections:"
       expect(page).to have_content "history"
     end
 
@@ -140,7 +140,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_css('h2', text: 'Your selections:')
+      expect(page).to have_content "Your selections:"
       expect(page).to have_content "history"
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_css('h2', text: 'Your selections:')
+      expect(page).to have_content "Your selections:"
       expect(page).to have_content "history"
     end
   end

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_content "You searched for:"
+      expect(page).to have_content I18n.t('blacklight.search.filters.title')
       expect(page).to have_content "history"
     end
 
@@ -140,7 +140,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_content "You searched for:"
+      expect(page).to have_content I18n.t('blacklight.search.filters.title')
       expect(page).to have_content "history"
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_content "You searched for:"
+      expect(page).to have_content I18n.t('blacklight.search.filters.title')
       expect(page).to have_content "history"
     end
   end

--- a/spec/features/search_filters_spec.rb
+++ b/spec/features/search_filters_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_content I18n.t('blacklight.search.filters.title')
+      expect(page).to have_css('h2', text: 'Your selections:')
       expect(page).to have_content "history"
     end
 
@@ -140,7 +140,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_content I18n.t('blacklight.search.filters.title')
+      expect(page).to have_css('h2', text: 'Your selections:')
       expect(page).to have_content "history"
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe "Facets" do
       expect(page).to have_css("span.facet-count.selected", text: "2")
     end
     within "#appliedParams" do
-      expect(page).to have_content I18n.t('blacklight.search.filters.title')
+      expect(page).to have_css('h2', text: 'Your selections:')
       expect(page).to have_content "history"
     end
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Search Page" do
     Capybara.ignore_hidden_elements = tmp_value
 
     within "#appliedParams" do
-      expect(page).to have_css('h2', text: 'Your selections:')
+      expect(page).to have_content "Your selections:"
       expect(page).to have_content "history"
     end
 
@@ -74,7 +74,7 @@ RSpec.describe "Search Page" do
     click_on 'search'
 
     within "#appliedParams" do
-      expect(page).to have_css('h2', text: 'Your selections:')
+      expect(page).to have_content "Your selections:"
       expect(page).to have_content "Title"
       expect(page).to have_content "inmul"
     end
@@ -104,7 +104,7 @@ RSpec.describe "Search Page" do
     fill_in "q", with: 'history'
     click_on 'search'
     within "#appliedParams" do
-      expect(page).to have_css('h2', text: 'Your selections:')
+      expect(page).to have_content "Your selections:"
       expect(page).to have_content "history"
     end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Search Page" do
     Capybara.ignore_hidden_elements = tmp_value
 
     within "#appliedParams" do
-      expect(page).to have_content I18n.t('blacklight.search.filters.title')
+      expect(page).to have_css('h2', text: 'Your selections:')
       expect(page).to have_content "history"
     end
 
@@ -74,7 +74,7 @@ RSpec.describe "Search Page" do
     click_on 'search'
 
     within "#appliedParams" do
-      expect(page).to have_content I18n.t('blacklight.search.filters.title')
+      expect(page).to have_css('h2', text: 'Your selections:')
       expect(page).to have_content "Title"
       expect(page).to have_content "inmul"
     end
@@ -104,7 +104,7 @@ RSpec.describe "Search Page" do
     fill_in "q", with: 'history'
     click_on 'search'
     within "#appliedParams" do
-      expect(page).to have_content I18n.t('blacklight.search.filters.title')
+      expect(page).to have_css('h2', text: 'Your selections:')
       expect(page).to have_content "history"
     end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Search Page" do
     Capybara.ignore_hidden_elements = tmp_value
 
     within "#appliedParams" do
-      expect(page).to have_content "You searched for:"
+      expect(page).to have_content I18n.t('blacklight.search.filters.title')
       expect(page).to have_content "history"
     end
 
@@ -74,7 +74,7 @@ RSpec.describe "Search Page" do
     click_on 'search'
 
     within "#appliedParams" do
-      expect(page).to have_content "You searched for:"
+      expect(page).to have_content I18n.t('blacklight.search.filters.title')
       expect(page).to have_content "Title"
       expect(page).to have_content "inmul"
     end
@@ -104,7 +104,7 @@ RSpec.describe "Search Page" do
     fill_in "q", with: 'history'
     click_on 'search'
     within "#appliedParams" do
-      expect(page).to have_content "You searched for:"
+      expect(page).to have_content I18n.t('blacklight.search.filters.title')
       expect(page).to have_content "history"
     end
 


### PR DESCRIPTION
Reworked the constraints heading - removed `search_constraints_header` locale, unhid the `You searched for:` span (turned it into a header), and updated the text to say `Your selections:`:

<img width="689" height="71" alt="Screenshot 2025-07-29 at 5 01 38 PM" src="https://github.com/user-attachments/assets/d34a4848-3a62-4c3e-87d8-32aa037f4306" />
