### PR TITLE
Pass no arguments to the superclass

### DIFF
--- a/app/components/blacklight/document/bookmark_component.rb
+++ b/app/components/blacklight/document/bookmark_component.rb
@@ -13,7 +13,7 @@ module Blacklight
         @checked = checked
         @bookmark_path = bookmark_path
         @action = action
-        super
+        super()
       end
 
       # Used by ActionsComponent

--- a/app/components/blacklight/document/page_header_component.rb
+++ b/app/components/blacklight/document/page_header_component.rb
@@ -9,7 +9,7 @@ module Blacklight
       delegate :blacklight_config, to: :helpers
 
       def initialize(document:, search_context:, search_session:)
-        super
+        super()
         @search_context = search_context
         @search_session = search_session
         @document = document

--- a/app/components/blacklight/facets/selected_value_component.rb
+++ b/app/components/blacklight/facets/selected_value_component.rb
@@ -7,7 +7,7 @@ module Blacklight
       def initialize(label:, href:)
         @label = label
         @href = href
-        super
+        super()
       end
 
       attr_reader :label, :href

--- a/spec/views/catalog/index.atom.builder_spec.rb
+++ b/spec/views/catalog/index.atom.builder_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe "catalog/index" do
     context 'with a custom template' do
       before do
         my_template = Class.new(ViewComponent::Base) do
+          def initialize(**); end
+
           def call
             'whatever content'.html_safe
           end


### PR DESCRIPTION
ViewComponent 4.0 does not have a wildcard initializer, so passing everything would prevent an upgrade

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
