### PR TITLE
Avoid ViewComponent::Base#set_slot

### DIFF
--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -54,7 +54,6 @@ module Blacklight
       next static_content if static_content.present?
 
       component ||= view_config.metadata_component || Blacklight::DocumentMetadataComponent
-
       component.new(*args, fields: fields || @presenter&.field_presenters || [], **kwargs)
     end)
 
@@ -119,10 +118,10 @@ module Blacklight
     end
 
     def before_render
-      set_slot(:title, nil) unless title
-      set_slot(:thumbnail, nil) unless thumbnail || show?
-      set_slot(:metadata, nil, fields: presenter.field_presenters, show: @show) unless metadata
-      set_slot(:embed, nil) unless embed
+      with_title unless title
+      with_thumbnail unless thumbnail || show?
+      with_metadata(fields: presenter.field_presenters, show: @show) unless metadata
+      with_embed unless embed
 
       view_partials.each do |view_partial|
         with_partial(view_partial) do

--- a/app/components/blacklight/header_component.rb
+++ b/app/components/blacklight/header_component.rb
@@ -19,8 +19,8 @@ module Blacklight
     # Hack so that the default lambdas are triggered
     # so that we don't have to do c.with_top_bar() in the call.
     def before_render
-      set_slot(:top_bar, nil) unless top_bar
-      set_slot(:search_bar, nil) unless search_bar
+      with_top_bar unless top_bar
+      with_search_bar unless search_bar
     end
   end
 end

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
   end
 
   it 'has some defined content areas' do
-    component.set_slot(:title) { 'Title' }
-    component.set_slot(:embed, nil, 'Embed')
-    component.set_slot(:metadata, nil, 'Metadata')
-    component.set_slot(:thumbnail, nil, 'Thumbnail')
-    component.set_slot(:actions) { 'Actions' }
+    component.with_title { 'Title' }
+    component.with_embed('Embed')
+    component.with_metadata('Metadata')
+    component.with_thumbnail('Thumbnail')
+    component.with_actions { 'Actions' }
     render_inline component
 
     expect(page).to have_content 'Title'
@@ -49,7 +49,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
   end
 
   it 'has schema.org properties' do
-    component.set_slot(:body) { '-' }
+    component.with_body { '-' }
     render_inline component
 
     expect(page).to have_css 'article[@itemtype="http://schema.org/Thing"]'
@@ -58,7 +58,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
 
   context 'with a provided body' do
     it 'opts-out of normal component content' do
-      component.set_slot(:body) { 'Body content' }
+      component.with_body { 'Body content' }
       render_inline component
 
       expect(page).to have_content 'Body content'
@@ -75,7 +75,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     let(:attr) { { counter: 5 } }
 
     it 'has data properties' do
-      component.set_slot(:body) { '-' }
+      component.with_body { '-' }
       render_inline component
 
       expect(page).to have_css 'article[@data-document-id="x"]'
@@ -137,7 +137,7 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     end
 
     it 'renders with an id' do
-      component.set_slot(:body) { '-' }
+      component.with_body { '-' }
       render_inline component
 
       expect(page).to have_css 'article#document'


### PR DESCRIPTION
This is deprecated, and unavailable in ViewComponent 4.0.  We don't have any reason to do it anyway

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
