### PR TITLE
Fix facet suggest catalog path

### DIFF
--- a/app/javascript/blacklight-frontend/facet_suggest.js
+++ b/app/javascript/blacklight-frontend/facet_suggest.js
@@ -17,8 +17,9 @@ const FacetSuggest = async (e) => {
     // Drop facet.page so a filtered suggestion list will always start on page 1
     url.searchParams.delete('facet.page');
     const facetSearchParams = url.searchParams.toString();
+    const basePathComponent = url.pathname.split('/')[0];
 
-    const urlToFetch = `/catalog/facet_suggest/${facetField}/${queryFragment}?${facetSearchParams}`;
+    const urlToFetch = `/${basePathComponent}/facet_suggest/${facetField}/${queryFragment}?${facetSearchParams}`;
 
     const response = await fetch(urlToFetch);
     if (response.ok) {

--- a/app/javascript/blacklight-frontend/facet_suggest.js
+++ b/app/javascript/blacklight-frontend/facet_suggest.js
@@ -17,7 +17,7 @@ const FacetSuggest = async (e) => {
     // Drop facet.page so a filtered suggestion list will always start on page 1
     url.searchParams.delete('facet.page');
     const facetSearchParams = url.searchParams.toString();
-    const basePathComponent = url.pathname.split('/')[0];
+    const basePathComponent = url.pathname.split('/')[1];
 
     const urlToFetch = `/${basePathComponent}/facet_suggest/${facetField}/${queryFragment}?${facetSearchParams}`;
 


### PR DESCRIPTION
If you've changed the resource path names for CatalogController routes...

```ruby
resource :catalog, as: 'catalog', path: '/items'
```

...the facet suggest lookups won't work. [The `/catalog/` path is hard-coded into the FacetSuggest object](https://github.com/projectblacklight/blacklight/pull/3711/files#diff-f12939c2b9cc757ac9564932c71adea5ee785945e77d9764333368d2e551af5aL21). 

This MR extracts the base catalog actions path from the `facetSearchContext` that is already read in by the javascript.

I struggled to add a spec to cover this change. I could not find precedent for specs covering changed route names for catalog controller actions. Errors in this change would most likely be caught by existing specs covering facet suggest actions.
