### PR TITLE
Backport ViewComponent 4 support into Blacklight 8

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -34,6 +34,20 @@
       "additional_name": "| esbuild"
     },
     {
+      "ruby": "3.3",
+      "rails_version": "8.0.1",
+      "view_component_version": "~> 4.0",
+      "additional_engine_cart_rails_options": "--css=bootstrap",
+      "additional_name": "| ViewComponent 4"
+    },
+    {
+      "ruby": "3.3",
+      "rails_version": "8.0.1",
+      "view_component_version": "~> 4.0",
+      "additional_engine_cart_rails_options": "--css=bootstrap --js=esbuild",
+      "additional_name": "| esbuild, ViewComponent 4"
+    },
+    {
       "ruby": "3.2",
       "rails_version": "7.1.5.1",
       "solr_version": "8.11.2",

--- a/app/components/blacklight/document/bookmark_component.rb
+++ b/app/components/blacklight/document/bookmark_component.rb
@@ -12,6 +12,7 @@ module Blacklight
         @document = document
         @checked = checked
         @bookmark_path = bookmark_path
+
         super(document: document, action: action, **kwargs)
       end
 

--- a/app/components/blacklight/document/page_header_component.rb
+++ b/app/components/blacklight/document/page_header_component.rb
@@ -9,7 +9,7 @@ module Blacklight
       delegate :blacklight_config, to: :helpers
 
       def initialize(document:, search_context:, search_session:)
-        super
+        super()
         @search_context = search_context
         @search_session = search_session
         @document = document

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -94,10 +94,10 @@ module Blacklight
     def initialize(document: nil, presenter: nil, partials: nil,
                    id: nil, classes: [], component: :article, title_component: nil,
                    counter: nil, document_counter: nil, counter_offset: 0,
-                   show: false, **args)
+                   show: false)
       Blacklight.deprecation.warn('the `presenter` argument to DocumentComponent#initialize is deprecated; pass the `presenter` in as document instead') if presenter
 
-      @presenter = presenter || document || args[self.class.collection_parameter]
+      @presenter = presenter || document
       @document = @presenter.document
       @view_partials = partials || []
 
@@ -107,7 +107,7 @@ module Blacklight
       @classes = classes
 
       @counter = counter
-      @document_counter = document_counter || args.fetch(self.class.collection_counter_parameter, nil)
+      @document_counter = document_counter
       @counter ||= @document_counter + COLLECTION_INDEX_OFFSET + counter_offset if @document_counter.present?
 
       @show = show

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -125,10 +125,10 @@ module Blacklight
     end
 
     def before_render
-      set_slot(:title, nil) unless title
-      set_slot(:thumbnail, nil) unless thumbnail || show?
-      set_slot(:metadata, nil, fields: presenter.field_presenters, show: @show) unless metadata
-      set_slot(:embed, nil) unless embed
+      with_title unless title
+      with_thumbnail unless thumbnail || show?
+      with_metadata(fields: presenter.field_presenters, show: @show) unless metadata
+      with_embed unless embed
 
       view_partials.each do |view_partial|
         with_partial(view_partial) do

--- a/app/components/blacklight/header_component.rb
+++ b/app/components/blacklight/header_component.rb
@@ -19,8 +19,8 @@ module Blacklight
     # Hack so that the default lambdas are triggered
     # so that we don't have to do c.with_top_bar() in the call.
     def before_render
-      set_slot(:top_bar, nil) unless top_bar
-      set_slot(:search_bar, nil) unless search_bar
+      with_top_bar unless top_bar
+      with_search_bar unless search_bar
     end
   end
 end

--- a/app/views/catalog/_document.atom.builder
+++ b/app/views/catalog/_document.atom.builder
@@ -21,7 +21,7 @@ xml.entry do
   with_format(:html) do
     xml.summary "type" => "html" do
       document_component = blacklight_config.view_config(:atom).summary_component
-      xml.text! render document_component.new(document_component.collection_parameter => document_presenter(document), component: :div, show: true)
+      xml.text! render document_component.new(document: document_presenter(document), component: :div, show: true)
     end
   end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,4 @@
 <% # container for a single doc -%>
 <% view_config = local_assigns[:view_config] || blacklight_config.view_config(document_index_view_type, action_name: action_name) %>
 <% document_component = view_config.document_component -%>
-<%= render document_component.new(document_component.collection_parameter => document_presenter(document), counter: document_counter_with_offset(document_counter), partials: view_config&.partials) %>
+<%= render document_component.new(document: document_presenter(document), counter: document_counter_with_offset(document_counter), partials: view_config&.partials) %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:head) { render_link_rel_alternates } %>
 
 <% document_component = blacklight_config.view_config(:show).document_component -%>
-<%= render (document_component).new(document_component.collection_parameter => document_presenter(@document), component: :div, show: true, partials: blacklight_config.view_config(:show).partials) do |component| %>
+<%= render (document_component).new(document: document_presenter(@document), component: :div, show: true, partials: blacklight_config.view_config(:show).partials) do |component| %>
   <% component.with_title(as: 'h1', classes: '', link_to_document: false, actions: false) %>
   <% component.with_footer do %>
     <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results
   s.add_dependency "i18n", '>= 1.7.0' # added named parameters
   s.add_dependency "ostruct", '>= 0.3.2'
-  s.add_dependency "view_component", '>= 2.74', '< 4'
+  s.add_dependency "view_component", '>= 2.74', '< 5'
   s.add_dependency "zeitwerk"
 
   s.add_development_dependency "rsolr", ">= 1.0.6", "< 3"  # Library for interacting with rSolr.

--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -11,8 +11,7 @@ module Blacklight
 
       def sidecar_files(*args, **kwargs)
         upstream_sidecar_files(*args, **kwargs).map do |path|
-          components_path = ViewComponent::VERSION::MAJOR == 3 ? view_component_path : config.generate.path
-
+          components_path = ViewComponent::VERSION::MAJOR < 4 ? view_component_path : config.generate.path
           app_path = Rails.root.join(path.slice(path.index(components_path)..-1).to_s).to_s
 
           if File.exist?(app_path)

--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -11,7 +11,9 @@ module Blacklight
 
       def sidecar_files(*args, **kwargs)
         upstream_sidecar_files(*args, **kwargs).map do |path|
-          app_path = Rails.root.join(path.slice(path.index(view_component_path)..-1).to_s).to_s
+          components_path = ViewComponent::VERSION::MAJOR == 3 ? view_component_path : config.generate.path
+
+          app_path = Rails.root.join(path.slice(path.index(components_path)..-1).to_s).to_s
 
           if File.exist?(app_path)
             app_path

--- a/spec/components/blacklight/document_component_spec.rb
+++ b/spec/components/blacklight/document_component_spec.rb
@@ -41,11 +41,12 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
   end
 
   it 'has some defined content areas' do
-    component.set_slot(:title) { 'Title' }
-    component.set_slot(:embed, nil, 'Embed')
-    component.set_slot(:metadata, nil, 'Metadata')
-    component.set_slot(:thumbnail, nil, 'Thumbnail')
-    component.set_slot(:actions) { 'Actions' }
+    component.with_title { 'Title' }
+    component.with_embed('Embed')
+    component.with_metadata('Metadata')
+    component.with_thumbnail('Thumbnail')
+    component.with_actions { 'Actions' }
+    render_inline component
 
     expect(rendered).to have_content 'Title'
     expect(rendered).to have_content 'Embed'
@@ -55,7 +56,8 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
   end
 
   it 'has schema.org properties' do
-    component.set_slot(:body) { '-' }
+    component.with_body { '-' }
+    render_inline component
 
     expect(rendered).to have_css 'article[@itemtype="http://schema.org/Thing"]'
     expect(rendered).to have_css 'article[@itemscope]'
@@ -63,7 +65,8 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
 
   context 'with a provided body' do
     it 'opts-out of normal component content' do
-      component.set_slot(:body) { 'Body content' }
+      component.with_body { 'Body content' }
+      render_inline component
 
       expect(rendered).to have_content 'Body content'
       expect(rendered).to have_no_css 'header'
@@ -79,7 +82,8 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     let(:attr) { { counter: 5 } }
 
     it 'has data properties' do
-      component.set_slot(:body) { '-' }
+      component.with_body { '-' }
+      render_inline component
 
       expect(rendered).to have_css 'article[@data-document-id="x"]'
       expect(rendered).to have_css 'article[@data-document-counter="5"]'
@@ -130,7 +134,8 @@ RSpec.describe Blacklight::DocumentComponent, type: :component do
     end
 
     it 'renders with an id' do
-      component.set_slot(:body) { '-' }
+      component.with_body { '-' }
+      render_inline component
 
       expect(rendered).to have_css 'article#document'
     end

--- a/spec/controllers/blacklight/catalog_spec.rb
+++ b/spec/controllers/blacklight/catalog_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Blacklight::Catalog do
   subject { controller }
 
-  let(:controller) { (Class.new(ApplicationController) { include Blacklight::Catalog }).new }
+  let(:controller) { Class.new(ApplicationController) { include Blacklight::Catalog }.new }
 
   describe "#search_state" do
     subject { controller.send(:search_state) }

--- a/spec/support/presenter_test_helpers.rb
+++ b/spec/support/presenter_test_helpers.rb
@@ -2,7 +2,7 @@
 
 module PresenterTestHelpers
   def controller
-    @controller ||= ViewComponent::Base.test_controller.constantize.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)
+    @controller ||= ApplicationController.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)
   end
 
   def request

--- a/spec/views/catalog/index.atom.builder_spec.rb
+++ b/spec/views/catalog/index.atom.builder_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe "catalog/index" do
     context 'with a custom template' do
       before do
         my_template = Class.new(ViewComponent::Base) do
+          def initialize(**); end
+
           def call
             'whatever content'.html_safe
           end


### PR DESCRIPTION
I admit I only understand about 80% of this, counting on the tests being good, to let me try to copy/paste/cherry-pick related commits from `main` (BL9) until tests pass. Wasn't too too hard with the relevant `main` PR's on hand. 

Relevant  PR's consulted/cherry-picked:

* https://github.com/projectblacklight/blacklight/pull/3706
* https://github.com/projectblacklight/blacklight/pull/3707
* https://github.com/projectblacklight/blacklight/pull/3708
* https://github.com/projectblacklight/blacklight/pull/3709 
* https://github.com/projectblacklight/blacklight/pull/3714