### PR TITLE
Allow modalSetup to be called when no modal DOM is on page

### DIFF
--- a/app/javascript/blacklight-frontend/modal.js
+++ b/app/javascript/blacklight-frontend/modal.js
@@ -160,11 +160,14 @@ const Modal = (() => {
 
     // Make sure user-agent dismissal of html 'dialog', etc `esc` key, triggers
     // our hide logic, including events and scroll restoration.
-    modal.target().addEventListener('cancel', (e) => {
-      e.preventDefault(); // 'hide' will close the modal unless cancelled
+    const modalDom = modal.target();
+    if (modalDom) {
+      modal.target().addEventListener('cancel', (e) => {
+        e.preventDefault(); // 'hide' will close the modal unless cancelled
 
-      modal.hide();
-    });
+        modal.hide();
+      });
+    }
   };
 
   modal.hide = function (el) {


### PR DESCRIPTION
It used to be possible to call Blacklight modal init code on a page that didn't actually have a modal, esssentially having no effect.  Fix to regression introduced in #3694, which made modalSetup instead raise a JS error (preventing parsing of remainder of file) in such a condition.

This isn't caught by tests because we have a modal including on all standard blacklight pages. 

This will need to be backported to 8.x. too. 