### PR TITLE
BACKPORT: Allow modalSetup to be called when no modal DOM is on page

### DIFF
--- a/app/javascript/blacklight/modal.js
+++ b/app/javascript/blacklight/modal.js
@@ -165,11 +165,14 @@ const Modal = (() => {
 
     // Make sure user-agent dismissal of html 'dialog', etc `esc` key, triggers
     // our hide logic, including events and scroll restoration.
-    modal.target().addEventListener('cancel', (e) => {
-      e.preventDefault(); // 'hide' will close the modal unless cancelled
+    const modalDom = modal.target();
+    if (modalDom) {
+      modal.target().addEventListener('cancel', (e) => {
+        e.preventDefault(); // 'hide' will close the modal unless cancelled
 
-      modal.hide();
-    });
+        modal.hide();
+      });
+    }
   };
 
   modal.hide = function (el) {


### PR DESCRIPTION
Backort of #3724 to 8.x. 

Will do a patch release after merged (cause I need it!)

----

It used to be, esssentially having no effect.  Fix to regression introduced in #3694, which made modalSetup instead raise a JS error (preventing parsing of remainder of file) in such a condition.
