### PR TITLE
3727 link to facet renders html for non html formats

### DIFF
--- a/app/presenters/blacklight/rendering/abstract_step.rb
+++ b/app/presenters/blacklight/rendering/abstract_step.rb
@@ -22,7 +22,14 @@ module Blacklight
       end
 
       def html?
-        options[:format].nil? || options[:format].to_s == 'html'
+        format.nil? || format == 'html'
+      end
+
+      # @return [String, nil]
+      def format
+        return options[:format] unless context.respond_to?(:search_state)
+
+        options[:format] || context.search_state&.params&.dig(:format)
       end
     end
   end

--- a/spec/presenters/blacklight/rendering/pipeline_spec.rb
+++ b/spec/presenters/blacklight/rendering/pipeline_spec.rb
@@ -62,6 +62,34 @@ RSpec.describe Blacklight::Rendering::Pipeline do
       end
     end
 
+    context 'when link_to_facet is in the config' do
+      let(:values) { %w[book manuscript] }
+      let(:field_config) { Blacklight::Configuration::Field.new(field: 'format', key: 'format', link_to_facet: true) }
+      let(:controller) { CatalogController.new }
+      let(:search_state) { Blacklight::SearchState.new({}, controller.blacklight_config, controller) }
+
+      before do
+        allow(context).to receive(:search_state).and_return(search_state)
+        allow(context).to receive(:search_action_path) { |f| "/catalog?f[format][]=#{f['f']['format'].first}" }
+        allow(context).to receive(:link_to) { |value, link|  ActiveSupport::SafeBuffer.new("<a href=#{link}>#{value}</a>") }
+      end
+
+      it 'renders html' do
+        expect(rendered).to eq "<a href=/catalog?f[format][]=book>book</a> and <a href=/catalog?f[format][]=manuscript>manuscript</a>"
+      end
+
+      context 'outside html context' do
+        let(:values) { %w[book manuscript] }
+        let(:field_config) { Blacklight::Configuration::Field.new(field: 'format', link_to_facet: true) }
+        let(:search_state) { Blacklight::SearchState.new({ format: 'json' }, CatalogController.blacklight_config, CatalogController.new) }
+
+        it 'does not render html' do
+          expect(rendered).to eq "book and manuscript"
+        end
+      end
+    end
+  end
+
   describe '.operations' do
     subject { described_class.operations }
 

--- a/spec/presenters/blacklight/rendering/pipeline_spec.rb
+++ b/spec/presenters/blacklight/rendering/pipeline_spec.rb
@@ -37,16 +37,30 @@ RSpec.describe Blacklight::Rendering::Pipeline do
     end
 
     context 'outside of an HTML context' do
-      let(:options) { { format: 'text' } }
+      context 'when options determines format' do
+        let(:options) { { format: 'text' } }
 
-      let(:values) { ['"blah"', "<notatag>"] }
-      let(:field_config) { Blacklight::Configuration::NullField.new itemprop: 'some-prop' }
+        let(:values) { ['"blah"', "<notatag>"] }
+        let(:field_config) { Blacklight::Configuration::NullField.new itemprop: 'some-prop' }
 
-      it 'does not HTML escape values or inject HTML tags' do
-        expect(rendered).to eq '"blah" and <notatag>'
+        it 'does not HTML escape values or inject HTML tags' do
+          expect(rendered).to eq '"blah" and <notatag>'
+        end
+      end
+
+      context 'when context determines format' do
+        let(:values) { ['"blah"', "<notatag>"] }
+        let(:field_config) { Blacklight::Configuration::NullField.new itemprop: 'some-prop' }
+        let(:controller) { CatalogController.new }
+        let(:search_state) { Blacklight::SearchState.new({ format: 'text' }, controller.blacklight_config, controller) }
+
+        before { allow(context).to receive(:search_state).and_return(search_state) }
+
+        it 'does not HTML escape values or inject HTML tags' do
+          expect(rendered).to eq '"blah" and <notatag>'
+        end
       end
     end
-  end
 
   describe '.operations' do
     subject { described_class.operations }


### PR DESCRIPTION
This MR allows the `AbstractStep` to consider the view context search state when determining the requested format. In doing so, we ensure that the link to facet step does not render html in non html contexts. 

Closes #3727 

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
