### PR TITLE
Explicitly require `view_component/version` before trying to use it.

### DIFF
--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'view_component/version'
+
 module Blacklight
   class Component < ViewComponent::Base
     class << self


### PR DESCRIPTION
🤷 