### PR TITLE
Push presenter configuration up to the configuration

### DIFF
--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -147,7 +147,7 @@ module Blacklight
       # @return [Blacklight::Configuration::ViewConfig::Index]
       property :index, default: ViewConfig::Index.new(
         # document presenter class used by helpers and views
-        document_presenter_class: nil,
+        document_presenter_class: Blacklight::IndexPresenter,
         # document presenter used for json responses
         json_presenter_class: Blacklight::JsonPresenter,
         # component class used to render a document
@@ -191,7 +191,7 @@ module Blacklight
       # @return [Blacklight::Configuration::ViewConfig::Show]
       property :show, default: ViewConfig::Show.new(
         # document presenter class used by helpers and views
-        document_presenter_class: nil,
+        document_presenter_class: Blacklight::ShowPresenter,
         document_component: Blacklight::DocumentComponent,
         document_thumbnail_component: nil,
         show_tools_component: Blacklight::Document::ShowToolsComponent,

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -81,14 +81,6 @@ class Blacklight::Configuration
       #   @return [Hash] Default route parameters for 'show' requests.
       #     Set this to a hash with additional arguments to merge into the route,
       #     or set `controller: :current` to route to the current controller.
-
-      def document_presenter_class
-        super || Blacklight::ShowPresenter
-      end
-
-      def to_h
-        super.merge(document_presenter_class: document_presenter_class)
-      end
     end
 
     class Index < ViewConfig
@@ -99,14 +91,6 @@ class Blacklight::Configuration
       #      see Blacklight::Catalog#additional_response_formats for information about the OpenStruct data
       # @!attribute collection_actions
       #   @return [String, Symbol]
-
-      def document_presenter_class
-        super || Blacklight::IndexPresenter
-      end
-
-      def to_h
-        super.merge(document_presenter_class: document_presenter_class)
-      end
     end
   end
 end


### PR DESCRIPTION
I suspect this was a work-around when we were eagerly loading the configuration (improved by #2826) and isn't necessary any more.