### PR TITLE
Refactor action_mapping to use its own configuration object

### DIFF
--- a/lib/blacklight/configuration/action_config_map_entry.rb
+++ b/lib/blacklight/configuration/action_config_map_entry.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class Configuration::ActionConfigMapEntry < OpenStructWithHashAccess
+    # @!attribute parent_action_key
+    # Pull in the configuration for this action from another action's config
+    # @return [Symbol]
+
+    def parent_config = parent_action_key
+
+    def parent_config=(value)
+      self.parent_action_key = value
+    end
+
+    #
+    # @!attribute blacklight_config_property
+    # Pull in the configuration for this action from a top-level config
+    # @return [Symbol]
+
+    def top_level_config = blacklight_config_property
+
+    def top_level_config=(value)
+      self.blacklight_config_property = value
+    end
+
+    #
+    # @!attribute default
+    # Pull in additional default configuration for this action from a top-level config
+    # @return [Array<Symbol>]
+  end
+end

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -670,25 +670,6 @@ RSpec.describe Blacklight::Configuration, :api do
         expect(config.view_config(action_name: :show)).to have_attributes config.show.to_h
       end
 
-      it 'includes the default action mapping configuration' do
-        config.action_mapping.default.whatever = :some_value
-
-        expect(config.view_config(action_name: :show)).to have_attributes whatever: :some_value
-      end
-
-      it 'includes the action-specific mappings' do
-        config.action_mapping.foo.document_presenter_class = Blacklight::DocumentPresenter
-
-        expect(config.view_config(action_name: :foo)).to have_attributes config.action_mapping.foo.to_h
-      end
-
-      it 'allows the action mapping to specific a parent configuration with some more defaults' do
-        config.action_mapping.foo.parent_config = :bar
-        config.action_mapping.bar.whatever = :bar_value
-
-        expect(config.view_config(action_name: :foo)).to have_attributes whatever: :bar_value
-      end
-
       context 'with the :citation action' do
         it 'also includes the show config' do
           expect(config.view_config(action_name: :citation)).to have_attributes config.show.to_h


### PR DESCRIPTION
… that points at existing view configs instead of trying to mush it together with the actual view config.

The ability to define an inline configuration is kinda cool, but I'm not sure it's that useful