### PR TITLE
Only render facet group when there are facets to render

### DIFF
--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -31,8 +31,7 @@ module Blacklight
       end
 
       def render?
-        # debugger
-        body.present?
+        body.to_s.present?
       end
     end
   end

--- a/spec/components/blacklight/response/facet_group_component_spec.rb
+++ b/spec/components/blacklight/response/facet_group_component_spec.rb
@@ -34,4 +34,20 @@ RSpec.describe Blacklight::Response::FacetGroupComponent, type: :component do
       end
     end
   end
+
+  context "when no facets within the group render" do
+    let(:instance) do
+      described_class.new(id: 'foo', title: 'bar').tap do |component|
+        component.with_body { ViewComponent::Slot.new("\n") }
+      end
+    end
+
+    it "does not render" do
+      expect(instance.render?).to eq false
+
+      within '.facets' do
+        expect(page).not_to have_css 'div.facets-collapse.d-lg-block.collapse.accordion'
+      end
+    end
+  end
 end


### PR DESCRIPTION
In our Blacklight app we have two facet groups with one that only has facets that render for catalogers.  When not logged in the user sees the facet group header without any facets.  The render method for the FacetGroupComponent attempts to render only if there is a body.  When debugging I saw that body is a `ViewComponent::Slot` so `.present?` returned true.  Changing this to check the rendered string resolves the problem.