### PR TITLE
require view_component/version in engine to avoid path-dependence

### DIFF
--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'view_component'
+require 'view_component/version'
 
 module Blacklight
   class Engine < Rails::Engine


### PR DESCRIPTION
versions 3 and 4 of the `view_component` gem do not autoload `VERSION`, which can lead to uninitialized constant errors when running Blacklight-based apps in some environments.
