### PR TITLE
add yaml-dev package to app docker image

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --update --no-cache \
   shared-mime-info \
   sqlite-dev \
   tzdata \
+  yaml-dev \
   yarn
 
 RUN mkdir /app


### PR DESCRIPTION
The native extensions for the `psych` gem fail to install when using the included Dockerfile and Docker Compose setup. This PR adds the system package that provides the psych gem the `yaml.h` header file it needs.

Closes #3754
