### PR TITLE
Run CI on Rails 8.1, for now 8.1.0.rc1

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -9,19 +9,37 @@
   "include": [
     {
       "ruby": "3.4",
-      "rails_version": "8.0.2",
+      "rails_version": "8.1.0.rc1",
+      "additional_engine_cart_rails_options": "--css=bootstrap"
+    },
+    {
+      "ruby": "3.4",
+      "rails_version": "8.1.0.rc1",
+      "additional_engine_cart_rails_options": "--css=bootstrap",
+      "view_component_version": "~> 3.0",
+      "additional_name": "ViewComponent 3"
+    },
+    {
+      "ruby": "3.4",
+      "rails_version": "8.1.0.rc1",
+      "additional_engine_cart_rails_options": "--css=bootstrap --js=esbuild",
+      "additional_name": "| esbuild"
+    },
+    {
+      "ruby": "3.4",
+      "rails_version": "8.0.3",
       "additional_engine_cart_rails_options": "--css=bootstrap",
       "view_component_version": "~> 3.0",
       "additional_name": "ViewComponent 3"
     },
     {
       "ruby": "3.3",
-      "rails_version": "8.0.2",
+      "rails_version": "8.0.3",
       "additional_engine_cart_rails_options": "--css=bootstrap"
     },
     {
       "ruby": "3.3",
-      "rails_version": "8.0.2",
+      "rails_version": "8.0.3",
       "additional_engine_cart_rails_options": "--css=bootstrap --js=esbuild",
       "additional_name": "| esbuild"
     },


### PR DESCRIPTION
Test on Rails 8.1, for now 8.1.0.rc1

Gemspec already allows rails < 9, so does not need to be adjusted to allow BL to be used with Rails 8.1.  This may have been a mistake, as Rails treats minor versions (eg 8.0 => 8.1) as major versions as far as semver/breaking changes. But it was already this way in previous releases, so it's done. 
