### PR TITLE
Backport " c41218...Explicitly require `view_component/version` before trying to use it."

### DIFF
--- a/lib/blacklight/component.rb
+++ b/lib/blacklight/component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'view_component/version'
+
 module Blacklight
   class Component < ViewComponent::Base
     class << self


### PR DESCRIPTION
Cherry picked from commit c41218435a5667ffff2301d80db1e79da76f4671 in order to load `ViewComponent::VERSION` in `release-8.x` branch when using `view_component` v4.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
