### PR TITLE
Allow Blacklight::Solr::Repository#search to be called with no args

### DIFF
--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -30,7 +30,7 @@ module Blacklight::Solr
         Blacklight.deprecation.warn("Passing positional arguments to search() is deprecated. Use the params kwarg instead.")
       end
 
-      request_params = (params || pos_params).reverse_merge(kwargs).reverse_merge({ qt: blacklight_config.qt })
+      request_params = (params || pos_params || {}).reverse_merge(kwargs).reverse_merge({ qt: blacklight_config.qt })
 
       send_and_receive(path || default_search_path(request_params), request_params)
     end

--- a/spec/models/blacklight/solr/repository_spec.rb
+++ b/spec/models/blacklight/solr/repository_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe Blacklight::Solr::Repository, :api do
       expect(subject.search(params: {})).to be_a Blacklight::Solr::Response
     end
 
+    it "can be called with no args" do
+      blacklight_config.solr_path = 'xyz'
+      allow(subject.connection).to receive(:send_and_receive).with('xyz', anything).and_return(mock_response)
+      expect(subject.search).to be_a Blacklight::Solr::Response
+    end
+
     it "uses the default solr path" do
       allow(subject.connection).to receive(:send_and_receive).with('select', anything).and_return(mock_response)
       expect(subject.search(params: {})).to be_a Blacklight::Solr::Response


### PR DESCRIPTION
It could be in Blacklight 8, with params using a default value of `{}`, it's convenient, and preferable to keep this backwards compat when no reason not to.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
