### PR TITLE
Add a blacklight_config.default_facet_suggest, to allow turn off new facet suggest feature by default

### DIFF
--- a/app/components/blacklight/facets/filters_component.rb
+++ b/app/components/blacklight/facets/filters_component.rb
@@ -21,7 +21,7 @@ module Blacklight::Facets
     delegate :display_facet, to: :presenter
 
     def render?
-      facet.suggest != false || render_index_navigation?
+      presenter.suggest? || render_index_navigation?
     end
 
     def render_index_navigation?

--- a/app/components/blacklight/facets/suggest_component.rb
+++ b/app/components/blacklight/facets/suggest_component.rb
@@ -11,11 +11,10 @@ module Blacklight
 
       attr_accessor :presenter
 
-      delegate :suggest, :key, :label, to: :presenter
+      delegate :key, :label, to: :presenter
 
       def render?
-        # Draw if suggest is true or not present
-        suggest != false
+        presenter.suggest?
       end
     end
   end

--- a/app/presenters/blacklight/facet_field_presenter.rb
+++ b/app/presenters/blacklight/facet_field_presenter.rb
@@ -4,23 +4,30 @@ module Blacklight
   class FacetFieldPresenter
     attr_reader :facet_field, :display_facet, :view_context, :search_state
 
-    delegate :key, :suggest, to: :facet_field
+    delegate :key, to: :facet_field
     delegate :field_name, to: :display_facet
 
     # @param [Blacklight::Configuration::FacetField] facet_field
     # @param [Blacklight::Solr::Response::Facets::FacetField] display_facet
     # @param [#search_action_path,#facet_field_presenter] view_context
     # @param [Blacklight::SearchState] search_state
-    def initialize(facet_field, display_facet, view_context, search_state = view_context.search_state)
+    def initialize(facet_field, display_facet, view_context, search_state = nil)
       @facet_field = facet_field
       @display_facet = display_facet
       @view_context = view_context
-      @search_state = search_state
+      @search_state = search_state || view_context&.search_state
     end
 
     # @param [Blacklight::Solr::Response::Facets::FacetItem, String] facet_item
     def item_presenter(facet_item)
       facet_field.item_presenter.new(facet_item, facet_field, view_context, key, search_state)
+    end
+
+    # Is facet suggest feature configured on for this facet, or by global default.
+    #
+    # @return [Boolean]
+    def suggest?
+      !!(facet_field.suggest.nil? ? blacklight_config.default_facet_suggest : facet_field.suggest)
     end
 
     def collapsed?

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -275,6 +275,10 @@ module Blacklight
       # @since v5.10.0
       # @return [Integer]
       property :default_facet_limit, default: 10
+      # @!attribute default_facet_suggest
+      # @since v9.0.0
+      # @return [Boolean]
+      property :default_facet_suggest, default: true
       # @!attribute default_more_limit
       # @since v7.0.0
       # @return [Integer]

--- a/spec/components/blacklight/facets/filters_component_spec.rb
+++ b/spec/components/blacklight/facets/filters_component_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Blacklight::Facets::FiltersComponent, type: :component do
-  let(:facet_field) { Blacklight::Configuration::FacetField.new key: 'language_facet', suggest: true }
+  let(:facet_field) { Blacklight::Configuration::FacetField.new key: 'language_facet', suggest?: true }
   let(:presenter) do
     instance_double(Blacklight::FacetFieldPresenter, facet_field: facet_field, label: 'Lang',
-                                                     view_context: view_context, suggest: true, key: 'lang')
+                                                     view_context: view_context, suggest?: true, key: 'lang')
   end
   let(:view_context) { vc_test_controller.view_context }
 

--- a/spec/components/blacklight/facets/suggest_component_spec.rb
+++ b/spec/components/blacklight/facets/suggest_component_spec.rb
@@ -58,11 +58,24 @@ RSpec.describe Blacklight::Facets::SuggestComponent, type: :component do
 
   context 'when the facet is not explicitly configured with a suggest key' do
     let(:facet) { Blacklight::Configuration::FacetField.new key: 'language_facet' }
+    let(:presenter) { Blacklight::FacetFieldPresenter.new(facet, nil, vc_test_controller.view_context, nil) }
 
     it 'displays' do
       with_request_url "/catalog/facet/language_facet" do
         rendered = render_inline component
         expect(rendered.css("input.facet-suggest").count).to eq 1
+      end
+    end
+
+    context "with blacklight_config.default_facet_suggest = false" do
+      before do
+        allow(vc_test_controller.view_context.blacklight_config).to receive(:default_facet_suggest).and_return(false)
+      end
+
+      it 'does not display' do
+        with_request_url "/catalog/facet/language_facet" do
+          expect(render_inline(component).to_s).to eq ''
+        end
       end
     end
   end


### PR DESCRIPTION
Doing this involved a bit of yak-shaving:

* DRY'd two components that were checking this to use FacetFieldPresenter#suggest consistently, to put logic there
* Changed name to #suggest? since it's boolean -- backwards incompat, but to little-used api and fine if we get it in before 9.0
* Relevant test needs a good view_context, which revealed FacetFieldPresenter's attempt to have default for search_state initializer arg was not working, fixed. (not totally sure why this was not causing problems before)

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
