### PR TITLE
Redesign facet suggest input styling/layout

### DIFF
--- a/app/components/blacklight/facets/filters_component.rb
+++ b/app/components/blacklight/facets/filters_component.rb
@@ -3,7 +3,7 @@
 module Blacklight::Facets
   class FiltersComponent < Blacklight::Component
     # @param [Blacklight::FacetFieldPresenter] presenter
-    def initialize(presenter:, classes: 'facet-filters card card-body bg-light p-3 mb-3 border-0',
+    def initialize(presenter:, classes: 'facet-filters mt-1 mb-3',
                    suggestions_component: Blacklight::Facets::SuggestComponent,
                    index_navigation_component: Blacklight::Facets::IndexNavigationComponent)
       @presenter = presenter

--- a/app/components/blacklight/facets/suggest_component.html.erb
+++ b/app/components/blacklight/facets/suggest_component.html.erb
@@ -1,12 +1,17 @@
-<label class="form-label" for="facet_suggest_<%= key %>">
-  <%= I18n.t('blacklight.search.facets.suggest.label', field_label: label) %>
-</label>
-<%= text_field_tag "facet_suggest_#{key}",
-  nil,
-  class: "facet-suggest form-control mb-3",
-  data: {
-    facet_field: key,
-    facet_search_context: helpers.search_facet_path(id: key)
-  },
-  placeholder: I18n.t('blacklight.search.form.search.placeholder')
-%>
+<div class="input-group">
+  <label class="input-group-text" for="facet_suggest_<%= key %>">
+    <%= I18n.t('blacklight.search.facets.suggest.label', field_label: label.downcase.pluralize) %>
+  </label>
+  <%= search_field_tag "facet_suggest_#{key}",
+    nil,
+    class: "facet-suggest form-control",
+    data: {
+      facet_field: key,
+      facet_search_context: helpers.search_facet_path(id: key)
+    },
+    placeholder: I18n.t('blacklight.search.facets.suggest.placeholder')
+  %>
+  <span class="input-group-text">
+    <%= render Blacklight::Icons::SearchComponent.new %>
+  </span>
+</div>

--- a/spec/components/blacklight/facets/filters_component_spec.rb
+++ b/spec/components/blacklight/facets/filters_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Blacklight::Facets::FiltersComponent, type: :component do
     let(:component) { described_class.new(presenter: presenter) }
 
     it 'draws default classes' do
-      expect(page).to have_css(".facet-filters.card.card-body.bg-light.p-3.mb-3.border-0")
+      expect(page).to have_css(".facet-filters.mt-1.mb-3")
     end
   end
 

--- a/spec/components/blacklight/facets/suggest_component_spec.rb
+++ b/spec/components/blacklight/facets/suggest_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Blacklight::Facets::SuggestComponent, type: :component do
     with_request_url "/catalog/facet/language_facet" do
       rendered = render_inline component
       label = rendered.css('label').first
-      expect(label.text.strip).to eq 'Filter Language'
+      expect(label.text.strip).to eq 'Filter languages'
 
       id_in_label_for = label.attribute('for').text
       expect(id_in_label_for).to eq('facet_suggest_language_facet')


### PR DESCRIPTION
Note that the previous one had a typo/mistake in i18n label -- there was already an i18n key entered for this, but it was using a different one, now it's using the intended one.

# Before

<img width="789" height="293" alt="blacklight-stock-before" src="https://github.com/user-attachments/assets/ffb0eb19-5e85-4f10-b72d-68e74a1800f3" />


# After

<img width="787" height="221" alt="Screenshot 2025-11-04 at 5 11 23 PM" src="https://github.com/user-attachments/assets/a784cd60-5c2a-4717-b021-b1debfb91ad0" />


## input is type=search

So on some browsers (Chrome and Safari, but not Firefox), you get a "erase input" `x` icon, which works very nicely with the JS to immediately reset to unfiltered display. 

<img width="793" height="217" alt="Screenshot 2025-11-04 at 5 11 38 PM" src="https://github.com/user-attachments/assets/a37c0b9c-8779-4e5e-9b94-ba13dce61676" />

