### PR TITLE
Restore long-lost form-handling ability to modal.js interactivity in modal dialog

### DIFF
--- a/app/assets/builds/blacklight.css
+++ b/app/assets/builds/blacklight.css
@@ -205,8 +205,6 @@ main {
 
 .bookmark-toggle {
   --bl-icon-color: var(--bs-primary);
-  /* override for line 21.
-      Creates weird spacing in toolbar when min-width is set to 8rem */
 }
 .no-js .bookmark-toggle input[type=submit] {
   display: inline;
@@ -238,6 +236,10 @@ main {
 }
 .bookmark-toggle .toggle-bookmark .toggle-bookmark-input:checked + span svg.bookmark-unchecked {
   display: none;
+}
+.bookmark-toggle {
+  /* override for line 21.
+      Creates weird spacing in toolbar when min-width is set to 8rem */
 }
 .bookmark-toggle .header-tools .toggle-bookmark-label {
   min-width: 2rem;
@@ -371,12 +373,12 @@ main {
   float: left;
 }
 
+.facet-field-heading a {
+  color: inherit;
+}
 .facet-field-heading {
   /* This prevents the contained stretch link from covering the panel body */
   position: relative;
-}
-.facet-field-heading a {
-  color: inherit;
 }
 
 /* Pivot Facets


### PR DESCRIPTION
Originally modal.js could handle form submissions in a modal as well as links. 

But this behavior wasn't actually used by Blacklight, or tested -- it was available for Blacklight apps to use though. It made sense to support since it was a variation on the hyperlink behavior, keep it DRY. 

But it was removed in some prior commits refactoring, perhaps be615049, if not before -- it was quite possibly already broken at that point. 

This PR adds it back in, in case it is desired by community!  

i got to needing this for a local app, but if it is not desired to be part of BL, it's okay with me, I can easily patch it back in locally only in my app. 

It does not at present have tests. it's kind of a pain to have tests, since there is no behavior in default BL that exersizes it, we'd have to figure out how to add exersizing behavior to test app somehow, which engine_cart makes difficult. If there is interest in this feature, and people believe tests are necessary, perhaps we can join heads on how to do it. 

Closes #2331