### PR TITLE
Switch facet suggest request to have query in URL query params, instead of path, with proper escaping

### DIFF
--- a/app/javascript/blacklight-frontend/facet_suggest.js
+++ b/app/javascript/blacklight-frontend/facet_suggest.js
@@ -16,10 +16,13 @@ const FacetSuggest = async (e) => {
 
     // Drop facet.page so a filtered suggestion list will always start on page 1
     url.searchParams.delete('facet.page');
+    // add our queryFragment for facet filtering
+    url.searchParams.append('query_fragment', queryFragment);
+
     const facetSearchParams = url.searchParams.toString();
     const basePathComponent = url.pathname.split('/')[1];
 
-    const urlToFetch = `/${basePathComponent}/facet_suggest/${facetField}/${queryFragment}?${facetSearchParams}`;
+    const urlToFetch = `/${basePathComponent}/facet_suggest/${facetField}?${facetSearchParams}`;
 
     const response = await fetch(urlToFetch);
     if (response.ok) {

--- a/lib/blacklight/routes/searchable.rb
+++ b/lib/blacklight/routes/searchable.rb
@@ -18,7 +18,7 @@ module Blacklight
         mapper.get "opensearch"
         mapper.get 'suggest', as: 'suggest_index'
         mapper.get "facet/:id", action: 'facet', as: 'facet'
-        mapper.get "facet_suggest/:id/(:query_fragment)", action: 'facet', as: 'facet_suggest', defaults: { only_values: true }
+        mapper.get "facet_suggest/:id", action: 'facet', as: 'facet_suggest', defaults: { only_values: true }
       end
     end
   end

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -112,6 +112,15 @@ RSpec.describe "Facets" do
       expect(page).to have_css 'a.facet-select', count: 2
     end
 
+    it 'can show suggestions including a period', :js do
+      visit '/catalog/facet/subject_ssim'
+      fill_in 'facet_suggest_subject_ssim', with: 'iran.'
+
+      expect(page).to have_css '.facet-suggestions'
+      expect(page).to have_link 'Iran. Vizārat-i Kishvar'
+      expect(page).to have_css 'a.facet-select', count: 1
+    end
+
     it 'shows the user facet suggestions that are relevant to their q param', :js do
       visit '/catalog/facet/subject_ssim?q=tibet&search_field=all_fields'
       fill_in 'facet_suggest_subject_ssim', with: 'la'


### PR DESCRIPTION
It was failing prior on queries including `.` or `/`.  It may have been possible to fix this with proper escaping and leave it in path component of URL (may also have to fight with rails routing to get `.` in path component) -- but it's much more straightoforward to put it in query component after the `?`, and let existing escaping happening take care of it.   This is a URL only used by JS fetch that shouldn't ordinarily be seen by the user, so aesthetics prob not a concern.

The Blacklight CI sample data has a `topic_facet` value with a period in it (`Iran. Vizārat-i Kishvar`), and my own local data does too. I haven't seen any with `/`, but of course it's possible and should work.

We _could_ have made the `query_fragment` required for the Rails route -- but it was optional before, and current usage perhaps requires it being optional! 

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
