### PR TITLE
Remove comments that imply Bootstrap 4 is still supported in BL9 (it …

### DIFF
--- a/app/javascript/blacklight-frontend/checkbox_submit.js
+++ b/app/javascript/blacklight-frontend/checkbox_submit.js
@@ -10,7 +10,7 @@
        attribute (HTML5-style doc-*) that contains the id/primary key
        of the object in question -- used by plugin for a unique value for
        DOM id's.
-  Uses HTML for a checkbox compatible with Bootstrap 4.
+  Uses HTML for a checkbox compatible with Bootstrap.
    new CheckboxSubmit(document.querySelector('form.something')).render()
 */
 export default class CheckboxSubmit {
@@ -36,7 +36,7 @@ export default class CheckboxSubmit {
     }).then((json) => {
       this.labelTarget.removeAttribute('disabled')
       this.checkboxTarget.removeAttribute('disabled')
-      // For accessibility return keyboard focus 
+      // For accessibility return keyboard focus
       // back to the checkbox after form submission
       this.checkboxTarget.focus()
       this.updateStateFor(!this.checked)

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -47,7 +47,6 @@ module Blacklight
       property :header_component, default: Blacklight::HeaderComponent
       property :full_width_layout, default: false
 
-      # bootstrap_version may be set to 4 or 5
       bootstrap_version = ENV['BOOTSTRAP_VERSION'].presence || "5"
       property :bootstrap_version, default: /(\d)(?:\.\d){0,2}/.match(bootstrap_version)[1].to_i
 

--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -12,7 +12,7 @@ class <%= controller_name.classify %>Controller < ApplicationController
   # rescue_from Blacklight::Exceptions::InvalidRequest, with: :my_handling_method
 
   configure_blacklight do |config|
-    ## Specify the style of markup to be generated (may be 4 or 5)
+    ## Specify the style of markup to be generated
     # config.bootstrap_version = 5
     #
     ## Class for sending and receiving requests from a search index


### PR DESCRIPTION
…is not).

- BL9 currently expects Bootstrap >= 5.3.5
- Bootstrap 4 reached EOL Jan 2023.
- Retain existing `bootstrap_version` variables for potential future use in BL9+
