### PR TITLE
BACKPORT to 7.x Avoid bundler 4 since it causes issues with engine_cart (#3784)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
       ref:
         required: false
         type: string
-        default: ''
+        default: ""
         description: The branch or reference to run the workflow against
 jobs:
   set_matrix:
@@ -43,7 +43,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler: "latest"
           ruby-version: ${{ matrix.ruby }}
       - name: Change permissions
         run: "chmod -f -R o-w /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems | :"


### PR DESCRIPTION
Backport https://github.com/projectblacklight/blacklight/pull/3784