### PR TITLE
Add http_method to example configuration

### DIFF
--- a/lib/generators/blacklight/templates/catalog_controller.rb
+++ b/lib/generators/blacklight/templates/catalog_controller.rb
@@ -36,7 +36,11 @@ class <%= controller_name.classify %>Controller < ApplicationController
     ## Optional fine-tuning for advanced search, e.g., set different limits for
     ## different facets.
     # config.advanced_search.form_solr_parameters = {}
-
+    #
+    ## What type of HTTP request to make to solr. Use `:post' to support requests longer than the URI length limit.
+    ## (default is `:get')
+    # config.http_method = :post
+    #
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
       rows: 10


### PR DESCRIPTION
Because I often need to set this, but can never remember the name of the configuration property.
