### PR TITLE
Move Style/FormatStringToken configuration to .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,9 @@ Rails/ApplicationMailer:
 Style/AccessModifierDeclarations:
   Enabled: false
 
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 Style/MissingRespondToMissing:
   Exclude:
     - "lib/blacklight/nested_open_struct_with_hash_access.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -367,14 +367,6 @@ Style/DocumentDynamicEvalDefinition:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 17
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MaxUnannotatedPlaceholdersAllowed, Mode, AllowedMethods, AllowedPatterns.
-# SupportedStyles: annotated, template, unannotated
-# AllowedMethods: redirect
-Style/FormatStringToken:
-  EnforcedStyle: template
-
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.


### PR DESCRIPTION
having it in .rubocop_todo.yml makes it seem like we will fix it at some point

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
