### PR TITLE
Provide a more structured dependency injection framework for components

### DIFF
--- a/app/helpers/blacklight/document_helper_behavior.rb
+++ b/app/helpers/blacklight/document_helper_behavior.rb
@@ -56,11 +56,6 @@ module Blacklight::DocumentHelperBehavior
   # Override this method if you want to use a differnet presenter for your documents
   # @param [Blacklight::Document] _document optional, here for extension + backwards compatibility only
   def document_presenter_class(_document = nil)
-    case action_name
-    when 'show', 'citation'
-      blacklight_config.view_config(:show, action_name: action_name).document_presenter_class
-    else
-      blacklight_config.view_config(document_index_view_type, action_name: action_name).document_presenter_class
-    end
+    blacklight_config.view_config(document_index_view_type, action_name: action_name).document_presenter_class
   end
 end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -139,22 +139,86 @@ module Blacklight
       # set to nil if a checkbox is prefered to the icon
       property :bookmark_icon_component, default: Blacklight::Icons::BookmarkIconComponent
 
+      property :components, default: {
+        icons: {
+          bookmark: Blacklight::Icons::BookmarkIconComponent
+        }
+      }
+
       # @!attribute index
       # General configuration for all views
       # @return [Blacklight::Configuration::ViewConfig::Index]
       property :index, default: ViewConfig::Index.new(
+        components: {
+          # any of these components should receive a document object (probably DocumentPresenter) and do something useful.
+          document: {
+            root: Blacklight::DocumentComponent,
+
+            # existing component config; mostly deprecated by section config?
+            embed: nil,
+            metadata: Blacklight::DocumentMetadataComponent,
+            thumbnail: Blacklight::Document::ThumbnailComponent,
+            title: Blacklight::DocumentTitleComponent,
+
+            # new config
+            layout: nil,
+            search_context_constraints: nil,
+            actions: [],
+            header: [],
+            sidebar: [],
+            section: [
+              [:document, :embed], # alias to a top-level key for backwards compatibility.
+              [:document, :metadata],
+              [:document, :thumbnail]
+            ],
+            footer: []
+          },
+          facets: {
+            # possibly too low-level to want to express here:
+            group: Blacklight::Response::FacetGroupComponent,
+            filters: Blacklight::Facets::FiltersComponent,
+            pagination: Blacklight::FacetFieldPaginationComponent,
+
+            # new stuff
+            default: nil,
+            layout: nil,
+            modal: nil
+          },
+          # any of these components should receive a search object (probably a SearchPresenter or something)
+          search_results: {
+            search_bar: nil,
+            header: [
+              [:search_results, :constraints]
+            ],
+            constraints: Blacklight::ConstraintsComponent,
+            search_header: Blacklight::SearchHeaderComponent,
+            sidebar: [
+              [:sesarch_results, :facets]
+            ],
+            facets: Blacklight::Search::SidebarComponent,
+
+            # new stuff:
+            title: nil,
+            head: nil,
+            footer: [
+              # pagination?
+            ]
+          },
+          system: {
+            dropdown: Blacklight::System::DropdownComponent,
+
+            # new stuff
+            button: nil,
+            flex: nil,
+            accordion: nil,
+            skip_link: nil,
+            modal: nil
+          }
+        },
         # document presenter class used by helpers and views
         document_presenter_class: Blacklight::IndexPresenter,
         # document presenter used for json responses
         json_presenter_class: Blacklight::JsonPresenter,
-        # component class used to render a document
-        document_component: Blacklight::DocumentComponent,
-        document_embed_component: nil,
-        document_metadata_component: Blacklight::DocumentMetadataComponent,
-        document_thumbnail_component: Blacklight::Document::ThumbnailComponent,
-        document_title_component: Blacklight::DocumentTitleComponent,
-        sidebar_component: Blacklight::Search::SidebarComponent,
-        dropdown_component: Blacklight::System::DropdownComponent,
         # solr field to use to render a document title
         title_field: nil,
         # solr field to use to render format-specific partials
@@ -167,18 +231,6 @@ module Blacklight
         group: false,
         # additional response formats for search results
         respond_to: OpenStructWithHashAccess.new,
-        # component class used to render the facet grouping
-        facet_group_component: Blacklight::Response::FacetGroupComponent,
-        # component class used to render the facet search and start at
-        facet_filters_component: Blacklight::Facets::FiltersComponent,
-        # component class used to render the facet pagination
-        facet_pagination_component: Blacklight::FacetFieldPaginationComponent,
-        # component class used to render search constraints
-        constraints_component: Blacklight::ConstraintsComponent,
-        # component class used to render the search bar
-        search_bar_component: nil,
-        # component class used to render the header above the documents
-        search_header_component: Blacklight::SearchHeaderComponent,
         # pagination parameters to pass to kaminari
         pagination_options: Blacklight::Engine.config.blacklight.default_pagination_options.dup
       )
@@ -707,7 +759,11 @@ module Blacklight
                     end
 
       view_config = Array(action_config.default - [action_config.blacklight_config_property || default]).inject(view_config) do |config, top_level_config|
-        config.reverse_merge(self[top_level_config])
+        result = config.reverse_merge(self[top_level_config])
+
+        result[:components] = (self[top_level_config][:components] || {}).deep_merge(result[:components])
+
+        result
       end
 
       if view_type && action_config.view_specific_property

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -140,6 +140,19 @@ module Blacklight
       property :bookmark_icon_component, default: Blacklight::Icons::BookmarkIconComponent
 
       property :components, default: {
+        document: {},
+        facets: {},
+        search_results: {},
+        system: {
+          # also defined in the index configuration for backwards compatibility.
+          dropdown: Blacklight::System::DropdownComponent,
+          # new stuff
+          button: nil,
+          flex: nil,
+          accordion: nil,
+          skip_link: nil,
+          modal: nil
+        },
         icons: {
           bookmark: Blacklight::Icons::BookmarkIconComponent
         }
@@ -205,14 +218,7 @@ module Blacklight
             ]
           },
           system: {
-            dropdown: Blacklight::System::DropdownComponent,
-
-            # new stuff
-            button: nil,
-            flex: nil,
-            accordion: nil,
-            skip_link: nil,
-            modal: nil
+            dropdown: Blacklight::System::DropdownComponent
           }
         },
         # document presenter class used by helpers and views
@@ -769,7 +775,9 @@ module Blacklight
       if view_type && action_config.view_specific_property
         view_type_specific_config = dig(action_config.view_specific_property, view_type) if self[action_config.view_specific_property]&.key?(view_type)
         view_config = view_config.merge(view_type_specific_config) if view_type_specific_config
+        view_config[:components] = (view_config[:components] || {}).deep_merge(view_type_specific_config[:components]) if view_type_specific_config&.dig(:components)
       end
+      view_config[:components] = self[:components].deep_merge(view_config[:components])
 
       view_config
     end

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -211,8 +211,8 @@ module Blacklight
       # @return [Hash{Symbol => Blacklight::Configuration::ActionConfigMapEntry}]
       property :action_mapping, default: NestedOpenStructWithHashAccess.new(
         ActionConfigMapEntry,
-        default: { blacklight_config_property: :index, default: [:index] },
-        show: { blacklight_config_property: :show },
+        default: { blacklight_config_property: :index, view_specific_property: :view, default: [:index] },
+        show: { blacklight_config_property: :show, view_specific_property: nil },
         citation: { parent_action_key: :show },
         email_record: { blacklight_config_property: :email },
         sms_record: { blacklight_config_property: :sms }
@@ -570,7 +570,7 @@ module Blacklight
         view_type = nil
       end
 
-      @view_config[[view_type, action_name]] ||= action_config(action_name, (view.fetch(view_type, nil) if view_type))
+      @view_config[[view_type, action_name]] ||= action_config(action_name, view_type)
     end
 
     # YARD will include inline disabling as docs, cannot do multiline inside @!macro.  AND this must be separate from doc block.
@@ -683,7 +683,7 @@ module Blacklight
       end
     end
 
-    def action_config(action_name, view_type_specific_config, default: :index)
+    def resolved_action_config(action_name)
       action_config = action_mapping[action_name]
       action_config ||= action_mapping[:default]
 
@@ -694,6 +694,11 @@ module Blacklight
         action_config = action_config.reverse_merge(parent_config)
       end
       action_config = action_config.reverse_merge(action_mapping[:default]) if action_config != action_mapping[:default]
+      action_config
+    end
+
+    def action_config(action_name, view_type, default: :index)
+      action_config = resolved_action_config(action_name)
 
       view_config = if action_config.blacklight_config_property
                       self[action_config.blacklight_config_property]
@@ -705,7 +710,10 @@ module Blacklight
         config.reverse_merge(self[top_level_config])
       end
 
-      view_config = view_config.merge(view_type_specific_config) if view_type_specific_config
+      if view_type && action_config.view_specific_property
+        view_type_specific_config = dig(action_config.view_specific_property, view_type) if self[action_config.view_specific_property]&.key?(view_type)
+        view_config = view_config.merge(view_type_specific_config) if view_type_specific_config
+      end
 
       view_config
     end

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -54,26 +54,67 @@ class Blacklight::Configuration
       end
     end
 
-    # Provide backwards compatibility with the configuration keys without the document_ prefix
-    def title_component(*) = document_title_component(*)
-    def metadata_component(*) = document_metadata_component(*)
-    def thumbnail_component(*) = document_thumbnail_component(*)
-    def embed_component(*) = document_embed_component(*)
+    def component_for(*keys)
+      result = dig(:components, *Array(keys).flatten)
 
-    def title_component=(value)
-      self.document_title_component = value
+      if result.is_a?(Symbol)
+        component_for(*result)
+      elsif result.is_a?(Array)
+        result.map do |item|
+          if item.is_a?(Symbol)
+            component_for(item)
+          else
+            item
+          end
+        end
+      else
+        result
+      end
     end
 
-    def metadata_component=(value)
-      self.document_metadata_component = value
+    BACKWARDS_COMPATIBLE_COMPONENT_KEY_MAPPING = {
+      document_component: [:document, :root],
+      document_embed_component: [:document, :embed],
+      document_metadata_component: [:document, :metadata],
+      document_thumbnail_component: [:document, :thumbnail],
+      document_title_component: [:document, :title],
+      embed_component: [:document, :embed],
+      metadata_component: [:document, :metadata],
+      humbnail_component: [:document, :thumbnail],
+      title_component: [:document, :title],
+      search_bar_component: [:search_results, :search_bar],
+      facet_group_component: [:facets, :group],
+      facet_filters_component: [:facets, :filters],
+      facet_pagination_component: [:facets, :pagination],
+      constraints_component: [:search_results, :constraints],
+      search_header_component: [:search_results, :search_header],
+      sidebar_component: [:search_results, :facets],
+      dropdown_component: [:system, :dropdown]
+    }.freeze
+
+    BACKWARDS_COMPATIBLE_COMPONENT_KEY_MAPPING.each do |old_key, new_keys|
+      define_method old_key do
+        component_for(*new_keys)
+      end
+
+      define_method "#{old_key}=" do |value|
+        self[:components] ||= {}
+
+        parent_node = new_keys.slice(...-1).inject(self[:components]) do |memo, key|
+          memo[key] ||= {}
+          memo[key]
+        end
+
+        parent_node[new_keys.last] = value
+      end
     end
 
-    def thumbnail_component=(value)
-      self.document_thumbnail_component = value
-    end
-
-    def embed_component=(value)
-      self.document_embed_component = value
+    def set_ostruct_member_value!(name, value)
+      if BACKWARDS_COMPATIBLE_COMPONENT_KEY_MAPPING.key?(name)
+        send("#{name}=", value)
+      else
+        super
+      end
     end
 
     class Show < ViewConfig

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe Blacklight::Configuration, :api do
 
     context 'with a view' do
       it 'includes the configuration-level view parameters' do
-        expect(config.view_config(:atom)).to have_attributes config.index.to_h.except(:partials)
+        expect(config.view_config(:atom)).to have_attributes config.index.to_h.except(:components, :partials)
         expect(config.view_config(:atom)).to have_attributes partials: [:document]
       end
     end

--- a/spec/models/blacklight/configuration_spec.rb
+++ b/spec/models/blacklight/configuration_spec.rb
@@ -653,7 +653,7 @@ RSpec.describe Blacklight::Configuration, :api do
 
     context 'with the :show view' do
       it 'includes the show config' do
-        expect(config.view_config(:show)).to have_attributes config.show.to_h
+        expect(config.view_config(:show)).to have_attributes config.show.to_h.except(:components)
       end
 
       it 'uses the show document presenter' do
@@ -667,12 +667,12 @@ RSpec.describe Blacklight::Configuration, :api do
 
     context 'with just an action name' do
       it 'includes the action config' do
-        expect(config.view_config(action_name: :show)).to have_attributes config.show.to_h
+        expect(config.view_config(action_name: :show)).to have_attributes config.show.to_h.except(:components)
       end
 
       context 'with the :citation action' do
         it 'also includes the show config' do
-          expect(config.view_config(action_name: :citation)).to have_attributes config.show.to_h
+          expect(config.view_config(action_name: :citation)).to have_attributes config.show.to_h.except(:components)
         end
       end
     end


### PR DESCRIPTION
Straw-man for future discussion. The hope and dream is a slightly more structured + formal dependency injection framework could make support for multiple UI frameworks (e.g. Bootstrap 5 + 6) more possible and ease one barrier for upgrading.

TODO:
- build out + extract some of the system/"component library" UI components, anticipating that could handle most of the Bootstrap 5 -> 6 pain.
- align injected components with the "right" level (not too high-level as to be exhausting to customize, not so low-level that we end up with a large number of injection points)
- align the parameters to injected components for greater consistency (e.g. all document-keyed components get a document presenter on an expected key)  
  -  extract a search presenter that encapsulates the search parameters, solr response, and config
     - extract a configuration presenter that will let us pass the whole configuration around, without losing context-specific information (#3838) 
- maybe nice to pull the components configuration up to the top-level of configuration?