### PR TITLE
Allow SearchService#search_state to be mutated

### DIFF
--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -14,6 +14,8 @@ module Blacklight
     # The blacklight_config + controller are accessed by the search_builder
     attr_reader :blacklight_config, :context
 
+    attr_writer :search_state
+
     def search_builder
       search_builder_class.new(self)
     end


### PR DESCRIPTION
This allows us to adjust the search_state and run a query again, without having to reinitialize the object.  

This can be used in a report where you may want to iterate through a bunch of pages of results to construct a CSV.

