### PR TITLE
Revert "Remove unused method (#3840)"

### DIFF
--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -18,6 +18,10 @@ module Blacklight
       search_builder_class.new(self)
     end
 
+    def search_state_class
+      @search_state.class
+    end
+
     # Fetch query results from solr
     # @yield [search_builder] optional block yields configured SearchBuilder,  caller can modify or create new
     #                         SearchBuilder to be used. Block should return SearchBuilder to be used.


### PR DESCRIPTION
In https://github.com/projectblacklight/blacklight/pull/3840#issuecomment-4519655712, I question whether this method is actually unused (or just insufficiently tested when it was added.)