### PR TITLE
Trust the `SearchBuilder` has defined `search_state` already

### DIFF
--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -367,12 +367,6 @@ module Blacklight::Solr
       end
     end
 
-    def search_state
-      return super if defined?(super)
-
-      @search_state ||= Blacklight::SearchState.new(blacklight_params, blacklight_config)
-    end
-
     def add_search_field_query_builder_params(solr_parameters)
       q, additional_parameters = search_field.query_builder.call(self, search_field, solr_parameters)
 


### PR DESCRIPTION
I think this was just an extra layer of backwards compatibility when introducing `SearchState`. I'm not sure we still need to guard against... someone mixing in `SearchBuilderBehavior` in a class that doesn't inherit from `Blacklight::SearchBuilder` any more.
