### PR TITLE
Deprecate the code branch where Repository#find_many isn't defined.

### DIFF
--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -160,6 +160,7 @@ module Blacklight
       solr_response = if repository.respond_to?(:find_many)
                         repository.find_many(query)
                       else
+                        Blacklight.deprecation.warn("Repository#find_many is not implemented. Falling back to Repository#search.")
                         repository.search(query)
                       end
 


### PR DESCRIPTION
I guess this code might support repository implementations that don't inherit from Blacklight::AbstractRepository, but that seems a little unlikely to exist?
