### PR TITLE
Allow Blacklight::SearchService#search_results to take params as an argument

### DIFF
--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -25,13 +25,16 @@ module Blacklight
     #                         SearchBuilder to be used. Block should return SearchBuilder to be used.
     #                         This is used in blacklight_range_limit
     # @return [Blacklight::Solr::Response] the solr response object
-    def search_results
-      builder = search_builder.with(search_state)
-      builder.page = search_state.page
-      builder.rows = search_state.per_page
+    def search_results(params: nil)
+      unless params
+        builder = search_builder.with(search_state)
+        builder.page = search_state.page
+        builder.rows = search_state.per_page
 
-      builder = yield(builder) if block_given?
-      response = repository.search(params: builder)
+        builder = yield(builder) if block_given?
+      end
+
+      response = repository.search(params: params || builder)
 
       if response.grouped? && grouped_key_for_results
         response.group(grouped_key_for_results)

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe Blacklight::SearchService, :api do
         expect(solr_response.docs).to have(0).results
       end
     end
+
+    describe 'when passing in the params' do
+      it 'returns the results' do
+        solr_response = service.search_results(params: { q: '', rows: 5 })
+
+        expect(solr_response.docs).to have(5).results
+      end
+    end
   end # Search Results
 
   # SPECS FOR SEARCH RESULTS FOR FACETS


### PR DESCRIPTION
This may better support use cases like #3841 (although I'm not sure I understand that case), and with some additional work might let us remove the SearchService abstraction.