### PR TITLE
Construct searches using the search builder directly from the controller.

### DIFF
--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -80,11 +80,13 @@ module Blacklight::Catalog
     @facet = blacklight_config.facet_fields[params[:id]]
     raise ActionController::RoutingError, 'Not Found' unless @facet
 
-    @response = if params[:query_fragment].present?
-                  search_service.facet_suggest_response(@facet.key, params[:query_fragment])
-                else
-                  search_service.facet_field_response(@facet.key)
-                end
+    builder = search_builder.with(search_state).facet(@facet.key)
+    if params[:query_fragment].present?
+      builder = builder.facet_suggestion_query(params[:query_fragment])
+    end
+
+    @response = retrieve_search_results(params: builder)
+
     # @display_facet is a Blacklight::Solr::Response::Facets::FacetField
     @display_facet = @response.aggregations[@facet.field]
 

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -42,6 +42,11 @@ module Blacklight::Searchable
     search_service.fetch(Array(ids))
   end
 
+  # @return [Blacklight::SearchBuilder]
+  def search_builder
+    blacklight_config.search_builder_class.new(self, blacklight_config: blacklight_config).with(search_state)
+  end
+
   # Override this method on the class that includes Blacklight::Searchable to provide more context to the search service if necessary.
   # For example, if your search builder needs to be aware of the current user, override this method to return a hash including the current user.
   # Then the search builder could use some property about the current user to construct a constraint on the search.

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -26,8 +26,8 @@ module Blacklight::Searchable
 
   # This method may be overridden to customize search behavior.
   # @return [Blacklight::Solr::Response] the solr response object
-  def retrieve_search_results
-    search_service.search_results
+  def retrieve_search_results(params: nil)
+    search_service.search_results(params: params || search_builder.with(search_state).rows(search_state.per_page).page(search_state.page))
   end
 
   # This method may be overridden to customize search behavior.
@@ -44,7 +44,7 @@ module Blacklight::Searchable
 
   # @return [Blacklight::SearchBuilder]
   def search_builder
-    blacklight_config.search_builder_class.new(self, blacklight_config: blacklight_config).with(search_state)
+    blacklight_config.search_builder_class.new(self, blacklight_config: blacklight_config)
   end
 
   # Override this method on the class that includes Blacklight::Searchable to provide more context to the search service if necessary.

--- a/app/controllers/concerns/blacklight/searchable.rb
+++ b/app/controllers/concerns/blacklight/searchable.rb
@@ -44,7 +44,14 @@ module Blacklight::Searchable
 
   # @return [Blacklight::SearchBuilder]
   def search_builder
-    blacklight_config.search_builder_class.new(self, blacklight_config: blacklight_config)
+    klass = blacklight_config.search_builder_class
+
+    if klass.initialize_supports_blacklight_config_parameter?
+      klass.new(self, blacklight_config: blacklight_config)
+    else
+      # deprecated behavior for implementations that don't support the new initializer signature.
+      klass.new(self)
+    end
   end
 
   # Override this method on the class that includes Blacklight::Searchable to provide more context to the search service if necessary.

--- a/app/services/blacklight/bookmarks_search_builder.rb
+++ b/app/services/blacklight/bookmarks_search_builder.rb
@@ -11,7 +11,7 @@ module Blacklight
     # @return [void]
     def bookmarked(solr_parameters)
       solr_parameters[:fq] ||= []
-      bookmarks = @scope.context.fetch(:bookmarks)
+      bookmarks = @scope.search_service_context.fetch(:bookmarks)
       return unless bookmarks
 
       document_ids = bookmarks.collect { |b| b.document_id.to_s }

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -31,10 +31,7 @@ module Blacklight
     # @return [Blacklight::Solr::Response] the solr response object
     def search_results(params: nil)
       unless params
-        builder = search_builder.with(search_state)
-        builder.page = search_state.page
-        builder.rows = search_state.per_page
-
+        builder = search_builder.with(search_state).page(search_state.page).rows(search_state.per_page)
         builder = yield(builder) if block_given?
       end
 
@@ -63,12 +60,14 @@ module Blacklight
 
     ##
     # Get the solr response when retrieving only a single facet field
+    # @deprecated
     # @return [Blacklight::Solr::Response] the solr response
     def facet_field_response(facet_field, extra_controller_params = {})
       query = search_builder.with(search_state).facet(facet_field)
       repository.search(params: query.merge(extra_controller_params))
     end
 
+    # @deprecated
     def facet_suggest_response(facet_field, facet_suggestion_query, extra_controller_params = {})
       query = search_builder.with(search_state).facet(facet_field).facet_suggestion_query(facet_suggestion_query)
       repository.search(params: query.merge(extra_controller_params))

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -29,13 +29,16 @@ module Blacklight
     #                         SearchBuilder to be used. Block should return SearchBuilder to be used.
     #                         This is used in blacklight_range_limit
     # @return [Blacklight::Solr::Response] the solr response object
-    def search_results
-      builder = search_builder.with(search_state)
-      builder.page = search_state.page
-      builder.rows = search_state.per_page
+    def search_results(params: nil)
+      unless params
+        builder = search_builder.with(search_state)
+        builder.page = search_state.page
+        builder.rows = search_state.per_page
 
-      builder = yield(builder) if block_given?
-      response = repository.search(params: builder)
+        builder = yield(builder) if block_given?
+      end
+
+      response = repository.search(params: params || builder)
 
       if response.grouped? && grouped_key_for_results
         response.group(grouped_key_for_results)

--- a/app/services/blacklight/search_service.rb
+++ b/app/services/blacklight/search_service.rb
@@ -7,10 +7,10 @@ module Blacklight
     # @params [Blacklight::SearchState] search_state
     # @params [Class] search_builder_class a class that inherits from Blacklight::SearchBuilder
     # @params [Hash] context any data the search builder needs to access. For example, the current user.
-    def initialize(config:, search_state:, search_builder_class: config.search_builder_class, **context)
+    def initialize(config:, search_state: nil, search_builder_class: config.search_builder_class, **context)
       @blacklight_config = config
       @search_state = search_state
-      @user_params = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(@search_state.params,
+      @user_params = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(@search_state&.params || {},
                                                                            'Use @search_state.params instead of @user_params',
                                                                            Blacklight.deprecation)
       @search_builder_class = search_builder_class
@@ -31,7 +31,7 @@ module Blacklight
     # @return [Blacklight::Solr::Response] the solr response object
     def search_results(params: nil)
       unless params
-        builder = search_builder.with(search_state).page(search_state.page).rows(search_state.per_page)
+        builder = search_builder.with(search_state).page(search_state&.page).rows(search_state&.per_page)
         builder = yield(builder) if block_given?
       end
 
@@ -114,7 +114,7 @@ module Blacklight
       query = search_builder.with(search_state).merge(solr_opensearch_params(field)).merge(extra_controller_params)
       response = repository.search(params: query)
 
-      [search_state.query_param, response.documents.flat_map { |doc| doc[field] }.uniq]
+      [search_state&.query_param, response.documents.flat_map { |doc| doc[field] }.uniq]
     end
     Blacklight.deprecation.deprecate_methods Blacklight::SearchService, opensearch_response: "The opensearch_response method is deprecated without replacement."
 

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -33,6 +33,14 @@ module Blacklight
       @reverse_merged_params = {}
     end
 
+    def self.initialize_supports_blacklight_config_parameter?
+      return @initialize_supports_blacklight_config_parameter if defined?(@initialize_supports_blacklight_config_parameter)
+
+      @initialize_supports_blacklight_config_parameter = instance_method(:initialize).parameters.any? { |_type, name| name == :blacklight_config }
+
+      Blacklight.deprecation.warn "#{self} initializer should accept a blacklight_config keyword argument in its initializer. This will be required in Blacklight 10."
+    end
+
     def search_state
       @search_state ||= begin
         search_state_class = @scope.try(:search_state_class) || Blacklight::SearchState

--- a/spec/services/blacklight/search_service_spec.rb
+++ b/spec/services/blacklight/search_service_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe Blacklight::SearchService, :api do
         expect(solr_response.docs).to have(0).results
       end
     end
+
+    describe 'when passing in the params' do
+      it 'returns the results' do
+        solr_response = service.search_results(params: { q: '', rows: 5 })
+
+        expect(solr_response.docs).to have(5).results
+      end
+    end
   end # Search Results
 
   # SPECS FOR SEARCH RESULTS FOR FACETS


### PR DESCRIPTION
I'm not there's advantage to having `Blacklight::SearchService` construct the search builder internally (other than it probably made sense at the time, before we encapsulated the params with SearchState).

If we hoist the search builder up to the controller (via the `Searchable` concern), maybe there's less magic?

Bypassing `SearchService#facet_field_response`  and `#facet_suggest_response` are potentially backwards-incompatible, but I couldn't find any indication that it's a method people are actually overriding downstream.

Includes #3856, #3843, and #3854
