### PR TITLE
Gracefully handle nil values to the fluent search builder interface.

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -162,14 +162,19 @@ module Blacklight
       end
     end
 
+    # An undefined value that can be used to detect if a parameter was passed in or not, since nil and false may be valid values for some parameters.
+    UNDEFINED = Object.new.freeze
+
     def start=(value)
+      return if value.nil?
+
       params_will_change!
       @start = value.to_i
     end
 
     # @param [#to_i] value
-    def start(value = nil)
-      if value
+    def start(value = Blacklight::SearchBuilder::UNDEFINED)
+      if value != Blacklight::SearchBuilder::UNDEFINED
         self.start = value
         return self
       end
@@ -181,14 +186,16 @@ module Blacklight
     alias padding start
 
     def page=(value)
+      return if value.nil?
+
       params_will_change!
       @page = value.to_i
       @page = 1 if @page < 1
     end
 
     # @param [#to_i] value
-    def page(value = nil)
-      if value
+    def page(value = Blacklight::SearchBuilder::UNDEFINED)
+      if value != Blacklight::SearchBuilder::UNDEFINED
         self.page = value
         return self
       end
@@ -196,13 +203,15 @@ module Blacklight
     end
 
     def rows=(value)
+      return if value.nil?
+
       params_will_change!
       @rows = [value, blacklight_config.max_per_page].map(&:to_i).min
     end
 
     # @param [#to_i] value
-    def rows(value = nil)
-      if value
+    def rows(value = Blacklight::SearchBuilder::UNDEFINED)
+      if value != Blacklight::SearchBuilder::UNDEFINED
         self.rows = value
         return self
       end

--- a/spec/models/blacklight/search_builder_spec.rb
+++ b/spec/models/blacklight/search_builder_spec.rb
@@ -137,15 +137,23 @@ RSpec.describe Blacklight::SearchBuilder, :api do
 
   describe "#page" do
     it "is the current user parameter page number" do
-      expect(subject.with(page: 2).send(:page)).to eq 2
+      expect(subject.with(page: 2).page).to eq 2
     end
 
     it "is page 1 if not page number given" do
-      expect(subject.send(:page)).to eq 1
+      expect(subject.page).to eq 1
     end
 
     it "coerces parameters to integers" do
-      expect(subject.with(page: '2b').send(:page)).to eq 2
+      expect(subject.with(page: '2b').page).to eq 2
+    end
+
+    it 'sets the page number' do
+      expect(subject.page(3).page).to eq 3
+    end
+
+    it 'gracefully handles setting the page number with a nil value' do
+      expect(subject.page(nil).page).to eq 1
     end
   end
 
@@ -158,6 +166,10 @@ RSpec.describe Blacklight::SearchBuilder, :api do
 
     it "sets the number of rows" do
       expect(subject.rows(17).rows).to eq 17
+    end
+
+    it "gracefully hnadles setting the number of rows to a nil value" do
+      expect(subject.rows(nil).rows).to eq 10
     end
 
     it "is the per_page parameter" do


### PR DESCRIPTION
It is convenient if the fluent interface and the actual setters work the same way with nil values. It's a little bit of a weird case, but confusing when things go wrong. 