### PR TITLE
Allow bookmarks to have all the upstream response formats.

### DIFF
--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -47,16 +47,8 @@ module Blacklight::Bookmarks
 
   def index
     @bookmarks = token_or_current_or_guest_user.bookmarks
-    @response = search_service.search_results
 
-    respond_to do |format|
-      format.html {}
-      format.rss  { render layout: false }
-      format.atom { render layout: false }
-
-      additional_response_formats(format)
-      document_export_formats(format)
-    end
+    super
   end
 
   def update


### PR DESCRIPTION
I don't think we intentionally omitted the json response flavor.