### PR TITLE
Remove solr-specific fields from Blacklight::SearchService

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -162,8 +162,12 @@ module Blacklight
       end
     end
 
+    # An abstract method intended to be overriden with the repository specific SearchBuilderBehavior.
+    #
+    # @return [Hash]
     def default_document_pagination_params
-      { fl: blacklight_config.document_model.unique_key }
+      Blacklight.logger.warn("#{self.class}#default_document_pagination_params is expected to be overridden, but was not.")
+      {}
     end
 
     def for_previous_and_next_documents(index, window = 1)

--- a/lib/blacklight/solr/search_builder_behavior.rb
+++ b/lib/blacklight/solr/search_builder_behavior.rb
@@ -100,6 +100,18 @@ module Blacklight::Solr
       solr_parameters.append_boolean_query(:must, bool_query)
     end
 
+    # Solr-specific request parameters for fetching documents with a
+    # minimal field set and without faceting. Used by
+    # Blacklight::SearchService when paging to the previous/next document.
+    #
+    # @return [Hash]
+    def default_document_pagination_params
+      {
+        fl: blacklight_config.document_model.unique_key,
+        facet: false
+      }
+    end
+
     # Transform "clause" parameters into the Solr JSON Query DSL
     def add_adv_search_clauses(solr_parameters)
       return if search_state.clause_params.blank? || search_state.clause_params.all? { |_k, v| v[:query].blank? }

--- a/spec/models/blacklight/search_builder_spec.rb
+++ b/spec/models/blacklight/search_builder_spec.rb
@@ -135,6 +135,34 @@ RSpec.describe Blacklight::SearchBuilder, :api do
     end
   end
 
+  describe "#for_previous_and_next_documents" do
+    subject(:builder) { SearchBuilder.new processor_chain, scope }
+
+    it "merges default document pagination params when not configured" do
+      allow(subject).to receive(:default_document_pagination_params).and_return(fl: 'id', facet: false)
+      subject.for_previous_and_next_documents(5)
+      expect(subject.to_hash).to include fl: 'id', facet: false
+    end
+
+    it "merges configured document pagination params" do
+      blacklight_config.document_pagination_params = { fl: 'id,title' }
+      subject.for_previous_and_next_documents(5)
+      expect(subject.to_hash).to include fl: 'id,title'
+    end
+
+    it "sets start and rows for previous/next documents" do
+      subject.for_previous_and_next_documents(5, 2)
+      expect(subject.start).to eq 3 # 5 - 2
+      expect(subject.rows).to eq 5  # 2 * 2 + 1
+    end
+
+    it "handles index 0" do
+      subject.for_previous_and_next_documents(0, 2)
+      expect(subject.start).to eq 0
+      expect(subject.rows).to eq 4 # 2 * 2
+    end
+  end
+
   describe "#page" do
     it "is the current user parameter page number" do
       expect(subject.with(page: 2).page).to eq 2


### PR DESCRIPTION
This supports a agnostic backend.
