### PR TITLE
Add support for Rails 8.1 to Blacklight 7

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -39,6 +39,15 @@
       "rails_version": "8.0.2"
     },
     {
+      "ruby": "3.4",
+      "rails_version": "8.1.3"
+    },
+    {
+      "ruby": "3.4",
+      "rails_version": "8.1.3",
+      "bootstrap_version": "~> 4.0"
+    },
+    {
       "ruby": "3.3",
       "rails_version": "7.1.5.1",
       "view_component_version": "~> 2.74",

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-capybara
   - rubocop-rails
   - rubocop-rspec

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,12 +8,12 @@
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
-Capybara/CurrentPathExpectation:
+Capybara/RSpec/CurrentPathExpectation:
   Exclude:
     - 'spec/features/alternate_controller_spec.rb'
 
 # Offense count: 20
-Capybara/VisibilityMatcher:
+Capybara/RSpec/VisibilityMatcher:
   Exclude:
     - 'spec/features/facets_spec.rb'
     - 'spec/features/search_filters_spec.rb'

--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+env:
+  SOLR_MODULES: analysis-extras
 collection:
-  dir: lib/generators/blacklight/templates/solr/conf
+  dir: lib/generators/blacklight/templates/solr/
   name: blacklight-core

--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency "rails", '>= 6.1', '< 8.1'
+  s.add_dependency "rails", '>= 6.1', '< 9'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+pin_all_from File.expand_path("../app/javascript/blacklight", __dir__), under: "blacklight"

--- a/lib/blacklight/configuration/field.rb
+++ b/lib/blacklight/configuration/field.rb
@@ -16,20 +16,20 @@ module Blacklight
 
     def normalize! _blacklight_config = nil
       self.field ||= key
-      self.key ||= self.field
+      self.key ||= field
 
       self.label ||= default_label
 
       self.if = true if self.if.nil?
       self.unless = false if self.unless.nil?
 
-      self.field &&= self.field.to_s
+      self.field &&= field.to_s
 
       self
     end
 
     def validate!
-      raise ArgumentError, "Must supply a field name" if self.field.nil?
+      raise ArgumentError, "Must supply a field name" if field.nil?
     end
 
     def display_label(context = nil, **options)
@@ -43,10 +43,10 @@ module Blacklight
     end
 
     def default_label
-      if self.key.respond_to?(:titleize)
-        self.key.titleize
+      if key.respond_to?(:titleize)
+        key.titleize
       else
-        self.key.to_s.titleize
+        key.to_s.titleize
       end
     end
 

--- a/lib/blacklight/configuration/sort_field.rb
+++ b/lib/blacklight/configuration/sort_field.rb
@@ -9,13 +9,13 @@ module Blacklight
       self.field ||= label&.parameterize
       self.field ||= sort
 
-      self.sort ||= self.field
+      self.sort ||= field
 
       self
     end
 
     def validate!
-      raise ArgumentError.new, "Must supply a sort string" if self.sort.nil?
+      raise ArgumentError.new, "Must supply a sort string" if sort.nil?
     end
   end
 end

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -38,13 +38,18 @@ module Blacklight
       end
     end
 
-    initializer "blacklight.assets.precompile" do
+    initializer "blacklight.assets.precompile" do |app|
       PRECOMPILE_ASSETS = %w(favicon.ico blacklight/blacklight.js blacklight/blacklight.js.map).freeze
 
       # When Rails has been generated in API mode, it does not have sprockets available
-      if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += PRECOMPILE_ASSETS
-      end
+      next unless app.config.respond_to?(:assets)
+
+      app.config.assets.paths << Engine.root.join("app/javascript")
+      app.config.assets.precompile += PRECOMPILE_ASSETS
+    end
+
+    initializer "blacklight.importmap", before: "importmap" do |app|
+      app.config.importmap.paths << Engine.root.join("config/importmap.rb") if app.config.respond_to?(:importmap)
     end
 
     bl_global_config = OpenStructWithHashAccess.new

--- a/lib/generators/blacklight/assets/importmap_generator.rb
+++ b/lib/generators/blacklight/assets/importmap_generator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Assets
+    class ImportmapGenerator < Rails::Generators::Base
+      class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 5.1'), desc: "Set the generated app's bootstrap version"
+
+      # This could be skipped if you want to use webpacker
+      def add_javascript_dependencies
+        gem 'bootstrap', options[:'bootstrap-version'].presence # in rails 7, only for stylesheets
+        gem 'jquery-rails' if bootstrap_4? # Bootstrap 4 has a dependency on jquery
+      end
+
+      def import_javascript_assets
+        append_to_file 'config/importmap.rb' do
+          <<~CONTENT
+            pin "@github/auto-complete-element", to: "https://cdn.skypack.dev/@github/auto-complete-element"
+            pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/dist/umd/popper.min.js"
+            pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@#{(defined?(Bootstrap) && Bootstrap::VERSION) || '5.2.2'}/dist/js/bootstrap.js"
+          CONTENT
+        end
+
+        append_to_file 'app/assets/config/manifest.js' do
+          <<~CONTENT
+            //= link blacklight/manifest.js
+          CONTENT
+        end
+      end
+
+      def append_blacklight_javascript
+        append_to_file 'app/javascript/application.js' do
+          <<~CONTENT
+            import bootstrap from "bootstrap"
+            import githubAutoCompleteElement from "@github/auto-complete-element"
+            import Blacklight from "blacklight"
+          CONTENT
+        end
+      end
+
+      def add_stylesheet
+        gem "sassc-rails", "~> 2.1" if Rails.version > '7'
+
+        create_file 'app/assets/stylesheets/blacklight.scss' do
+          <<~CONTENT
+            @import 'bootstrap';
+            @import 'blacklight/blacklight';
+          CONTENT
+        end
+      end
+
+      def bootstrap_4?
+        options[:'bootstrap-version'].match?(/\A[^0-9]*4\./)
+      end
+    end
+  end
+end

--- a/lib/generators/blacklight/assets/propshaft_generator.rb
+++ b/lib/generators/blacklight/assets/propshaft_generator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Assets
+    class PropshaftGenerator < Rails::Generators::Base
+      def add_package
+        if ENV['CI']
+          run "yarn add blacklight-frontend:#{Blacklight::Engine.root}"
+        else
+          run 'yarn add blacklight-frontend'
+        end
+      end
+
+      def add_third_party_packages
+        run 'yarn add @github/auto-complete-element'
+      end
+
+      def add_package_assets
+        append_to_file 'app/assets/stylesheets/application.bootstrap.scss' do
+          <<~CONTENT
+            @import "blacklight-frontend/app/assets/stylesheets/blacklight/blacklight";
+          CONTENT
+        end
+
+        append_to_file 'app/javascript/application.js' do
+          <<~CONTENT
+            import Blacklight from "blacklight-frontend";
+            import githubAutoCompleteElement from "@github/auto-complete-element";
+          CONTENT
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/blacklight/assets/sprockets_generator.rb
+++ b/lib/generators/blacklight/assets/sprockets_generator.rb
@@ -42,7 +42,7 @@ module Blacklight
         end
       end
 
-      def assets
+      def assets # rubocop:disable Metrics/MethodLength
         create_file 'app/assets/stylesheets/blacklight.scss' do
           <<~CONTENT
             @import 'bootstrap';

--- a/lib/generators/blacklight/assets/sprockets_generator.rb
+++ b/lib/generators/blacklight/assets/sprockets_generator.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Assets
+    class SprocketsGenerator < Rails::Generators::Base
+      class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 4.0'), desc: "Set the generated app's bootstrap version"
+
+      def replace_propshaft_with_sprockets
+        return if defined?(Sprockets)
+
+        # Rails 8+ defaults to Propshaft, but Blacklight 7.x JS requires Sprockets
+        gsub_file 'Gemfile', /^gem ['"]propshaft['"].*$/, '# \0'
+        gem 'sprockets-rails'
+      end
+
+      def add_javascript_dependencies
+        gem 'bootstrap', options[:'bootstrap-version'].presence
+        gem 'jquery-rails'
+        gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
+      end
+
+      def add_sass_support
+        gem "sassc-rails", "~> 2.1" if Rails.version > '7'
+      end
+
+      def setup_sprockets_manifest
+        if !defined?(Sprockets)
+          # Rails 8+ with Propshaft replaced: create Sprockets config from scratch
+          directory = File.expand_path('app/assets/config', destination_root)
+          FileUtils.mkdir_p(directory)
+          create_file 'app/assets/config/manifest.js' do
+            <<~CONTENT
+              //= link_tree ../images
+              //= link_directory ../stylesheets .css
+              //= link application.js
+            CONTENT
+          end
+          empty_directory 'app/assets/images'
+        elsif defined?(Sprockets::VERSION) && Sprockets::VERSION >= '4'
+          append_to_file 'app/assets/config/manifest.js', "\n//= link application.js"
+          empty_directory 'app/assets/images'
+        end
+      end
+
+      def assets
+        create_file 'app/assets/stylesheets/blacklight.scss' do
+          <<~CONTENT
+            @import 'bootstrap';
+            @import 'blacklight/blacklight';
+          CONTENT
+        end
+
+        # Ensure application.css is a proper Sprockets manifest that loads blacklight styles
+        application_css = File.expand_path('app/assets/stylesheets/application.css', destination_root)
+        if File.exist?(application_css)
+          content = File.read(application_css)
+          unless content.include?('require blacklight')
+            create_file 'app/assets/stylesheets/application.css', force: true do
+              <<~CONTENT
+                /*
+                 *= require blacklight
+                 *= require_self
+                 */
+              CONTENT
+            end
+          end
+        end
+
+        # Ensure this method is idempotent
+        return if has_blacklight_assets?
+
+        create_file 'app/assets/javascripts/application.js' do
+          <<~CONTENT
+            //= require jquery3
+            //= require rails-ujs
+
+            // Required by Blacklight
+            //= require popper
+            // Twitter Typeahead for autocomplete
+            //= require twitter/typeahead
+            //= require bootstrap
+            //= require blacklight/blacklight
+          CONTENT
+        end
+      end
+
+      private
+
+      def has_blacklight_assets?
+        application_js.include?('blacklight/blacklight')
+      end
+
+      def application_js
+        path = File.expand_path("app/assets/javascripts/application.js", destination_root)
+
+        File.exist?(path) ? File.read(path) : ''
+      end
+    end
+  end
+end

--- a/lib/generators/blacklight/assets_generator.rb
+++ b/lib/generators/blacklight/assets_generator.rb
@@ -1,94 +1,17 @@
 # frozen_string_literal: true
-module Blacklight
-  class Assets < Rails::Generators::Base
-    source_root File.expand_path('../templates', __FILE__)
 
+require 'shellwords'
+
+module Blacklight
+  class AssetsGenerator < Rails::Generators::Base
     class_option :'bootstrap-version', type: :string, default: ENV.fetch('BOOTSTRAP_VERSION', '~> 4.0'), desc: "Set the generated app's bootstrap version"
 
-    # This could be skipped if you want to use webpacker
-    def add_javascript_dependencies
-      gem 'bootstrap', options[:'bootstrap-version']
-      gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
-    end
+    def run_asset_pipeline_specific_generator
+      generated_options = "--bootstrap-version='#{Shellwords.escape(options[:'bootstrap-version'])}'" if options[:'bootstrap-version']
 
-    def appease_rails7
-      return unless Rails.version > '7'
-
-      gem "sassc-rails", "~> 2.1"
-    end
-
-    # Add sprockets javascript if needed
-    def create_sprockets_javascript
-      create_file 'app/assets/javascripts/application.js' do
-        <<~CONTENT
-          //= require jquery3
-          //= require rails-ujs
-          #{'//= require turbolinks' if Rails.version < '7'}
-        CONTENT
-      end
-    end
-
-    ##
-    # Remove the empty generated app/assets/images directory. Without doing this,
-    # the default Sprockets 4 manifest will raise an exception.
-    def appease_sprockets4
-      return if !defined?(Sprockets::VERSION) || Sprockets::VERSION < '4' || using_importmap?
-
-      append_to_file 'app/assets/config/manifest.js', "\n//= link application.js\n"
-      empty_directory 'app/assets/images'
-    end
-
-    def assets
-      copy_file "blacklight.scss", "app/assets/stylesheets/blacklight.scss"
-
-      # Ensure this method is idempotent
-      return if has_blacklight_assets?
-
-      gem 'jquery-rails'
-      contents = "\n//\n// Required by Blacklight\n"
-      contents += "//= require popper\n"
-      contents += "// Twitter Typeahead for autocomplete\n"
-      contents += "//= require twitter/typeahead\n"
-      contents += "//= require bootstrap\n"
-      contents += "//= require blacklight/blacklight\n"
-
-      marker = if turbolinks?
-                 '//= require turbolinks'
-               else
-                 '//= require rails-ujs'
-               end
-
-      insert_into_file "app/assets/javascripts/application.js", after: marker do
-        contents
-      end
-
-      insert_into_file "app/assets/javascripts/application.js", before: '//= require rails-ujs' do
-        "//= require jquery3\n"
-      end
-    end
-
-    private
-
-    def root
-      @root ||= Pathname(destination_root)
-    end
-
-    def using_importmap?
-      @using_importmap ||= root.join('config/importmap.rb').exist?
-    end
-
-    def turbolinks?
-      @turbolinks ||= application_js.include?('turbolinks')
-    end
-
-    def has_blacklight_assets?
-      application_js.include?('blacklight/blacklight')
-    end
-
-    def application_js
-      path = File.expand_path("app/assets/javascripts/application.js", destination_root)
-
-      File.exist?(path) ? File.read(path) : ''
+      # Blacklight 7.x JS is distributed via Sprockets (//= require directives, jQuery, etc.)
+      # so we always use the sprockets generator regardless of what Rails defaulted to.
+      generate 'blacklight:assets:sprockets', generated_options
     end
   end
 end

--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -11,7 +11,7 @@ module Blacklight
     class_option :devise, type: :boolean, default: false, aliases: "-d", desc: "Use Devise as authentication logic."
     class_option :marc, type: :boolean, default: false, aliases: "-m", desc: "Generate MARC-based demo."
     class_option :'bootstrap-version', type: :string, default: nil, desc: "Set the generated app's bootstrap version"
-    class_option :'skip-assets', type: :boolean, default: !defined?(Sprockets), desc: "Skip generating javascript and css assets into the application"
+    class_option :'skip-assets', type: :boolean, default: false, desc: "Skip generating javascript and css assets into the application"
     class_option :'skip-solr', type: :boolean, default: false, desc: "Skip generating solr configurations."
 
     desc <<-EOS
@@ -41,7 +41,7 @@ module Blacklight
 
     def bundle_install
       inside destination_root do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           run "bundle install"
         end
       end

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -47,7 +47,6 @@
           full_title_tsim
           short_title_tsim
           alternative_title_tsim
-          active_fedora_model_ssi
           title_tsim
           author_tsim
           subject_tsim
@@ -84,76 +83,6 @@
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
        <str name="facet.limit">10</str>
-       <str name="facet.field">active_fedora_model_ssi</str>
-       <str name="facet.field">subject_ssim</str>
-
-       <str name="spellcheck">true</str>
-       <str name="spellcheck.dictionary">default</str>
-       <str name="spellcheck.onlyMorePopular">true</str>
-       <str name="spellcheck.extendedResults">true</str>
-       <str name="spellcheck.collate">false</str>
-       <str name="spellcheck.count">5</str>
-
-     </lst>
-    <arr name="last-components">
-      <str>spellcheck</str>
-    </arr>
-  </requestHandler>
-
-  <requestHandler name="/advanced" class="solr.SearchHandler">
-    <!-- a lucene request handler for using the JSON Query DSL,
-         specifically for advanced search.
-         Using a separate requestHandler is a workaround to
-         https://issues.apache.org/jira/browse/SOLR-16916, although
-         it could be desirable for other reasons as well.
-      -->
-     <lst name="defaults">
-       <str name="defType">lucene</str>
-       <str name="echoParams">explicit</str>
-        <str name="df">title_tsim</str>
-        <str name="qf">
-          id
-          full_title_tsim
-          short_title_tsim
-          alternative_title_tsim
-          active_fedora_model_ssi
-          title_tsim
-          author_tsim
-          subject_tsim
-          all_text_timv
-        </str>
-        <str name="pf">
-          all_text_timv^10
-        </str>
-
-       <str name="author_qf">
-          author_tsim
-       </str>
-       <str name="author_pf">
-       </str>
-       <str name="title_qf">
-          title_tsim
-          full_title_tsim
-          short_title_tsim
-          alternative_title_tsim
-       </str>
-       <str name="title_pf">
-       </str>
-       <str name="subject_qf">
-          subject_tsim
-       </str>
-       <str name="subject_pf">
-       </str>
-
-       <str name="fl">
-         *,
-         score
-       </str>
-
-       <str name="facet">true</str>
-       <str name="facet.mincount">1</str>
-       <str name="facet.limit">10</str>
-       <str name="facet.field">active_fedora_model_ssi</str>
        <str name="facet.field">subject_ssim</str>
 
        <str name="spellcheck">true</str>
@@ -258,7 +187,7 @@
   <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
 
   <requestDispatcher handleSelect="true" >
-    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
+    <requestParsers multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -98,6 +98,73 @@
     </arr>
   </requestHandler>
 
+  <requestHandler name="/advanced" class="solr.SearchHandler">
+    <!-- a lucene request handler for using the JSON Query DSL,
+         specifically for advanced search.
+         Using a separate requestHandler is a workaround to
+         https://issues.apache.org/jira/browse/SOLR-16916, although
+         it could be desirable for other reasons as well.
+      -->
+     <lst name="defaults">
+       <str name="defType">lucene</str>
+       <str name="echoParams">explicit</str>
+        <str name="df">title_tsim</str>
+        <str name="qf">
+          id
+          full_title_tsim
+          short_title_tsim
+          alternative_title_tsim
+          title_tsim
+          author_tsim
+          subject_tsim
+          all_text_timv
+        </str>
+        <str name="pf">
+          all_text_timv^10
+        </str>
+
+       <str name="author_qf">
+          author_tsim
+       </str>
+       <str name="author_pf">
+       </str>
+       <str name="title_qf">
+          title_tsim
+          full_title_tsim
+          short_title_tsim
+          alternative_title_tsim
+       </str>
+       <str name="title_pf">
+       </str>
+       <str name="subject_qf">
+          subject_tsim
+       </str>
+       <str name="subject_pf">
+       </str>
+
+       <str name="fl">
+         *,
+         score
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.limit">10</str>
+       <str name="facet.field">subject_ssim</str>
+
+       <str name="spellcheck">true</str>
+       <str name="spellcheck.dictionary">default</str>
+       <str name="spellcheck.onlyMorePopular">true</str>
+       <str name="spellcheck.extendedResults">true</str>
+       <str name="spellcheck.collate">false</str>
+       <str name="spellcheck.count">5</str>
+
+     </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
   <requestHandler name="permissions" class="solr.SearchHandler" >
     <lst name="defaults">
       <str name="facet">off</str>

--- a/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/blacklight/templates/solr/conf/solrconfig.xml
@@ -23,7 +23,7 @@
 
   <dataDir>${solr.data.dir:}</dataDir>
 
-  <requestHandler name="search" class="solr.SearchHandler" default="true">
+  <requestHandler name="/select" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request
       -->
@@ -253,7 +253,7 @@
 
   <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
 
-  <requestDispatcher handleSelect="true" >
+  <requestDispatcher>
     <requestParsers multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 

--- a/spec/helpers/blacklight/facets_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/facets_helper_behavior_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Blacklight::FacetsHelperBehavior do
     context "when one of the facet items is rendered as nil" do
       # An app may override render_facet_item to filter out some undesired facet items by returning nil.
       before do
-        allow_any_instance_of # rubocop:disable RSpec/AnyInstance(Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true)
+        allow_any_instance_of (Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true) # rubocop:disable RSpec/AnyInstance
         allow(helper).to receive(:render_facet_item).and_return('<a class="facet-select">Book</a>'.html_safe, nil)
       end
 

--- a/spec/helpers/blacklight/facets_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/facets_helper_behavior_spec.rb
@@ -231,8 +231,7 @@ RSpec.describe Blacklight::FacetsHelperBehavior do
     context "when one of the facet items is rendered as nil" do
       # An app may override render_facet_item to filter out some undesired facet items by returning nil.
       before do
-        allow(helper.method(:render_facet_item)).to receive(:owner).and_return(self.class)
-        # allow_any_instance_of(Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true)
+        allow_any_instance_of(Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true)
         allow(helper).to receive(:render_facet_item).and_return('<a class="facet-select">Book</a>'.html_safe, nil)
       end
 

--- a/spec/helpers/blacklight/facets_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/facets_helper_behavior_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Blacklight::FacetsHelperBehavior do
     context "when one of the facet items is rendered as nil" do
       # An app may override render_facet_item to filter out some undesired facet items by returning nil.
       before do
-        allow_any_instance_of(Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true)
+        allow_any_instance_of # rubocop:disable RSpec/AnyInstance(Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true)
         allow(helper).to receive(:render_facet_item).and_return('<a class="facet-select">Book</a>'.html_safe, nil)
       end
 

--- a/spec/helpers/blacklight/facets_helper_behavior_spec.rb
+++ b/spec/helpers/blacklight/facets_helper_behavior_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Blacklight::FacetsHelperBehavior do
     context "when one of the facet items is rendered as nil" do
       # An app may override render_facet_item to filter out some undesired facet items by returning nil.
       before do
-        allow_any_instance_of (Blacklight::FacetItemComponent).to receive(:overridden_helper_methods?).and_return(true) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of Blacklight::FacetItemComponent.to receive(:overridden_helper_methods?).and_return(true) # rubocop:disable RSpec/AnyInstance
         allow(helper).to receive(:render_facet_item).and_return('<a class="facet-select">Book</a>'.html_safe, nil)
       end
 

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -11,7 +11,7 @@ class TestAppGenerator < Rails::Generators::Base
   def run_blacklight_generator
     say_status("warning", "GENERATING BL", :yellow)
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       run "bundle install"
     end
     options = '--devise'

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -12,12 +12,28 @@ RuboCop::RakeTask.new(:rubocop)
 
 require 'solr_wrapper'
 require 'open3'
+require 'net/http'
 
 def system_with_error_handling(*args)
   Open3.popen3(*args) do |_stdin, stdout, stderr, thread|
     puts stdout.read
     raise "Unable to run #{args.inspect}: #{stderr.read}" unless thread.value.success?
   end
+end
+
+def wait_for_solr(port: 8983, timeout: 30)
+  print "Waiting for Solr to be ready"
+  timeout.times do
+    begin
+      Net::HTTP.get_response(URI("http://localhost:#{port}/solr/admin/cores?action=STATUS"))
+      puts " ready."
+      return
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Net::OpenTimeout
+      print "."
+      sleep 1
+    end
+  end
+  raise "Solr did not become ready within #{timeout} seconds"
 end
 
 def with_solr
@@ -29,6 +45,7 @@ def with_solr
     begin
       puts "Starting Solr"
       system_with_error_handling "docker compose up -d solr"
+      wait_for_solr
       yield
     ensure
       puts "Stopping Solr"

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -12,31 +12,12 @@ RuboCop::RakeTask.new(:rubocop)
 
 require 'solr_wrapper'
 require 'open3'
-require 'net/http'
 
 def system_with_error_handling(*args)
   Open3.popen3(*args) do |_stdin, stdout, stderr, thread|
     puts stdout.read
     raise "Unable to run #{args.inspect}: #{stderr.read}" unless thread.value.success?
   end
-end
-
-def wait_for_solr(port: 8983, timeout: 30)
-  print "Waiting for Solr to be ready"
-  timeout.times do
-    begin
-      response = Net::HTTP.get_response(URI("http://localhost:#{port}/solr/blacklight-core/admin/ping"))
-      if response.is_a?(Net::HTTPSuccess)
-        puts " ready."
-        return
-      end
-    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Net::OpenTimeout, EOFError
-      # Solr not yet accepting connections
-    end
-    print "."
-    sleep 1
-  end
-  raise "Solr did not become ready within #{timeout} seconds"
 end
 
 def with_solr
@@ -48,7 +29,6 @@ def with_solr
     begin
       puts "Starting Solr"
       system_with_error_handling "docker compose up -d solr"
-      wait_for_solr
       yield
     ensure
       puts "Stopping Solr"

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -24,7 +24,7 @@ def with_solr
   # We're being invoked by the app entrypoint script and solr is already up via docker compose
   if ENV['SOLR_ENV'] == 'docker-compose'
     yield
-  elsif system('docker compose -v')
+  elsif system('docker compose version')
     # We're not running `docker compose up' but still want to use a docker instance of solr.
     begin
       puts "Starting Solr"

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -28,7 +28,7 @@ def wait_for_solr(port: 8983, timeout: 30)
       Net::HTTP.get_response(URI("http://localhost:#{port}/solr/admin/cores?action=STATUS"))
       puts " ready."
       return
-    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Net::OpenTimeout
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Net::OpenTimeout, EOFError
       print "."
       sleep 1
     end

--- a/tasks/blacklight.rake
+++ b/tasks/blacklight.rake
@@ -25,13 +25,16 @@ def wait_for_solr(port: 8983, timeout: 30)
   print "Waiting for Solr to be ready"
   timeout.times do
     begin
-      Net::HTTP.get_response(URI("http://localhost:#{port}/solr/admin/cores?action=STATUS"))
-      puts " ready."
-      return
+      response = Net::HTTP.get_response(URI("http://localhost:#{port}/solr/blacklight-core/admin/ping"))
+      if response.is_a?(Net::HTTPSuccess)
+        puts " ready."
+        return
+      end
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Net::OpenTimeout, EOFError
-      print "."
-      sleep 1
+      # Solr not yet accepting connections
     end
+    print "."
+    sleep 1
   end
   raise "Solr did not become ready within #{timeout} seconds"
 end


### PR DESCRIPTION
This will save my team from months of maintenance work in a time when we really need to be pushing on iterating features for product fit and migration use cases.

I believe it's fully backwards compatible, initial tests are showing this opens the door to upgrading old Geoblacklight, Spotlight, and vanilla Blacklight applications.