### PR TITLE
Add spacing below email and sms form fields

### DIFF
--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -6,7 +6,7 @@
 
   <div class="modal-body">
     <%= render '/shared/flash_msg' %>
-    <div class="row">
+    <div class="row mb-3">
       <label class="col-form-label col-sm-2" for="to">
         <%= t('blacklight.email.form.to') %>
       </label>
@@ -15,7 +15,7 @@
       </div>
     </div>
 
-    <div class="row">
+    <div class="row mb-3">
       <label class="col-form-label col-sm-2" for="message">
         <%= t('blacklight.email.form.message') %>
       </label>
@@ -25,7 +25,7 @@
     </div>
 
     <% @documents&.each do |doc| %>
-      <%=hidden_field_tag "id[]", doc.id %>
+      <%= hidden_field_tag "id[]", doc.id %>
     <% end %>
     <%- if params[:sort] -%>
       <%= hidden_field_tag "sort", params[:sort] %>

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -5,7 +5,7 @@
              method: :post do %>
 <div class="modal-body">
   <%= render '/shared/flash_msg' %>
-    <div class="row">
+    <div class="row mb-3">
       <label class="col-form-label col-sm-2" for="to">
         <%= t('blacklight.sms.form.to') %>
       </label>
@@ -13,17 +13,17 @@
         <%= telephone_field_tag :to, params[:to], class: 'form-control', required: true %>
       </div>
     </div>
-    <div class="row">
+    <div class="row mb-3">
       <label class="col-form-label col-sm-2" for="carrier">
         <%= t('blacklight.sms.form.carrier') %>
       </label>
       <div class="col-sm-10">
-          <%= select_tag(:carrier, options_for_select(sms_mappings.to_a.sort.unshift([t('blacklight.sms.form.carrier_prompt'),'']), params[:carrier]), class: 'form-control') %><br/>
+          <%= select_tag(:carrier, options_for_select(sms_mappings.to_a.sort.unshift([t('blacklight.sms.form.carrier_prompt'),'']), params[:carrier]), class: 'form-control') %><br>
       </div>
 
     </div>
     <% @documents&.each do |doc| %>
-       <%=hidden_field_tag "id[]", doc.id %>
+       <%= hidden_field_tag "id[]", doc.id %>
     <% end %>
 </div>
 <div class="modal-footer">


### PR DESCRIPTION
See https://github.com/geoblacklight/geoblacklight/issues/1472

Horizontal forms are supposed to have a `.mb-3` class on the row. See https://getbootstrap.com/docs/5.3/forms/layout/#horizontal-form

Before:
<img width="803" height="297" alt="Screenshot 2026-06-15 at 4 52 49 PM" src="https://github.com/user-attachments/assets/2703f079-f958-4ebb-be36-2d7a2ed8333f" />

After:
<img width="802" height="327" alt="Screenshot 2026-06-15 at 4 52 37 PM" src="https://github.com/user-attachments/assets/3274b3ff-167f-4a95-acdc-0658a209eb03" />


