### PR TITLE
Remove Capybara/ClickLinkOrButtonStyle cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -460,8 +460,6 @@ Style/SuperWithArgsParentheses: # new in 1.58
   Enabled: true
 Style/YAMLFileRead: # new in 1.53
   Enabled: true
-Capybara/ClickLinkOrButtonStyle: # new in 2.19
-  Enabled: true
 Capybara/AssertStyle: # new in 2.17
   Enabled: true
 Capybara/RSpec/MatchStyle:


### PR DESCRIPTION
This seems to be causing CI problems. Evidently it was deleted:
https://github.com/rubocop/rubocop-capybara/issues/81
