### PR TITLE
Allow using Rails default authentication in lieu of Devise

### DIFF
--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -13,6 +13,8 @@ module Blacklight::Bookmarks
 
     copy_blacklight_config_from(CatalogController)
 
+    allow_unauthenticated_access raise: false if respond_to?(:allow_unauthenticated_access)
+
     before_action :verify_user
 
     blacklight_config.track_search_session.storage = false
@@ -140,7 +142,7 @@ module Blacklight::Bookmarks
   private
 
   def verify_user
-    unless current_or_guest_user || (action == "index" && token_or_current_or_guest_user)
+    unless current_or_guest_user || (action_name == "index" && token_or_current_or_guest_user)
       flash[:notice] = I18n.t('blacklight.bookmarks.need_login')
       raise Blacklight::Exceptions::AccessDenied
     end

--- a/app/controllers/concerns/blacklight/catalog.rb
+++ b/app/controllers/concerns/blacklight/catalog.rb
@@ -13,6 +13,8 @@ module Blacklight::Catalog
   # The following code is executed when someone includes blacklight::catalog in their
   # own controller.
   included do
+    allow_unauthenticated_access raise: false if respond_to?(:allow_unauthenticated_access)
+
     if respond_to? :helper_method
       helper_method :sms_mappings, :has_search_parameters?
     end

--- a/app/controllers/concerns/blacklight/controller.rb
+++ b/app/controllers/concerns/blacklight/controller.rb
@@ -5,6 +5,8 @@
 module Blacklight::Controller
   extend ActiveSupport::Concern
 
+  include Blacklight::GuestUser
+
   included do
     include ActiveSupport::Callbacks
 
@@ -17,6 +19,7 @@ module Blacklight::Controller
 
     if respond_to? :helper_method
       helper_method :current_user_session, :current_user, :current_or_guest_user
+      helper_method :blacklight_account_path, :blacklight_login_path, :blacklight_login_url, :blacklight_logout_link_options, :blacklight_logout_path
 
       # extra head content
       helper_method :has_user_authentication_provider?
@@ -85,10 +88,10 @@ module Blacklight::Controller
 
   # Here's a stub implementation we'll add if it isn't provided for us
   def current_or_guest_user
-    if defined? super
-      super
+    if defined?(super) && (user = super)
+      user
     elsif has_user_authentication_provider?
-      current_user
+      current_user || guest_user
     end
   end
   alias blacklight_current_or_guest_user current_or_guest_user
@@ -97,13 +100,13 @@ module Blacklight::Controller
   #
   #
   def has_user_authentication_provider?
-    respond_to? :current_user
+    respond_to?(:current_user) || blacklight_login_path.present? || blacklight_logout_path.present?
   end
 
   ##
   # When a user logs in, transfer any saved searches or bookmarks to the current_user
   def transfer_guest_to_user
-    return unless respond_to?(:current_user) && respond_to?(:guest_user) && current_user && guest_user
+    return unless respond_to?(:current_user) && current_user && guest_user
 
     current_user_searches = current_user.searches.pluck(:query_params)
     current_user_bookmarks = current_user.bookmarks.pluck(:document_id)
@@ -133,10 +136,51 @@ module Blacklight::Controller
 
     redirect_to(root_url) && return unless has_user_authentication_provider?
 
-    redirect_to new_user_session_url(referer: request.fullpath)
+    store_location_for_rails_authentication
+    redirect_to(root_url) && return unless blacklight_login_url
+
+    redirect_to blacklight_login_url(referer: request.fullpath)
   end
 
   def determine_layout
     'blacklight'
+  end
+
+  def blacklight_login_path(options = {})
+    if respond_to?(:new_user_session_path)
+      new_user_session_path(options)
+    elsif respond_to?(:new_session_path)
+      new_session_path(options)
+    end
+  end
+
+  def blacklight_login_url(options = {})
+    if respond_to?(:new_user_session_url)
+      new_user_session_url(options)
+    elsif respond_to?(:new_session_url)
+      new_session_url(options)
+    end
+  end
+
+  def blacklight_logout_path
+    if respond_to?(:destroy_user_session_path)
+      destroy_user_session_path
+    elsif respond_to?(:session_path)
+      session_path
+    end
+  end
+
+  def blacklight_logout_link_options
+    return {} unless respond_to?(:session_path)
+
+    { data: { turbo_method: :delete } }
+  end
+
+  def blacklight_account_path
+    edit_user_registration_path if respond_to?(:edit_user_registration_path)
+  end
+
+  def store_location_for_rails_authentication
+    session[:return_to_after_authenticating] = request.url if respond_to?(:new_session_url)
   end
 end

--- a/app/controllers/concerns/blacklight/guest_user.rb
+++ b/app/controllers/concerns/blacklight/guest_user.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Blacklight
+  # Provides a persisted "guest" user for anonymous visitors so they can
+  # accumulate bookmarks and searches that are transferred to a real account
+  # upon sign-in (see Blacklight::Controller#transfer_guest_to_user).
+  #
+  # This is the fallback used by Rails' built-in authentication. When Devise
+  # together with the +devise-guests+ gem is used, that pair provides its own
+  # +#guest_user+ / +#current_or_guest_user+ (and knows how to build a valid
+  # Devise guest, e.g. skipping password validation). They sit higher in the
+  # ancestor chain than this concern, so +#guest_user+ defers to +super+ when
+  # available and only falls back to the implementation below otherwise. The
+  # helper methods below are intentionally named to avoid colliding with
+  # +devise-guests+' own +#create_guest_user+.
+  module GuestUser
+    extend ActiveSupport::Concern
+
+    # Returns a persisted guest user for the current session, creating one on
+    # first access. Keyed off the session so it survives across requests.
+    # Returns +nil+ if a guest cannot be created (e.g. no user model).
+    def guest_user
+      return super if defined?(super)
+      return @blacklight_guest_user if defined?(@blacklight_guest_user) && @blacklight_guest_user
+
+      @blacklight_guest_user = find_blacklight_guest_user || create_blacklight_guest_user
+    end
+
+    private
+
+    def find_blacklight_guest_user
+      return unless (id = session[:blacklight_guest_user_id])
+
+      blacklight_guest_user_class.find_by(id: id)
+    end
+
+    def create_blacklight_guest_user
+      user = blacklight_guest_user_class.create_guest_user!
+      session[:blacklight_guest_user_id] = user.id
+      user
+    rescue ActiveRecord::RecordInvalid
+      nil
+    end
+
+    # The model class that guest users are created from. Defaults to +User+,
+    # consistent with Blacklight::TokenBasedUser. Override to use another model.
+    def blacklight_guest_user_class
+      ::User
+    end
+  end
+end

--- a/app/controllers/concerns/blacklight/search_history.rb
+++ b/app/controllers/concerns/blacklight/search_history.rb
@@ -7,6 +7,8 @@ module Blacklight
     include Blacklight::SearchContext
 
     included do
+      allow_unauthenticated_access raise: false if respond_to?(:allow_unauthenticated_access)
+
       copy_blacklight_config_from(CatalogController)
     end
 

--- a/app/models/concerns/blacklight/user.rb
+++ b/app/models/concerns/blacklight/user.rb
@@ -12,6 +12,41 @@ module Blacklight::User
     has_many :searches,  dependent: :destroy, as: :user
   end
 
+  class_methods do
+    # The column that holds the user's login/identifier. Rails' authentication
+    # generator uses +email_address+, while Devise and others use +email+.
+    def blacklight_email_column
+      column_names.include?("email_address") ? :email_address : :email
+    end
+
+    # Create a persisted "guest" user for an anonymous visitor, so they can
+    # accumulate bookmarks and searches that are transferred to a real account
+    # upon sign-in. Works whether the model uses +email+ or +email_address+,
+    # and supplies a random password when the model authenticates with a
+    # password (either +has_secure_password+'s +password_digest+ column or
+    # Devise's +encrypted_password+ column).
+    def create_guest_user!
+      attributes = { blacklight_email_column => "guest_#{Time.current.to_i}_#{SecureRandom.hex(4)}@example.com" }
+
+      if authenticates_with_password?
+        password = SecureRandom.hex(16)
+        attributes[:password] = password
+        attributes[:password_confirmation] = password
+      end
+
+      create!(attributes)
+    end
+
+    # True when the model stores a password (Rails' +has_secure_password+ via
+    # +password_digest+, or Devise's +database_authenticatable+ via
+    # +encrypted_password+). In either case the model exposes a virtual
+    # +password+ / +password_confirmation+ attribute that must be populated to
+    # satisfy validation.
+    def authenticates_with_password?
+      column_names.intersect?(%w[password_digest encrypted_password])
+    end
+  end
+
   def bookmarks_for_documents documents = []
     if documents.any?
       bookmarks.where(document_type: documents.first.class.base_class.to_s, document_id: documents.map(&:id))

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -4,19 +4,24 @@
   <% end %>
 
   <% if has_user_authentication_provider? %>
-    <% if current_user %>
+    <% user = current_user if respond_to?(:current_user) %>
+    <% if user %>
+    <% if blacklight_logout_path %>
     <li class="nav-item">
-      <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path, class: 'nav-link' %>
+      <%= link_to t('blacklight.header_links.logout'), blacklight_logout_path, { class: 'nav-link' }.merge(blacklight_logout_link_options) %>
     </li>
-    <% unless current_user.to_s.blank? -%>
+    <% end %>
+    <% if blacklight_account_path && user.to_s.present? -%>
     <li class="nav-item">
-      <%= link_to current_user, edit_user_registration_path, class: 'nav-link' %>
+      <%= link_to user, blacklight_account_path, class: 'nav-link' %>
     </li>
     <% end %>
     <% else %>
+    <% if blacklight_login_path %>
     <li class="nav-item">
-      <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+      <%= link_to t('blacklight.header_links.login'), blacklight_login_path, class: 'nav-link' %>
     </li>
+    <% end %>
     <% end %>
   <% end %>
 </ul>

--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -10,6 +10,7 @@ module Blacklight
     argument     :search_builder_name, type: :string, default: "search_builder"
 
     class_option :devise, type: :boolean, default: false, aliases: "-d", desc: "Use Devise as authentication logic."
+    class_option :authentication, type: :boolean, default: false, desc: "Use Rails' built-in authentication generator."
     class_option :marc, type: :boolean, default: false, aliases: "-m", desc: "Generate MARC-based demo."
     class_option :'bootstrap-version', type: :string, default: nil, desc: "Set the generated app's bootstrap version"
     class_option :'skip-assets', type: :boolean, default: false, desc: "Skip generating javascript and css assets into the application"
@@ -62,9 +63,10 @@ module Blacklight
 
     def generate_blacklight_user
       generator_args = [model_name]
-      if options[:devise]
-        generator_args << "--devise #{options[:devise]}"
-      end
+      raise Thor::Error, "Choose either --devise or --authentication, not both." if options[:devise] && options[:authentication]
+
+      generator_args << "--devise" if options[:devise]
+      generator_args << "--authentication" if options[:authentication]
 
       generate 'blacklight:user', generator_args.join(" ")
     end

--- a/lib/generators/blacklight/user_generator.rb
+++ b/lib/generators/blacklight/user_generator.rb
@@ -10,13 +10,19 @@ module Blacklight
     source_root File.expand_path('templates', __dir__)
 
     argument     :model_name, type: :string, default: "user"
-    class_option :devise, type: :boolean, default: false, aliases: "-d", desc: "Use Devise as authentication logic (this is default)."
+    class_option :devise, type: :boolean, default: false, aliases: "-d", desc: "Use Devise as authentication logic."
+    class_option :authentication, type: :boolean, default: false, desc: "Use Rails' built-in authentication generator."
 
     desc <<-EOS
       This generator makes the following changes to your application:
-       1. Creates a devise-based user model
+       1. Optionally creates an authenticated user model
        2. Injects blacklight-specific behavior into your user model
     EOS
+
+    def validate_authentication_options
+      raise Thor::Error, "Choose either --devise or --authentication, not both." if options[:devise] && options[:authentication]
+    end
+
     # Install Devise?
     def generate_devise_assets
       return unless options[:devise]
@@ -39,6 +45,18 @@ module Blacklight
       gsub_file("config/initializers/devise.rb", "# config.reload_routes = true", "config.reload_routes = false")
     end
 
+    # Install Rails' built-in authentication generator?
+    def generate_rails_authentication_assets
+      return unless options[:authentication]
+
+      raise Thor::Error, "Rails' authentication generator is only available in Rails 8.0 and newer." unless rails_authentication_generator_available?
+      raise Thor::Error, "Rails' authentication generator creates a User model; omit the model name when using --authentication." unless model_name.underscore == "user"
+
+      generate "authentication", rails_authentication_generator_args
+      inject_rails_authentication_blacklight_behavior
+      inject_rails_authentication_guest_transfer
+    end
+
     # Add Blacklight to the user model
     def inject_blacklight_user_behavior
       file_path = "app/models/#{model_name.underscore}.rb"
@@ -49,8 +67,8 @@ module Blacklight
             include Blacklight::User
 
             # Blacklight::User uses a method on your User class to get a user-displayable
-            # label (e.g. login or identifier) for the account. Blacklight uses `email' by default.
-            # self.string_display_key = :email
+            # label (e.g. login or identifier) for the account.
+            #{blacklight_user_display_key_configuration}
           EOS
         end
       else
@@ -61,6 +79,49 @@ module Blacklight
 
             `rails -g blacklight:user client`
         EOS
+      end
+    end
+
+    private
+
+    def rails_authentication_generator_available?
+      Rails.gem_version >= Gem::Version.new("8.0.0")
+    end
+
+    def rails_authentication_generator_args
+      Rails.application.config.api_only ? "--api" : ""
+    end
+
+    def inject_rails_authentication_blacklight_behavior
+      inject_into_class "app/controllers/application_controller.rb", "ApplicationController" do
+        [
+          "  # Makes Rails' generated authentication available through Blacklight's auth hooks.",
+          "  helper_method :current_user",
+          "",
+          "  def current_user",
+          "    resume_session&.user",
+          "  end",
+          ""
+        ].join("\n")
+      end
+    end
+
+    # Move bookmarks/searches accumulated by the anonymous guest user over to the
+    # real account when they sign in.
+    def inject_rails_authentication_guest_transfer
+      sessions_path = "app/controllers/sessions_controller.rb"
+      return unless File.exist?(File.expand_path(sessions_path, destination_root))
+
+      inject_into_file sessions_path, after: "      start_new_session_for user\n" do
+        "      transfer_guest_to_user\n"
+      end
+    end
+
+    def blacklight_user_display_key_configuration
+      if options[:authentication]
+        "self.string_display_key = :email_address"
+      else
+        "# self.string_display_key = :email"
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,9 +1,80 @@
 # frozen_string_literal: true
 
+# Blacklight manages its own guest users only when no other provider (such as
+# the devise-guests gem) is present. Under Devise, current_or_guest_user defers
+# to devise-guests, so the guest-fallback specs below run on the Rails
+# authentication test app only.
+BLACKLIGHT_MANAGES_GUESTS = !defined?(DeviseGuests)
+
 RSpec.describe ApplicationController do
   describe "#blacklight_config" do
     it "provides a default blacklight_config everywhere" do
       expect(controller.blacklight_config).to eq CatalogController.blacklight_config
+    end
+  end
+
+  describe "authentication path helpers" do
+    it "prefers Devise routes when available" do
+      allow(controller).to receive(:respond_to?).and_call_original
+      allow(controller).to receive(:respond_to?).with(:new_user_session_path).and_return(true)
+      allow(controller).to receive(:new_user_session_path).and_return("/users/sign_in")
+
+      expect(controller.send(:blacklight_login_path)).to eq "/users/sign_in"
+    end
+
+    it "falls back to Rails authentication routes" do
+      allow(controller).to receive(:respond_to?).and_call_original
+      allow(controller).to receive(:respond_to?).with(:new_user_session_path).and_return(false)
+      allow(controller).to receive(:respond_to?).with(:new_session_path).and_return(true)
+      allow(controller).to receive(:new_session_path).and_return("/session/new")
+
+      expect(controller.send(:blacklight_login_path)).to eq "/session/new"
+    end
+
+    it "uses a DELETE logout link for Rails authentication" do
+      allow(controller).to receive(:respond_to?).and_call_original
+      allow(controller).to receive(:respond_to?).with(:destroy_user_session_path).and_return(false)
+      allow(controller).to receive(:respond_to?).with(:session_path).and_return(true)
+      allow(controller).to receive(:session_path).and_return("/session")
+
+      expect(controller.send(:blacklight_logout_path)).to eq "/session"
+      expect(controller.send(:blacklight_logout_link_options)).to eq(data: { turbo_method: :delete })
+    end
+  end
+
+  describe "#current_or_guest_user and #guest_user" do
+    it "returns the current user when one is signed in" do
+      user = create_user(email: "signed_in@example.com", password: "password12345")
+      allow(controller).to receive(:current_user).and_return(user)
+
+      expect(controller.send(:current_or_guest_user)).to eq user
+      expect { controller.send(:current_or_guest_user) }.not_to(change { User.where("#{User.blacklight_email_column} LIKE 'guest_%'").count })
+    end
+
+    # Blacklight only manages its own guest users when no other provider (such
+    # as the devise-guests gem) is doing so. Under Devise, current_or_guest_user
+    # defers to devise-guests, so these fallback behaviors are exercised on the
+    # Rails authentication test app instead.
+    context "when Blacklight manages guest users", if: BLACKLIGHT_MANAGES_GUESTS do
+      it "creates and memoizes a persisted guest user for anonymous visitors" do
+        session = {}
+        allow(controller).to receive_messages(current_user: nil, session: session)
+
+        guest = controller.send(:current_or_guest_user)
+
+        expect(guest).to be_persisted
+        expect(session[:blacklight_guest_user_id]).to eq guest.id
+        expect(guest.public_send(User.blacklight_email_column)).to match(/^guest_.*@example\.com$/)
+
+        expect(controller.send(:current_or_guest_user)).to eq guest
+      end
+
+      it "reuses an existing guest across requests via the session" do
+        existing = User.create_guest_user!
+        allow(controller).to receive_messages(current_user: nil, session: { blacklight_guest_user_id: existing.id })
+
+        expect(controller.send(:current_or_guest_user)).to eq existing
+      end
     end
   end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe BookmarksController do
   end
 
   describe "update" do
+    let(:user) { create_user }
+
+    before do
+      allow(controller).to receive(:current_or_guest_user).and_return(user)
+    end
+
     it "has a 200 status code when creating a new one" do
       put :update, xhr: true, params: { id: '2007020969', format: :js }
       expect(response).to be_successful
@@ -31,8 +37,13 @@ RSpec.describe BookmarksController do
   end
 
   describe "create" do
+    let(:user) { create_user }
+
+    before do
+      allow(controller).to receive(:current_or_guest_user).and_return(user)
+    end
+
     it "can create bookmarks via params bookmarks attribute" do
-      @controller.send(:current_or_guest_user).save
       put :create, xhr: true, params: {
         id: "notused",
         bookmarks: [
@@ -50,9 +61,11 @@ RSpec.describe BookmarksController do
   end
 
   describe "delete" do
+    let(:user) { create_user }
+
     before do
-      @controller.send(:current_or_guest_user).save
-      @controller.send(:current_or_guest_user).bookmarks.create! document_id: '2007020969', document_type: "SolrDocument"
+      allow(controller).to receive(:current_or_guest_user).and_return(user)
+      user.bookmarks.create! document_id: '2007020969', document_type: "SolrDocument"
     end
 
     it "has a 200 status code when delete is success" do
@@ -90,12 +103,12 @@ RSpec.describe BookmarksController do
   end
 
   describe 'token based users' do
-    let(:user) { User.find_or_create_by(email: 'user1@example.com') { |u| u.password = 'password' } }
+    let(:user) { create_user email: 'user1@example.com', password: 'password' }
     let(:current_time) { nil }
     let(:token) { controller.send(:encrypt_user_id, user.id, current_time) }
 
     before do
-      allow(controller).to receive(:fetch).and_return([])
+      allow(controller).to receive_messages(fetch: [], retrieve_search_results: instance_double(Blacklight::Solr::Response))
     end
 
     it 'finds the user from the encrypted token' do

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe CatalogHelper do
     context "with an ActiveRecord collection" do
       subject { helper.page_entries_info(Bookmark.page(1).per(25)) }
 
-      let(:user) { User.create! email: 'xyz@example.com', password: 'xyz12345' }
+      let(:user) { create_user email: 'xyz@example.com', password: 'xyz12345' }
 
       before { 50.times { Bookmark.create!(user: user) } }
 

--- a/spec/integration/generators/blacklight/user_generator_spec.rb
+++ b/spec/integration/generators/blacklight/user_generator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'generators/blacklight/user_generator'
+
+RSpec.describe Blacklight::UserGenerator do
+  describe "#validate_authentication_options" do
+    it "rejects multiple authentication providers" do
+      generator = described_class.new(["user"], devise: true, authentication: true)
+
+      expect { generator.validate_authentication_options }.to raise_error(Thor::Error, /either --devise or --authentication/)
+    end
+  end
+
+  describe "#blacklight_user_display_key_configuration" do
+    it "uses Rails authentication's email_address field when requested" do
+      generator = described_class.new(["user"], authentication: true)
+
+      expect(generator.send(:blacklight_user_display_key_configuration)).to eq "self.string_display_key = :email_address"
+    end
+
+    it "keeps the email configuration commented by default" do
+      generator = described_class.new(["user"])
+
+      expect(generator.send(:blacklight_user_display_key_configuration)).to eq "# self.string_display_key = :email"
+    end
+  end
+
+  describe "#inject_rails_authentication_guest_transfer" do
+    let(:destination) { Dir.mktmpdir }
+    let(:generator) { described_class.new(["user"], authentication: true) }
+    let(:sessions_path) { File.join(destination, "app/controllers/sessions_controller.rb") }
+
+    before { generator.destination_root = destination }
+
+    after { FileUtils.rm_rf(destination) }
+
+    it "injects the guest transfer call after starting a session" do
+      FileUtils.mkdir_p(File.dirname(sessions_path))
+      File.write(sessions_path, <<~RUBY)
+        class SessionsController < ApplicationController
+          def create
+            if user = User.authenticate_by(params.permit(:email_address, :password))
+              start_new_session_for user
+              redirect_to after_authentication_url
+            end
+          end
+        end
+      RUBY
+
+      generator.send(:inject_rails_authentication_guest_transfer)
+
+      expect(File.read(sessions_path)).to include("start_new_session_for user\n      transfer_guest_to_user\n")
+    end
+
+    it "is a no-op when there is no sessions controller" do
+      expect { generator.send(:inject_rails_authentication_guest_transfer) }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/blacklight/user_spec.rb
+++ b/spec/models/blacklight/user_spec.rb
@@ -1,10 +1,34 @@
 # frozen_string_literal: true
 
 RSpec.describe "Blacklight::User", :api do
-  subject { User.create! email: 'xyz@example.com', password: 'xyz12345' }
+  subject { create_user email: 'xyz@example.com', password: 'xyz12345' }
 
   def mock_bookmark document_id
     Bookmark.new document_id: document_id, document_type: SolrDocument.to_s
+  end
+
+  describe ".blacklight_email_column" do
+    it "returns the email column the model actually has" do
+      expected = User.column_names.include?("email_address") ? :email_address : :email
+      expect(User.blacklight_email_column).to eq expected
+    end
+  end
+
+  describe ".create_guest_user!" do
+    it "creates a persisted user with a generated, unique identifier" do
+      guest = User.create_guest_user!
+
+      expect(guest).to be_persisted
+      expect(guest.public_send(User.blacklight_email_column)).to match(/^guest_.*@example\.com$/)
+    end
+
+    it "generates a distinct identifier each time" do
+      one = User.create_guest_user!
+      two = User.create_guest_user!
+
+      expect(one.public_send(User.blacklight_email_column))
+        .not_to eq(two.public_send(User.blacklight_email_column))
+    end
   end
 
   describe "#bookmarks_for_documents" do
@@ -47,12 +71,15 @@ RSpec.describe "Blacklight::User", :api do
   end
 
   describe '#to_s' do
-    it 'is the email by default' do
-      expect(subject.to_s).to eq subject.email
+    it 'is the configured display key by default' do
+      display_key = User.column_names.include?("email_address") ? :email_address : :email
+
+      expect(subject.to_s).to eq subject.public_send(display_key)
     end
 
-    context 'when no email method is provided' do
-      let(:old_method) { subject.class.instance_method(:email) }
+    context 'when no configured display key method is provided' do
+      let(:display_key) { User.column_names.include?("email_address") ? :email_address : :email }
+      let(:old_method) { subject.class.instance_method(display_key) }
 
       before do
         subject.class.send(:undef_method, old_method.name)

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Bookmark do
     b
   end
 
-  let(:user) { User.create! email: 'xyz@example.com', password: 'xyz12345' }
+  let(:user) { create_user email: 'xyz@example.com', password: 'xyz12345' }
 
   it "is valid" do
     expect(subject).to be_valid

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Search do
   let(:search) { described_class.new(user: user) }
-  let(:user) { User.create! email: 'xyz@example.com', password: 'xyz12345' }
+  let(:user) { create_user email: 'xyz@example.com', password: 'xyz12345' }
   let(:hash_params) { { q: "query", f: { facet: "filter" } } }
   let(:query_params) { hash_params }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,9 +55,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.include Devise::Test::ControllerHelpers, type: :controller
-
   config.infer_spec_type_from_file_location!
+  config.include UserHelpers
+  config.include Devise::Test::ControllerHelpers, type: :controller if defined?(Devise)
   config.include PresenterTestHelpers, type: :presenter
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponentTestHelpers, type: :component

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -4,6 +4,8 @@
 module Features
   module SessionHelpers
     def sign_up_with(email, password)
+      return create_user(email: email, password: password) if respond_to?(:new_session_path)
+
       Capybara.exact = true
       visit new_user_registration_path
       fill_in 'Email', with: email
@@ -14,10 +16,17 @@ module Features
 
     def sign_in(login = 'user1')
       email = "#{login}@#{login}.com"
-      User.create(email: email, password: "password", password_confirmation: "password")
-      visit new_user_session_path
-      fill_in("user_email", with: email)
-      fill_in("user_password", with: "password")
+      create_user(email: email, password: "password")
+
+      if respond_to?(:new_session_path)
+        visit new_session_path
+        fill_in("email_address", with: email)
+        fill_in("password", with: "password")
+      else
+        visit new_user_session_path
+        fill_in("user_email", with: email)
+        fill_in("user_password", with: "password")
+      end
 
       if has_button? "Sign in"
         click_on("Sign in")

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module UserHelpers
+  def build_user(attributes = {})
+    User.new(user_attributes(attributes))
+  end
+
+  def create_user(attributes = {})
+    User.create!(user_attributes(attributes))
+  end
+
+  def user_attributes(attributes = {})
+    attributes = attributes.dup
+    password = attributes.delete(:password) || "password"
+    email = attributes.delete(:email) || attributes.delete(:email_address) || "user@example.com"
+    email_attribute = User.column_names.include?("email_address") ? :email_address : :email
+
+    {
+      email_attribute => email,
+      password: password,
+      password_confirmation: attributes.delete(:password_confirmation) || password
+    }.merge(attributes)
+  end
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -15,7 +15,7 @@ class TestAppGenerator < Rails::Generators::Base
     Bundler.with_unbundled_env do
       run "bundle install"
     end
-    options = '--devise'
+    options = Rails.gem_version >= Gem::Version.new('8.0.0') ? '--authentication' : '--devise'
     if ENV['BLACKLIGHT_API_TEST'].present?
       options += ' --skip-assets'
     end

--- a/spec/views/catalog/_paginate_compact.html.erb_spec.rb
+++ b/spec/views/catalog/_paginate_compact.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "catalog/_paginate_compact.html.erb" do
-  let(:user) { User.new { |u| u.save(validate: false) } }
+  let(:user) { create_user }
   let(:blacklight_config) { Blacklight::Configuration.new }
 
   before do

--- a/spec/views/shared/_user_util_links.html.erb_spec.rb
+++ b/spec/views/shared/_user_util_links.html.erb_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe "shared/_user_util_links" do
     end
   end
 
+  before do
+    allow(controller).to receive(:render_bookmarks_control?).and_return false
+  end
+
   it "renders the correct bookmark count" do
     count = rand(99)
     allow(controller).to receive(:render_bookmarks_control?).and_return true
@@ -14,5 +18,57 @@ RSpec.describe "shared/_user_util_links" do
     allow(view).to receive_message_chain(:current_or_guest_user, :bookmarks, :count).and_return(count)
     render "shared/user_util_links"
     expect(rendered).to have_css('#bookmarks_nav span.badge[data-role=bookmark-counter]', text: count.to_s)
+  end
+
+  it "renders Rails authentication session links" do
+    user = instance_double(User, to_s: "xyz@example.com")
+
+    allow(view).to receive_messages(
+      blacklight_account_path: nil,
+      blacklight_config: blacklight_config,
+      blacklight_login_path: "/session/new",
+      blacklight_logout_link_options: { data: { turbo_method: :delete } },
+      blacklight_logout_path: "/session",
+      current_user: user,
+      has_user_authentication_provider?: true
+    )
+
+    render "shared/user_util_links"
+
+    expect(rendered).to have_link("Log Out", href: "/session")
+    expect(rendered).to have_css('a[data-turbo-method="delete"]', text: "Log Out")
+    expect(rendered).to have_no_link("xyz@example.com")
+  end
+
+  it "renders Devise-compatible session and registration links" do
+    user = instance_double(User, to_s: "xyz@example.com")
+
+    allow(view).to receive_messages(
+      blacklight_account_path: "/users/edit",
+      blacklight_config: blacklight_config,
+      blacklight_login_path: "/users/sign_in",
+      blacklight_logout_link_options: {},
+      blacklight_logout_path: "/users/sign_out",
+      current_user: user,
+      has_user_authentication_provider?: true
+    )
+
+    render "shared/user_util_links"
+
+    expect(rendered).to have_link("Log Out", href: "/users/sign_out")
+    expect(rendered).to have_link("xyz@example.com", href: "/users/edit")
+  end
+
+  it "renders a provider-neutral login link" do
+    allow(view).to receive_messages(
+      blacklight_config: blacklight_config,
+      blacklight_login_path: "/session/new",
+      current_user: nil,
+      has_user_authentication_provider?: true
+    )
+
+    render "shared/user_util_links"
+
+    expect(rendered).to have_link("Login", href: "/session/new")
   end
 end

--- a/template.demo.rb
+++ b/template.demo.rb
@@ -4,7 +4,8 @@ gem 'blacklight', '>= 7.0'
 
 after_bundle do
   # run the blacklight install generator
-  options = ENV.fetch("BLACKLIGHT_INSTALL_OPTIONS", '--devise --marc')
+  default_authentication_option = Rails.gem_version >= Gem::Version.new('8.0.0') ? '--authentication' : '--devise'
+  options = ENV.fetch("BLACKLIGHT_INSTALL_OPTIONS", "#{default_authentication_option} --marc")
 
   generate 'blacklight:install', options
 


### PR DESCRIPTION
We no longer need to have a Devise dependency as rails now has a generator for authenticated sessions.