### PR TITLE
Fix facet pagination without a configured limit

### DIFF
--- a/app/presenters/blacklight/facet_field_presenter.rb
+++ b/app/presenters/blacklight/facet_field_presenter.rb
@@ -91,6 +91,10 @@ module Blacklight
     # available), and used in display (with @response available) to create
     # a facet paginator with the right limit.
     def facet_limit
+      if in_modal? && !facet_field.limit
+        return facet_field.fetch(:more_limit, blacklight_config.default_more_limit)
+      end
+
       return unless facet_field.limit
 
       if @display_facet

--- a/spec/presenters/blacklight/facet_field_presenter_spec.rb
+++ b/spec/presenters/blacklight/facet_field_presenter_spec.rb
@@ -131,6 +131,31 @@ RSpec.describe Blacklight::FacetFieldPresenter, type: :presenter do
       expect(paginator.current_page).to eq 1
       expect(paginator.total_count).to eq 0
     end
+
+    context 'on a facet page without a configured limit' do
+      let(:items) { Array.new(21) { {} } }
+
+      before { controller.params[:action] = 'facet' }
+
+      it 'uses the default more limit' do
+        expect(paginator.limit).to eq 20
+        expect(paginator.next_page).to eq 2
+      end
+    end
+
+    context 'on a facet page with a configured more limit' do
+      let(:items) { Array.new(31) { {} } }
+
+      before do
+        controller.params[:action] = 'facet'
+        facet_field.more_limit = 30
+      end
+
+      it 'uses the configured more limit' do
+        expect(paginator.limit).to eq 30
+        expect(paginator.next_page).to eq 2
+      end
+    end
   end
 
   describe "#facet_limit" do


### PR DESCRIPTION
Fixes #3888.

Facet pages now use the configured `more_limit`, or `default_more_limit` when no facet limit is set. This keeps the paginator consistent with the number of values requested from Solr and allows the “Next” button to remain enabled when more values are available.

Tests cover both the default and configured `more_limit` cases.