### PR TITLE
Wait for Turbo visits to finish before running axe

### DIFF
--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Accessibility testing', :js, api: false do
         visit root_path
         fill_in "q", with: 'history'
         click_on 'search'
+        wait_for_turbo
 
         expect(page).to be_axe_clean
 
@@ -25,6 +26,7 @@ RSpec.describe 'Accessibility testing', :js, api: false do
           click_on 'Language'
           click_on "Tibetan"
         end
+        wait_for_turbo
 
         expect(page).to be_axe_clean
       end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -4,8 +4,10 @@
 
 require File.expand_path('features/search_helpers.rb', __dir__)
 require File.expand_path('features/session_helpers.rb', __dir__)
+require File.expand_path('features/turbo_helpers.rb', __dir__)
 
 RSpec.configure do |config|
   config.include Features::SearchHelpers, type: :feature
   config.include Features::SessionHelpers, type: :feature
+  config.include Features::TurboHelpers, type: :feature
 end

--- a/spec/support/features/turbo_helpers.rb
+++ b/spec/support/features/turbo_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# spec/support/features/turbo_helpers.rb
+module Features
+  module TurboHelpers
+    # Turbo Drive marks the document as busy for the duration of a visit. Capybara
+    # clicks return before the visit completes, so wait for the busy state to clear
+    # before making assertions that don't wait on their own (e.g. be_axe_clean).
+    def wait_for_turbo
+      expect(page).to have_no_css('html[aria-busy]', visible: :all)
+    end
+  end
+end


### PR DESCRIPTION
Capybara clicks return before the Turbo Drive visit they trigger has
completed, so the axe audits on the catalog page were running against a
partially rendered document. Turbo marks the document element busy for
the duration of a visit, and as of axe-core 4.13.0 the `html` element is
specified as `allowedAriaAttrs: []` (dequelabs/axe-core#5259), so the
in-flight `aria-busy="true"` is now reported as a critical
aria-allowed-attr violation.

Add a `wait_for_turbo` helper that blocks until the busy state clears,
and call it after the two Turbo navigations in the axe spec.
