### PR TITLE
Set facets.missing translation value as strings (not arrays)

### DIFF
--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -91,8 +91,7 @@ de:
         group:
           close: Facetten ausblenden
           open: Facetten zeigen
-        missing:
-          - fehlt
+        missing: "[fehlt]"
         more_html: mehr <span class="visually-hidden">%{field_name}</span> »
         pivot:
           hide: Schließen

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -91,8 +91,7 @@ it:
         group:
           close: Nascondi sfaccettature
           open: Mostra sfaccettature
-        missing:
-          - Mancante
+        missing: "[Mancante]"
         more_html: altri <span class="visually-hidden">%{field_name}</span> »
         pivot:
           hide: Chiudi

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -89,8 +89,7 @@ pt-BR:
         group:
           close: Ocultar facetas
           open: Mostrar facetas
-        missing:
-          - Ausência
+        missing: "[Ausência]"
         more_html: mais <span class="visually-hidden">%{field_name}</span> »
         pivot:
           hide: Fechar


### PR DESCRIPTION
Fixes #3894 
