### PR TITLE
Do not permit negative rows param

### DIFF
--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -230,7 +230,8 @@ module Blacklight
       return if value.nil?
 
       params_will_change!
-      @rows = [value, blacklight_config.max_per_page].map(&:to_i).min
+      new_rows = value.to_i.then { |parsed| parsed.positive? ? parsed : blacklight_config.default_per_page }
+      @rows = [new_rows, blacklight_config.max_per_page.to_i].min
     end
 
     # @param [#to_i] value

--- a/spec/features/search_pagination_spec.rb
+++ b/spec/features/search_pagination_spec.rb
@@ -93,4 +93,18 @@ RSpec.describe "Search Pagination" do
       expect(page).to have_text "1 - 20 of "
     end
   end
+
+  it 'falls back to the default in the case of negative rows param' do
+    visit '/catalog?search_field=all_fields&q=&rows=-20'
+    within("#sortAndPerPage") do
+      expect(page).to have_text "1 - 10 of "
+    end
+  end
+
+  it 'falls back to the default in the case of negative per_page param' do
+    visit '/catalog?search_field=all_fields&q=&per_page=-20'
+    within("#sortAndPerPage") do
+      expect(page).to have_text "1 - 10 of "
+    end
+  end
 end


### PR DESCRIPTION
Found in our catalog's logs.  If you attempt to send a negative rows param to solr, you will get the error:

```
'rows' parameter cannot be negative
```

Prior to this commit, Blacklight did not validate this param to be positive, so users could trigger this solr error by including a negative rows or per_page param in their search URL.

With this PR, we fall back to the default per_page if the user entered a negative per_page.

<!--
Thanks for contributing to Blacklight!

If you changed any SASS files in this pull-request, ensure you have built the CSS.
You can do this by running `npm run build` and commit the resulting changes to `app/assets/builds/blacklight.css`

-->
