### PR TITLE
Fix Layout/ExtraSpacing rubocop offenses in dublin_core_spec

### DIFF
--- a/spec/models/blacklight/document/dublin_core_spec.rb
+++ b/spec/models/blacklight/document/dublin_core_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "Blacklight::Document::DublinCore" do
   it "includes 'dc:'-prefixed semantic fields" do
     data = { 'id' => '123456', 'title_tsim' => ['654321'] }
     document = @mock_class.new(data)
-    expect(document.export_as_oai_dc_xml).to match  'xmlns:dc="http://purl.org/dc/elements/1.1/"'
-    expect(document.export_as_oai_dc_xml).to match  '<dc:title>654321</dc:title>'
+    expect(document.export_as_oai_dc_xml).to match 'xmlns:dc="http://purl.org/dc/elements/1.1/"'
+    expect(document.export_as_oai_dc_xml).to match '<dc:title>654321</dc:title>'
   end
 
   it "works with multi-value fields" do


### PR DESCRIPTION
The scheduled `release-7.x` CI run has been failing lint since a newer unpinned RuboCop flagged these two pre-existing `Layout/ExtraSpacing` offenses. Both are trivial whitespace fixes with no behavior change.
