### PR TITLE
Add Solr request time and query count to the Rails request log line

### DIFF
--- a/app/controllers/concerns/blacklight/controller_runtime.rb
+++ b/app/controllers/concerns/blacklight/controller_runtime.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Blacklight
+  # Adds Solr timing to the Rails request log line, mirroring how
+  # ActiveRecord::Railties::ControllerRuntime adds ActiveRecord timing, e.g.:
+  #   Completed 200 OK in 62ms (Views: 12.0ms | ActiveRecord: 1.2ms | Solr: 45.3ms (2 queries))
+  module ControllerRuntime
+    extend ActiveSupport::Concern
+
+    protected
+
+    def process_action(action, *args)
+      Blacklight::RuntimeRegistry.stats.reset
+      super
+    end
+
+    def append_info_to_payload(payload)
+      super
+      stats = Blacklight::RuntimeRegistry.stats
+      payload[:solr_runtime] = stats.solr_runtime
+      payload[:solr_query_count] = stats.solr_query_count
+      stats.reset
+    end
+
+    module ClassMethods
+      def log_process_action(payload)
+        messages = super
+        count = payload[:solr_query_count].to_i
+        return messages unless count.positive?
+
+        messages << solr_log_message(payload[:solr_runtime], count)
+        messages
+      end
+
+      private
+
+      def solr_log_message(runtime, count)
+        format("Solr: %.1fms (%d %s)", runtime.to_f, count, "query".pluralize(count))
+      end
+    end
+  end
+end

--- a/lib/blacklight/abstract_repository.rb
+++ b/lib/blacklight/abstract_repository.rb
@@ -10,9 +10,11 @@ module Blacklight
     attr_writer :connection
 
     # (Note: ActiveSupport::Benchmarkable requires a logger method)
+    # No longer used in core Blacklight, keeping for downstream consumers
     # @return [Logger]
     attr_writer :logger
 
+    # No longer used in core Blacklight, keeping for downstream consumers
     include ActiveSupport::Benchmarkable
 
     ##

--- a/lib/blacklight/engine.rb
+++ b/lib/blacklight/engine.rb
@@ -22,6 +22,15 @@ module Blacklight
       Blacklight::Configuration.initialize_default_configuration
     end
 
+    initializer "blacklight.runtime_registry" do
+      ActiveSupport::Notifications.monotonic_subscribe("solr_request.blacklight", Blacklight::RuntimeRegistry)
+      Blacklight::LogSubscriber.attach_to :blacklight
+
+      # ActionController::LogSubscriber#process_action calls ActionController::Base.log_process_action,
+      # so this has to live on ActionController::Base itself - a subclass's override is never consulted.
+      ActiveSupport.on_load(:action_controller) { include Blacklight::ControllerRuntime }
+    end
+
     # This makes our rake tasks visible.
     rake_tasks do
       Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..'))) do

--- a/lib/blacklight/log_subscriber.rb
+++ b/lib/blacklight/log_subscriber.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Blacklight
+  # Debug-only logging for solr_request.blacklight notifications
+  # see Blacklight::ControllerRuntime for the :info-level per-request summary.
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    # ActiveSupport::LogSubscriber#debug/#info call the instance method
+    # `logger`, which the base class hardcodes to `LogSubscriber.logger`
+    # (itself) rather than `self.class.logger`. If that's ever fixed
+    # upstream, a `self.logger` override here would be worth implementing.
+    delegate :logger, to: :Blacklight
+
+    def solr_request(event)
+      payload = event.payload
+      debug { "Solr fetch (#{event.duration.round(1)}ms): #{payload[:method]} #{payload[:path]} #{payload[:params].to_hash.inspect}" }
+      debug { "Solr response: #{payload[:response].inspect}" } if verbose_logging?
+    end
+
+    private
+
+    def verbose_logging?
+      defined?(::BLACKLIGHT_VERBOSE_LOGGING) && ::BLACKLIGHT_VERBOSE_LOGGING
+    end
+  end
+end

--- a/lib/blacklight/runtime_registry.rb
+++ b/lib/blacklight/runtime_registry.rb
@@ -3,5 +3,29 @@
 module Blacklight
   class RuntimeRegistry
     thread_mattr_accessor :connection, :connection_config
+
+    # per-thread/fiber Solr timing, read by Blacklight::ControllerRuntime
+    class Stats
+      attr_accessor :solr_runtime, :solr_query_count
+
+      def initialize
+        @solr_runtime = 0.0
+        @solr_query_count = 0
+      end
+
+      public alias_method :reset, :initialize
+    end
+
+    class << self
+      def stats
+        ActiveSupport::IsolatedExecutionState[:blacklight_solr_runtime] ||= Stats.new
+      end
+
+      # @see ActiveSupport::Notifications.monotonic_subscribe
+      def call(_name, start, finish, _id, _payload)
+        stats.solr_runtime += (finish - start) * 1000.0
+        stats.solr_query_count += 1
+      end
+    end
   end
 end

--- a/lib/blacklight/solr/repository.rb
+++ b/lib/blacklight/solr/repository.rb
@@ -38,8 +38,10 @@ module Blacklight::Solr
     # @param [Hash] request_params
     # @return [Blacklight::Suggest::Response]
     def suggestions(request_params)
-      suggest_results = connection.send_and_receive(suggest_handler_path, params: request_params)
-      Blacklight::Suggest::Response.new suggest_results, request_params, suggest_handler_path, suggester_name
+      instrument_solr_request(suggest_handler_path, request_params) do
+        suggest_results = connection.send_and_receive(suggest_handler_path, params: request_params)
+        Blacklight::Suggest::Response.new suggest_results, request_params, suggest_handler_path, suggester_name
+      end
     end
 
     ##
@@ -53,7 +55,7 @@ module Blacklight::Solr
     ##
     # @return [boolean] true if the repository is reachable
     def ping?
-      response = connection.send_and_receive 'admin/ping', {}
+      response = instrument_solr_request('admin/ping', {}) { connection.send_and_receive('admin/ping', {}) }
       Blacklight.logger&.info("Ping [#{connection.uri}] returned: '#{response['status']}'")
       response['status'] == "OK"
     end
@@ -69,13 +71,10 @@ module Blacklight::Solr
     # @param [Hash, Blacklight::SearchBuilder] solr_params parameters for RSolr::Client#send_and_receive
     # @return [Blacklight::Solr::Response] the solr response object
     def send_and_receive(path, solr_params = {})
-      benchmark("Solr fetch", level: :debug) do
-        res = connection.send_and_receive(path, build_solr_request(solr_params))
-        solr_response = blacklight_config.response_model.new(res, solr_params, document_model: blacklight_config.document_model, blacklight_config: blacklight_config)
-
-        Blacklight.logger&.debug("Solr query: #{blacklight_config.http_method} #{path} #{solr_params.to_hash.inspect}")
-        Blacklight.logger&.debug("Solr response: #{solr_response.inspect}") if defined?(::BLACKLIGHT_VERBOSE_LOGGING) && ::BLACKLIGHT_VERBOSE_LOGGING
-        solr_response
+      request = build_solr_request(solr_params)
+      instrument_solr_request(path, solr_params, method: request[:method]) do
+        res = connection.send_and_receive(path, request)
+        blacklight_config.response_model.new(res, solr_params, document_model: blacklight_config.document_model, blacklight_config: blacklight_config)
       end
     rescue *defined_rsolr_timeout_exceptions => e
       raise Blacklight::Exceptions::RepositoryTimeout, "Timeout connecting to Solr instance using #{connection.inspect}: #{e.inspect}"
@@ -105,6 +104,12 @@ module Blacklight::Solr
     end
 
     private
+
+    def instrument_solr_request(path, params, method: :get)
+      ActiveSupport::Notifications.instrument("solr_request.blacklight", path: path, params: params, method: method) do |payload|
+        payload[:response] = yield
+      end
+    end
 
     ##
     # @return [String]

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,6 +7,29 @@
 BLACKLIGHT_MANAGES_GUESTS = !defined?(DeviseGuests)
 
 RSpec.describe ApplicationController do
+  describe ".log_process_action" do
+    it "appends Solr runtime to the messages ActiveRecord/ActionController already log" do
+      messages = described_class.log_process_action(solr_runtime: 45.3, solr_query_count: 2)
+      expect(messages).to include("Solr: 45.3ms (2 queries)")
+    end
+
+    it "uses singular 'query' for a single Solr request" do
+      messages = described_class.log_process_action(solr_runtime: 12.0, solr_query_count: 1)
+      expect(messages).to include("Solr: 12.0ms (1 query)")
+    end
+
+    it "does not add a message when no Solr request was made" do
+      messages = described_class.log_process_action({})
+      expect(messages.grep(/Solr/)).to be_empty
+    end
+
+    it "does not add a message when the payload reports zero Solr queries" do
+      # Stats#solr_runtime defaults to 0.0 (truthy, never nil) - query count is the real "did Solr get queried" signal.
+      messages = described_class.log_process_action(solr_runtime: 0.0, solr_query_count: 0)
+      expect(messages.grep(/Solr/)).to be_empty
+    end
+  end
+
   describe "#blacklight_config" do
     it "provides a default blacklight_config everywhere" do
       expect(controller.blacklight_config).to eq CatalogController.blacklight_config

--- a/spec/lib/blacklight/runtime_registry_spec.rb
+++ b/spec/lib/blacklight/runtime_registry_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Blacklight::RuntimeRegistry do
+  before { described_class.stats.reset }
+
+  describe ".call" do
+    it "accumulates the event's duration into stats.solr_runtime" do
+      described_class.call("solr_request.blacklight", 0.0, 0.0125, nil, {})
+
+      expect(described_class.stats.solr_runtime).to eq 12.5
+    end
+
+    it "increments stats.solr_query_count" do
+      described_class.call("solr_request.blacklight", 0.0, 0.0125, nil, {})
+      described_class.call("solr_request.blacklight", 0.0, 0.0125, nil, {})
+
+      expect(described_class.stats.solr_query_count).to eq 2
+    end
+  end
+
+  describe ".stats" do
+    it "is thread-local" do
+      described_class.call("solr_request.blacklight", 0.0, 0.0125, nil, {})
+
+      Thread.new { expect(described_class.stats.solr_runtime).to eq 0.0 }.join
+    end
+  end
+
+  describe "Stats#reset" do
+    it "clears the accumulated runtime and query count" do
+      stats = described_class.stats
+      described_class.call("solr_request.blacklight", 0.0, 0.0125, nil, {})
+
+      stats.reset
+
+      expect(stats.solr_runtime).to eq 0.0
+      expect(stats.solr_query_count).to eq 0
+    end
+  end
+
+  describe "subscribed to solr_request.blacklight notifications" do
+    it "fires without raising (Blacklight::Engine subscribes this at boot)" do
+      expect { ActiveSupport::Notifications.instrument("solr_request.blacklight") }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/blacklight/solr/repository_spec.rb
+++ b/spec/models/blacklight/solr/repository_spec.rb
@@ -143,6 +143,31 @@ RSpec.describe Blacklight::Solr::Repository, :api do
       allow(repository.connection).to receive(:send_and_receive).and_raise(rsolr_timeout)
       expect { subject.search(params: {}) }.to raise_exception(Blacklight::Exceptions::RepositoryTimeout, /Timeout connecting to Solr instance/)
     end
+
+    it "instruments the request with ActiveSupport::Notifications" do
+      allow(subject.connection).to receive(:send_and_receive).and_return(mock_response)
+
+      payload = nil
+      callback = ->(event) { payload = event.payload }
+      ActiveSupport::Notifications.subscribed(callback, "solr_request.blacklight") do
+        subject.search(params: {})
+      end
+
+      expect(payload).to include(path: 'select', method: :get)
+    end
+
+    it "instruments a json query dsl request as post, regardless of http_method configuration" do
+      blacklight_config.http_method = :get
+      allow(subject.connection).to receive(:send_and_receive).and_return(mock_response)
+
+      payload = nil
+      callback = ->(event) { payload = event.payload }
+      ActiveSupport::Notifications.subscribed(callback, "solr_request.blacklight") do
+        subject.search(params: { json: { query: 'foo' } })
+      end
+
+      expect(payload).to include(method: :post)
+    end
   end
 
   describe "#build_solr_request" do
@@ -230,5 +255,49 @@ RSpec.describe Blacklight::Solr::Repository, :api do
     subject { repository.ping }
 
     it { is_expected.to be true }
+
+    it "instruments the request with ActiveSupport::Notifications" do
+      payload = nil
+      callback = ->(event) { payload = event.payload }
+      ActiveSupport::Notifications.subscribed(callback, "solr_request.blacklight") do
+        repository.ping
+      end
+
+      expect(payload).to include(path: 'admin/ping', method: :get)
+    end
+  end
+
+  describe "debug logging" do
+    let(:io) { StringIO.new }
+    let(:test_logger) { Logger.new(io, level: Logger::DEBUG) }
+
+    before do
+      allow(Blacklight).to receive(:logger).and_return(test_logger)
+      allow(subject.connection).to receive(:send_and_receive).and_return(mock_response)
+    end
+
+    it "logs the solr query at debug, never at info" do
+      subject.search(params: { q: 'test' })
+
+      expect(io.string).to include("test")
+      expect(io.string).not_to include("INFO")
+    end
+
+    it "does not log the full response by default" do
+      subject.search(params: { q: 'test' })
+
+      expect(io.string).not_to include("Solr response")
+    end
+
+    context "when BLACKLIGHT_VERBOSE_LOGGING is set" do
+      before { stub_const('BLACKLIGHT_VERBOSE_LOGGING', true) }
+
+      it "logs the full response at debug, never at info" do
+        subject.search(params: { q: 'test' })
+
+        expect(io.string).to include("Solr response")
+        expect(io.string).not_to include("INFO")
+      end
+    end
   end
 end


### PR DESCRIPTION
Rails' `Completed ... (ActiveRecord: ...)` log line has no equivalent for Solr, so query time is invisible at the default `info` log level. Adds a `Blacklight::LogSubscriber`/`Blacklight::ControllerRuntime` pair that mirrors how `ActiveRecord::Railties::ControllerRuntime` contributes to that same line. 

It now reads, for example:

```log
Completed 200 OK in 62ms (Views: 12.0ms | ActiveRecord: 1.2ms | Solr: 45.3ms (2 queries))
```

Solr-specific for now (event name, log label) rather than generalized to `AbstractRepository` for other backends (Elasticsearch/EDS/etc.) — happy to generalize if that's wanted, but didn't want to guess at the right abstraction without a concrete second backend to design against.
