### PR TITLE
Pin json < 3.0 to fix Rails < 8.1 CI

### DIFF
--- a/blacklight.gemspec
+++ b/blacklight.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", '>= 6.1', '< 9'
   s.add_dependency "globalid"
   s.add_dependency "jbuilder", '~> 2.7'
+  s.add_dependency "json", '< 3.0' # 3.0 dropped the quirks_mode kwarg ActiveSupport::JSON still passes on Rails < 8.1 - remove once this gemspec requires rails >= 8.1
   s.add_dependency "kaminari", ">= 0.15" # the pagination (page 1,2,3, etc..) of our search results
   s.add_dependency "deprecation"
   s.add_dependency "i18n", '>= 1.7.0' # added named parameters


### PR DESCRIPTION
`json` 3.0 dropped the `quirks_mode` kwarg that `ActiveSupport::JSON::Encoding` still passes on Rails < 8.1, raising `ArgumentError: unknown keyword: quirks_mode` on any ActiveRecord JSON serialization — this has been failing every `release-7.x` test job except `rails 8.1.3`.

**Tradeoff:** this is an unconditional gemspec pin, so it also forces `json < 3.0` on apps running Rails 8.1+ that don't need it.
