### PR TITLE
Fix axe spec

### DIFF
--- a/lib/generators/blacklight/install_generator.rb
+++ b/lib/generators/blacklight/install_generator.rb
@@ -41,6 +41,11 @@ module Blacklight
       generate "blacklight:assets", generated_options unless options[:'skip-assets']
     end
 
+    def pin_json_version
+      # json 3.0's JSON.parse rejects ActiveSupport::JSON.decode's positional options hash; unfixed as of Rails 8.1.3.
+      gem 'json', '< 3.0'
+    end
+
     def bundle_install
       inside destination_root do
         Bundler.with_unbundled_env do

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'Accessibility testing', :js, api: false do
 
       it 'validates the home page' do
         visit root_path
+        wait_for_turbo
+
         expect(page).to be_axe_clean
       end
 
@@ -33,11 +35,15 @@ RSpec.describe 'Accessibility testing', :js, api: false do
 
       it 'validates the advanced search form' do
         visit advanced_search_catalog_path
+        wait_for_turbo
+
         expect(page).to be_axe_clean
       end
 
       it 'validates the single results page' do
         visit solr_document_path('2007020969')
+        wait_for_turbo
+
         expect(page).to be_axe_clean
       end
     end

--- a/spec/support/features/turbo_helpers.rb
+++ b/spec/support/features/turbo_helpers.rb
@@ -7,6 +7,7 @@ module Features
     # clicks return before the visit completes, so wait for the busy state to clear
     # before making assertions that don't wait on their own (e.g. be_axe_clean).
     def wait_for_turbo
+      page.has_css?('html[aria-busy]', visible: :all, wait: 0.5)
       expect(page).to have_no_css('html[aria-busy]', visible: :all)
     end
   end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -3,3 +3,6 @@ gem 'rails-controller-testing'
 unless ENV['VIEW_COMPONENT_VERSION'].to_s == ""
   gem 'view_component', ENV.fetch('VIEW_COMPONENT_VERSION')
 end
+
+# json 3.0's JSON.parse rejects ActiveSupport::JSON.decode's positional options hash; unfixed as of Rails 8.1.3.
+gem 'json', '< 3.0'


### PR DESCRIPTION
This fixes a flaky spec - the axe spec was running into a race condition with Capybara and turbolinks. 

It also pins json to less than 3.0 via the rails generator and a test-specific Gemfile, rather than via the Gemspec, per @jrochkind astute comment on this other PR - https://github.com/projectblacklight/blacklight/pull/3901#issuecomment-5588477882. Bundling them together because neither is likely to get CI green on its own.
